### PR TITLE
Audit RumorStore locking

### DIFF
--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
         server.member_list.add_initial_member_imlw(member);
     }
 
-    server.start_mlw_rsw(&server::timing::Timing::default())
+    server.start_rsw_mlw(&server::timing::Timing::default())
           .expect("Cannot start server");
     loop {
         println!("{:#?}", server.member_list);

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
         server.member_list.add_initial_member_imlw(member);
     }
 
-    server.start_mlw(&server::timing::Timing::default())
+    server.start_mlw_rsr(&server::timing::Timing::default())
           .expect("Cannot start server");
     loop {
         println!("{:#?}", server.member_list);

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -55,7 +55,7 @@ fn main() {
         server.member_list.add_initial_member_imlw(member);
     }
 
-    server.start_mlw_rsr(&server::timing::Timing::default())
+    server.start_mlw_rsw(&server::timing::Timing::default())
           .expect("Cannot start server");
     loop {
         println!("{:#?}", server.member_list);

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -347,9 +347,8 @@ pub struct MemberList {
 }
 
 impl Serialize for MemberList {
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
         where S: Serializer
     {
@@ -384,16 +383,14 @@ impl MemberList {
                      update_counter:  AtomicUsize::new(0), }
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     fn read_entries(&self) -> ReadGuard<'_, HashMap<UuidSimple, member_list::Entry>> {
         self.entries.read()
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     fn write_entries(&self) -> WriteGuard<'_, HashMap<UuidSimple, member_list::Entry>> {
         self.entries.write()
     }
@@ -408,28 +405,24 @@ impl MemberList {
 
     pub fn get_update_counter(&self) -> usize { self.update_counter.load(Ordering::Relaxed) }
 
-    /// # Locking
-    /// * `MemberList::intitial_entries` (read) This method must not be called while any
-    ///   MemberList::intitial_entries lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::initial_members` (read)
     pub fn len_initial_members_imlr(&self) -> usize { self.initial_members_read().len() }
 
-    /// # Locking
-    /// * `MemberList::intitial_entries` (write) This method must not be called while any
-    ///   MemberList::intitial_entries lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::initial_members` (write)
     pub fn add_initial_member_imlw(&self, member: Member) {
         self.initial_members_write().push(member);
     }
 
-    /// # Locking
-    /// * `MemberList::intitial_entries` (write) This method must not be called while any
-    ///   MemberList::intitial_entries lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::initial_members` (write)
     pub fn set_initial_members_imlw(&self, members: Vec<Member>) {
         *self.initial_members_write() = members;
     }
 
-    /// # Locking
-    /// * `MemberList::intitial_entries` (read) This method must not be called while any
-    ///   MemberList::intitial_entries lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::initial_members` (read)
     pub fn with_initial_members_imlr(&self, with_closure: impl Fn(&Member)) {
         for member in self.initial_members_read().iter() {
             with_closure(member);
@@ -500,18 +493,16 @@ impl MemberList {
     /// | Confirmed |       |           |           | propagate |
     /// | Departed  |       |           |           |           |
     ///
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     // TODO (CM): why don't we just insert a membership record here?
     pub fn insert_mlw(&self, incoming_member: Member, incoming_health: Health) -> bool {
         self.insert_membership_mlw(Membership { member: incoming_member,
                                                 health: incoming_health, })
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     fn insert_membership_mlw(&self, incoming: Membership) -> bool {
         // Is this clone necessary, or can a key be a reference to a field contained in the value?
         // Maybe the members we store should not contain the ID to reduce the duplication?
@@ -543,9 +534,8 @@ impl MemberList {
         modified
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     pub fn set_departed_mlw(&self, member_id: &str) {
         if let Some(member_list::Entry { member, health, .. }) =
             self.write_entries().get_mut(member_id)
@@ -560,9 +550,8 @@ impl MemberList {
         }
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     fn calculate_peer_health_metrics_mlr(&self) {
         let mut health_counts: HashMap<Health, i64> = HashMap::new();
 
@@ -582,18 +571,16 @@ impl MemberList {
 
     /// Returns the health of the member, if the member exists.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn health_of_mlr(&self, member: &Member) -> Option<Health> {
         self.health_of_by_id_mlr(&member.id)
     }
 
     /// Returns the health of the member, if the member exists.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn health_of_by_id_mlr(&self, member_id: &str) -> Option<Health> {
         self.read_entries()
             .get(member_id)
@@ -602,9 +589,8 @@ impl MemberList {
 
     /// Returns the health of the member, blocking for a limited timeout
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     ///
     /// # Errors:
     /// * `Error::Timeout` if the health data can't be accessed within `timeout`
@@ -629,9 +615,8 @@ impl MemberList {
     /// Returns true if the member is alive, suspect, or persistent; used during the target
     /// selection phase of the outbound thread.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn pingable_mlr(&self, member: &Member) -> bool {
         if member.persistent {
             return true;
@@ -645,18 +630,16 @@ impl MemberList {
     /// Returns true if we are pinging this member because they are persistent, but we think they
     /// are gone.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn persistent_and_confirmed_mlr(&self, member: &Member) -> bool {
         member.persistent && self.health_of_mlr(member) == Some(Health::Confirmed)
     }
 
     /// Returns a protobuf membership record for the given member id.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn membership_for_mlr(&self, member_id: &str) -> Option<Membership> {
         self.read_entries()
             .get(member_id)
@@ -668,21 +651,18 @@ impl MemberList {
 
     /// Returns the number of entries.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn len_mlr(&self) -> usize { self.read_entries().len() }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn is_empty_mlr(&self) -> bool { self.read_entries().is_empty() }
 
     /// A randomized list of members to check.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn check_list_mlr(&self, exclude_id: &str) -> Vec<Member> {
         let mut members: Vec<_> = self.read_entries()
                                       .values()
@@ -696,10 +676,10 @@ impl MemberList {
 
     /// Takes a function whose first argument is a member, and calls it for every pingreq target.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held. Additionally `with_closure` is called with this lock held, so the closure
-    ///   must not call any functions which take this lock.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
+    /// * Additionally `with_closure` is called with this lock held, so the closure must not call
+    ///   any functions which take this lock.
     pub fn with_pingreq_targets_mlr(&self,
                                     sending_member_id: &str,
                                     target_member_id: &str,
@@ -721,9 +701,8 @@ impl MemberList {
     /// If an owned `Member` is required, use this. If a shared reference is
     /// good enough, use `with_member`.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn get_cloned_mlr(&self, member_id: &str) -> Option<Member> {
         self.read_entries()
             .get(member_id)
@@ -733,10 +712,10 @@ impl MemberList {
     /// Iterates over the memberships list, calling the function for each membership.
     /// This could be return Result<T> instead, but there's only the one caller now.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held. Additionally `with_closure` is called with this lock held, so the closure
-    ///   must not call any functions which take this lock.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
+    /// * Additionally `with_closure` is called with this lock held, so the closure must not call
+    ///   any functions which take this lock.
     pub fn with_memberships_mlr<T: Default>(&self,
                                             mut with_closure: impl FnMut(Membership) -> Result<T>)
                                             -> Result<T> {
@@ -758,9 +737,8 @@ impl MemberList {
     /// appropriately, and a list of newly-Confirmed Member IDs is
     /// returned.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     pub fn members_expired_to_confirmed_mlw(&self, timeout: Duration) -> Vec<String> {
         self.members_expired_to_mlw(Health::Confirmed, timeout)
     }
@@ -769,9 +747,8 @@ impl MemberList {
     /// have now expired to Departed. Health is updated appropriately,
     /// and a list of newly-Departed Member IDs is returned.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     pub fn members_expired_to_departed_mlw(&self, timeout: Duration) -> Vec<String> {
         self.members_expired_to_mlw(Health::Departed, timeout)
     }
@@ -788,9 +765,8 @@ impl MemberList {
     ///
     /// The newly-updated health status is recorded properly.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     // TODO (CM): Better return type than Vec<String>
     fn members_expired_to_mlw(&self, expiring_to: Health, timeout: Duration) -> Vec<String> {
         let now = SteadyTime::now();
@@ -824,9 +800,8 @@ impl MemberList {
         expired
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn contains_member_mlr(&self, member_id: &str) -> bool {
         self.read_entries().contains_key(member_id)
     }
@@ -840,9 +815,8 @@ impl<'a> MemberListProxy<'a> {
 }
 
 impl<'a> Serialize for MemberListProxy<'a> {
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
         where S: Serializer
     {
@@ -889,9 +863,8 @@ mod tests {
         // This is a remnant of when the MemberList::members entries were
         // simple Member structs. The tests that use this should be replaced,
         // but until then, this keeps them working.
-        /// # Locking
-        /// * `MemberList::entries` (read) This method must not be called while any
-        ///   MemberList::entries lock is held.
+        /// # Locking (see locking.md)
+        /// * `MemberList::entries` (read)
         fn with_member_iter<T>(&self,
                                mut with_closure: impl FnMut(hash_map::Values<'_, String, Member>)
                                      -> T)

--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -27,6 +27,7 @@ use serde;
 use std::{collections::{hash_map::Entry,
                         HashMap},
           default::Default,
+          fmt,
           result,
           sync::{atomic::{AtomicUsize,
                           Ordering},
@@ -102,12 +103,14 @@ impl RumorKey {
                    id: id.into(),
                    key: key.into() }
     }
+}
 
-    pub fn key(&self) -> RumorKeyKey {
+impl fmt::Display for RumorKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if !self.key.is_empty() {
-            format!("{}-{}", self.id, self.key)
+            write!(f, "{}-{}", self.id, self.key)
         } else {
-            self.id.clone()
+            write!(f, "{}", self.id)
         }
     }
 }

--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -260,14 +260,17 @@ mod storage {
         /// which it will be.
         fn increment_update_counter(&self) { self.update_counter.fetch_add(1, Ordering::Relaxed); }
 
-        /// # Locking
-        /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (read)
+        /// * IterableGuard contains an instance of a held lock in order to facilitate ergonomic
+        ///   access to collection data inside the lock. However, this means that the lock will be
+        ///   held until the `IterableGuard` goes out of scope. In general, it's best to avoid
+        ///   binding the return of `lock_rsr` in favor of using it as the first link in a chain of
+        ///   functions that will be consumed by an iterator adapter or `for` loop.
         pub fn lock_rsr(&self) -> IterableGuard<RumorMap<T>> { IterableGuard::read(&self.list) }
 
-        /// # Locking
-        /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (write)
         pub fn remove_rsw(&self, key: &str, id: &str) {
             let mut list = self.list.write();
             list.get_mut(key).and_then(|r| r.remove(id));
@@ -278,9 +281,8 @@ mod storage {
         /// Insert a rumor into the Rumor Store. Returns true if the value didn't exist or if it was
         /// mutated; if nothing changed, returns false.
         ///
-        /// # Locking
-        /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (write)
         pub fn insert_rsw(&self, rumor: R) -> bool {
             let mut list = self.list.write();
             let rumors = list.entry(String::from(rumor.key()))
@@ -315,9 +317,8 @@ mod storage {
 
     impl<T> Serialize for RumorStore<T> where T: Rumor
     {
-        /// # Locking
-        /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (read)
         fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
             where S: Serializer
         {
@@ -341,9 +342,8 @@ mod storage {
     }
 
     impl<'a> Serialize for RumorStoreProxy<'a, Departure> {
-        /// # Locking
-        /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (read)
         fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
             where S: Serializer
         {
@@ -368,9 +368,8 @@ mod storage {
     }
 
     impl<'a> Serialize for RumorStoreProxy<'a, Election> {
-        /// # Locking
-        /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (read)
         fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
             where S: Serializer
         {
@@ -394,9 +393,8 @@ mod storage {
 
     // This is the same as Election =/
     impl<'a> Serialize for RumorStoreProxy<'a, ElectionUpdate> {
-        /// # Locking
-        /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (read)
         fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
             where S: Serializer
         {
@@ -419,9 +417,8 @@ mod storage {
     }
 
     impl<'a> Serialize for RumorStoreProxy<'a, Service> {
-        /// # Locking
-        /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (read)
         fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
             where S: Serializer
         {
@@ -437,9 +434,8 @@ mod storage {
     }
 
     impl<'a> Serialize for RumorStoreProxy<'a, ServiceConfig> {
-        /// # Locking
-        /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (read)
         fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
             where S: Serializer
         {
@@ -462,9 +458,8 @@ mod storage {
     }
 
     impl<'a> Serialize for RumorStoreProxy<'a, ServiceFile> {
-        /// # Locking
-        /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list
-        ///   lock is held.
+        /// # Locking (see locking.md)
+        /// * `RumorStore::list` (read)
         fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
             where S: Serializer
         {

--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -131,8 +131,8 @@ pub struct RumorStore<T: Rumor> {
 impl<T> Default for RumorStore<T> where T: Rumor
 {
     fn default() -> RumorStore<T> {
-        RumorStore { list:           Arc::new(Lock::new(HashMap::new())),
-                     update_counter: Arc::new(AtomicUsize::new(0)), }
+        RumorStore { list:           Arc::default(),
+                     update_counter: Arc::default(), }
     }
 }
 

--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -242,7 +242,7 @@ mod storage {
     impl<'a, C: ConstKeyRumor> IterableGuard<'a, RumorMap<C>> {
         pub fn contains_id(&self, member_id: &str) -> bool {
             self.get(C::const_key())
-                .map(|departures| departures.contains_key(member_id))
+                .map(|rumors| rumors.contains_key(member_id))
                 .unwrap_or(false)
         }
     }

--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -415,18 +415,12 @@ mod storage {
             result
         }
 
-        pub fn remove(&self, key: &str, id: &str) {
+        /// # Locking
+        /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list
+        ///   lock is held.
+        pub fn remove_rsw(&self, key: &str, id: &str) {
             let mut list = self.list.write();
             list.get_mut(key).and_then(|r| r.remove(id));
-        }
-
-        pub fn with_keys<F>(&self, mut with_closure: F)
-            where F: FnMut((&String, &HashMap<String, T>))
-        {
-            let list = self.list.read();
-            for x in list.iter() {
-                with_closure(x);
-            }
         }
 
         pub fn with_rumors<F>(&self, key: &str, mut with_closure: F)

--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -556,7 +556,7 @@ mod tests {
     use uuid::Uuid;
 
     #[derive(Clone, Debug, Serialize)]
-    pub struct FakeRumor {
+    struct FakeRumor {
         pub id:  String,
         pub key: String,
     }

--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -159,10 +159,7 @@ mod storage {
             self.0.and_then(|m| m.get(member_id).map(f))
         }
 
-        // TODO: rename to contains_key (to be like stdlib) or contains_id since RumorStore
-        // has a two-level structure where we tend to use `key` for the first level and `id`
-        // for the second (see RumorKey).
-        pub fn contains_rumor(&self, member_id: &str) -> bool {
+        pub fn contains_id(&self, member_id: &str) -> bool {
             self.map_rumor(member_id, |_| true).unwrap_or(false)
         }
     }
@@ -201,8 +198,7 @@ mod storage {
                            id: member_id,
                            .. } = rumor.into();
 
-            self.service_group(&service_group)
-                .contains_rumor(&member_id)
+            self.service_group(&service_group).contains_id(&member_id)
         }
     }
 

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -122,33 +122,35 @@ impl DatFileReader {
     /// # Locking
     /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
     ///   lock is held.
-    pub fn read_into_mlw(&mut self, server: &Server) -> Result<()> {
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn read_into_mlw_rsw(&mut self, server: &Server) -> Result<()> {
         for Membership { member, health } in self.read_members()? {
             server.insert_member_mlw(member, health);
         }
 
         for service in self.read_rumors::<Service>()? {
-            server.insert_service_mlw(service);
+            server.insert_service_mlw_rsw(service);
         }
 
         for service_config in self.read_rumors::<ServiceConfig>()? {
-            server.insert_service_config(service_config);
+            server.insert_service_config_rsw(service_config);
         }
 
         for service_file in self.read_rumors::<ServiceFile>()? {
-            server.insert_service_file(service_file);
+            server.insert_service_file_rsw(service_file);
         }
 
         for election in self.read_rumors::<Election>()? {
-            server.insert_election_mlr(election);
+            server.insert_election_mlr_rsw(election);
         }
 
         for update_election in self.read_rumors::<ElectionUpdate>()? {
-            server.insert_update_election_mlr(update_election);
+            server.insert_update_election_mlr_rsw(update_election);
         }
 
         for departure in self.read_rumors::<Departure>()? {
-            server.insert_departure_mlw(departure);
+            server.insert_departure_mlw_rsw(departure);
         }
 
         Ok(())
@@ -538,14 +540,14 @@ mod tests {
 
         assert!(!file_path.exists());
 
-        let result = DatFileReader::read_or_create_mlr(file_path.to_path_buf(),
-                                                       &MemberList::new(),
-                                                       &RumorStore::default(),
-                                                       &RumorStore::default(),
-                                                       &RumorStore::default(),
-                                                       &RumorStore::default(),
-                                                       &RumorStore::default(),
-                                                       &RumorStore::default());
+        let result = DatFileReader::read_or_create_mlr_rsr(file_path.to_path_buf(),
+                                                           &MemberList::new(),
+                                                           &RumorStore::default(),
+                                                           &RumorStore::default(),
+                                                           &RumorStore::default(),
+                                                           &RumorStore::default(),
+                                                           &RumorStore::default(),
+                                                           &RumorStore::default());
 
         assert!(result.is_ok(), "{}", result.unwrap_err());
         assert!(file_path.is_file());

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -284,11 +284,7 @@ impl DatFileWriter {
               W: Write
     {
         let mut total = 0;
-        for member in store.list
-                           .read()
-                           .expect("Rumor store lock poisoned")
-                           .values()
-        {
+        for member in store.list.read().values() {
             for rumor in member.values() {
                 total += self.write_rumor(writer, rumor)?;
             }

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -69,11 +69,9 @@ pub struct DatFileReader {
 pub struct DatFileWriter(DatFile);
 
 impl DatFileReader {
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
+    /// * `MemberList::entries` (read)
     #[allow(clippy::too_many_arguments)]
     pub fn read_or_create_rsr_mlr(data_path: PathBuf,
                                   member_list: &MemberList,
@@ -119,11 +117,9 @@ impl DatFileReader {
 
     pub fn path(&self) -> &Path { &self.dat_file.0 }
 
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (write)
     pub fn read_into_rsw_mlw(&mut self, server: &Server) -> Result<()> {
         for Membership { member, health } in self.read_members()? {
             server.insert_member_mlw(member, health);
@@ -192,11 +188,9 @@ impl DatFileWriter {
 
     pub fn path(&self) -> &Path { &(self.0).0 }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
+    /// * `MemberList::entries` (read)
     #[allow(clippy::too_many_arguments)]
     pub fn write_rsr_mlr(&self,
                          member_list: &MemberList,
@@ -258,9 +252,8 @@ impl DatFileWriter {
         Ok(total)
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     fn write_member_list_mlr(&self,
                              writer: &mut impl Write,
                              member_list: &MemberList)
@@ -288,9 +281,8 @@ impl DatFileWriter {
         Ok(total)
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
     fn write_rumor_store_rsr<T, W>(&self, writer: &mut W, store: &RumorStore<T>) -> Result<u64>
         where T: Rumor,
               W: Write

--- a/components/butterfly/src/rumor/departure.rs
+++ b/components/butterfly/src/rumor/departure.rs
@@ -91,10 +91,10 @@ mod tests {
         let rs = create_rumor_store();
         let d1 = Departure::new("member_1");
         let d2 = Departure::new("member_2");
-        rs.insert(d1);
-        rs.insert(d2);
+        rs.insert_rsw(d1);
+        rs.insert_rsw(d2);
 
-        let list = rs.list.read();
+        let list = rs.lock_rsr();
         assert_eq!(list.len(), 1); // for the "departure" key
 
         let sub_list = list.get("departure").unwrap();

--- a/components/butterfly/src/rumor/departure.rs
+++ b/components/butterfly/src/rumor/departure.rs
@@ -10,7 +10,8 @@ use crate::{error::{Error,
                        newscast::{self,
                                   Rumor as ProtoRumor},
                        FromProto},
-            rumor::{Rumor,
+            rumor::{ConstKeyRumor,
+                    Rumor,
                     RumorPayload,
                     RumorType}};
 use std::{cmp::Ordering,
@@ -55,9 +56,13 @@ impl Rumor for Departure {
 
     fn kind(&self) -> RumorType { RumorType::Departure }
 
-    fn id(&self) -> &str { &self.member_id }
+    fn key(&self) -> &str { Self::const_key() }
 
-    fn key(&self) -> &str { "departure" }
+    fn id(&self) -> &str { &self.member_id }
+}
+
+impl ConstKeyRumor for Departure {
+    fn const_key() -> &'static str { "departure" }
 }
 
 impl PartialOrd for Departure {
@@ -79,7 +84,8 @@ mod tests {
     use std::cmp::Ordering;
 
     use super::Departure;
-    use crate::rumor::{Rumor,
+    use crate::rumor::{ConstKeyRumor as _,
+                       Rumor,
                        RumorStore};
 
     fn create_departure(member_id: &str) -> Departure { Departure::new(member_id) }
@@ -97,7 +103,7 @@ mod tests {
         let list = rs.lock_rsr();
         assert_eq!(list.len(), 1); // for the "departure" key
 
-        let sub_list = list.get("departure").unwrap();
+        let sub_list = list.get(Departure::const_key()).unwrap();
         assert_eq!(sub_list.len(), 2); // for each of the members we inserted
     }
 

--- a/components/butterfly/src/rumor/departure.rs
+++ b/components/butterfly/src/rumor/departure.rs
@@ -94,7 +94,7 @@ mod tests {
         rs.insert(d1);
         rs.insert(d2);
 
-        let list = rs.list.read().expect("Rumor store lock poisoned");
+        let list = rs.list.read();
         assert_eq!(list.len(), 1); // for the "departure" key
 
         let sub_list = list.get("departure").unwrap();

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -16,14 +16,15 @@ use crate::{error::{Error,
                        newscast::{self,
                                   Rumor as ProtoRumor},
                        FromProto},
-            rumor::{Rumor,
+            rumor::{ConstIdRumor,
+                    Rumor,
                     RumorPayload,
                     RumorType}};
 use std::{fmt,
           ops::{Deref,
                 DerefMut}};
 
-pub trait ElectionRumor {
+pub trait ElectionRumor: ConstIdRumor {
     fn member_id(&self) -> &str;
 
     fn is_finished(&self) -> bool;
@@ -194,13 +195,15 @@ impl Rumor for Election {
         }
     }
 
-    /// We are the Election rumor!
     fn kind(&self) -> RumorType { RumorType::Election }
 
-    /// There can be only
-    fn id(&self) -> &str { "election" }
+    fn id(&self) -> &str { Self::const_id() }
 
     fn key(&self) -> &str { self.service_group.as_ref() }
+}
+
+impl ConstIdRumor for Election {
+    fn const_id() -> &'static str { "election" }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -273,9 +276,13 @@ impl Rumor for ElectionUpdate {
 
     fn kind(&self) -> RumorType { RumorType::ElectionUpdate }
 
-    fn id(&self) -> &str { "election" }
+    fn id(&self) -> &str { Self::const_id() }
 
     fn key(&self) -> &str { self.0.key() }
+}
+
+impl ConstIdRumor for ElectionUpdate {
+    fn const_id() -> &'static str { "election" }
 }
 
 #[cfg(test)]
@@ -283,6 +290,7 @@ mod tests {
     use crate::rumor::{election::{Election,
                                   ElectionUpdate,
                                   Term},
+                       ConstIdRumor as _,
                        Rumor,
                        RumorStore};
     use habitat_core::service::ServiceGroup;
@@ -320,7 +328,7 @@ mod tests {
 
         let sub_list = list.get("tdep.prod").unwrap();
         assert_eq!(sub_list.len(), 1); // because only the latest election is kept
-        assert!(sub_list.get("election").is_some());
+        assert!(sub_list.get(Election::const_id()).is_some());
     }
 
     #[test]
@@ -336,7 +344,7 @@ mod tests {
 
         let sub_list = list.get("tdep.prod").unwrap();
         assert_eq!(sub_list.len(), 1); // because only the latest election is kept
-        assert!(sub_list.get("election").is_some());
+        assert!(sub_list.get(ElectionUpdate::const_id()).is_some());
     }
 
     #[test]

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -315,7 +315,7 @@ mod tests {
         rs.insert(e1);
         rs.insert(e2);
 
-        let list = rs.list.read().expect("Rumor store lock poisoned");
+        let list = rs.list.read();
         assert_eq!(list.len(), 1); // because we only have 1 service group
 
         let sub_list = list.get("tdep.prod").unwrap();
@@ -331,7 +331,7 @@ mod tests {
         rs.insert(e1);
         rs.insert(e2);
 
-        let list = rs.list.read().expect("Rumor store lock poisoned");
+        let list = rs.list.read();
         assert_eq!(list.len(), 1); // because we only have 1 service group
 
         let sub_list = list.get("tdep.prod").unwrap();

--- a/components/butterfly/src/rumor/election.rs
+++ b/components/butterfly/src/rumor/election.rs
@@ -312,10 +312,10 @@ mod tests {
         let rs = create_election_rumor_store();
         let e1 = create_election("member_1", 1);
         let e2 = create_election("member_2", 2);
-        rs.insert(e1);
-        rs.insert(e2);
+        rs.insert_rsw(e1);
+        rs.insert_rsw(e2);
 
-        let list = rs.list.read();
+        let list = rs.lock_rsr();
         assert_eq!(list.len(), 1); // because we only have 1 service group
 
         let sub_list = list.get("tdep.prod").unwrap();
@@ -328,10 +328,10 @@ mod tests {
         let rs = create_election_update_rumor_store();
         let e1 = create_election_update("member_1", 1);
         let e2 = create_election_update("member_2", 2);
-        rs.insert(e1);
-        rs.insert(e2);
+        rs.insert_rsw(e1);
+        rs.insert_rsw(e2);
 
-        let list = rs.list.read();
+        let list = rs.lock_rsr();
         assert_eq!(list.len(), 1); // because we only have 1 service group
 
         let sub_list = list.get("tdep.prod").unwrap();

--- a/components/butterfly/src/rumor/service_config.rs
+++ b/components/butterfly/src/rumor/service_config.rs
@@ -188,7 +188,7 @@ mod tests {
         rs.insert(s1);
         rs.insert(s2);
 
-        let list = rs.list.read().expect("Rumor store lock poisoned");
+        let list = rs.list.read();
         assert_eq!(list.len(), 1); // because we only have 1 service group
 
         let sub_list = list.get("neurosis.production").unwrap();

--- a/components/butterfly/src/rumor/service_config.rs
+++ b/components/butterfly/src/rumor/service_config.rs
@@ -8,7 +8,8 @@ use crate::{error::{Error,
                        newscast::{self,
                                   Rumor as ProtoRumor},
                        FromProto},
-            rumor::{Rumor,
+            rumor::{ConstIdRumor,
+                    Rumor,
                     RumorPayload,
                     RumorType}};
 use habitat_core::{crypto::{keys::box_key_pair::WrappedSealedBox,
@@ -153,22 +154,25 @@ impl Rumor for ServiceConfig {
 
     fn kind(&self) -> RumorType { RumorType::ServiceConfig }
 
-    fn id(&self) -> &str { "service_config" }
+    fn id(&self) -> &str { Self::const_id() }
 
     fn key(&self) -> &str { &self.service_group }
 }
 
+impl ConstIdRumor for ServiceConfig {
+    fn const_id() -> &'static str { "service_config" }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::ServiceConfig;
+    use crate::rumor::{ConstIdRumor as _,
+                       Rumor,
+                       RumorStore};
+    use habitat_core::service::ServiceGroup;
     use std::{cmp::Ordering,
               str::FromStr};
-
-    use habitat_core::service::ServiceGroup;
     use toml;
-
-    use super::ServiceConfig;
-    use crate::rumor::{Rumor,
-                       RumorStore};
 
     fn create_rumor_store() -> RumorStore<ServiceConfig> { RumorStore::default() }
 
@@ -194,7 +198,7 @@ mod tests {
         let sub_list = list.get("neurosis.production").unwrap();
         assert_eq!(sub_list.len(), 1); // because only the latest service config is kept
 
-        let sc = sub_list.get("service_config").unwrap();
+        let sc = sub_list.get(ServiceConfig::const_id()).unwrap();
         assert_eq!(sc.config, Vec::<u8>::from("awesome"));
     }
 

--- a/components/butterfly/src/rumor/service_config.rs
+++ b/components/butterfly/src/rumor/service_config.rs
@@ -185,10 +185,10 @@ mod tests {
         let s1 = create_service_config("timmeh", "lol");
         let mut s2 = create_service_config("timmeh", "awesome");
         s2.incarnation = 1; // 0 is the default, which means this rumor will win
-        rs.insert(s1);
-        rs.insert(s2);
+        rs.insert_rsw(s1);
+        rs.insert_rsw(s2);
 
-        let list = rs.list.read();
+        let list = rs.lock_rsr();
         assert_eq!(list.len(), 1); // because we only have 1 service group
 
         let sub_list = list.get("neurosis.production").unwrap();

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -409,7 +409,7 @@ impl Server {
     /// # Locking
     /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
     ///   lock is held.
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
     ///
     /// # Errors
@@ -417,7 +417,7 @@ impl Server {
     /// * Returns `Error::CannotBind` if the socket cannot be bound
     /// * Returns `Error::SocketSetReadTimeout` if the socket read timeout cannot be set
     /// * Returns `Error::SocketSetWriteTimeout` if the socket write timeout cannot be set
-    pub fn start_mlw_rsr(&mut self, timing: &timing::Timing) -> Result<()> {
+    pub fn start_mlw_rsw(&mut self, timing: &timing::Timing) -> Result<()> {
         debug!("entering habitat_butterfly::server::Server::start");
         let (tx_outbound, rx_inbound) = channel();
         if let Some(ref path) = self.data_path {
@@ -435,7 +435,7 @@ impl Server {
                                                                    &self.update_store,
                                                                    &self.departure_store)?;
 
-            match reader.read_into_mlw(&self) {
+            match reader.read_into_mlw_rsw(&self) {
                 Ok(_) => {
                     debug!("Successfully ingested rumors from {}",
                            reader.path().display())
@@ -682,7 +682,9 @@ impl Server {
     /// # Locking
     /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
     ///   lock is held.
-    pub fn insert_service_mlw(&self, service: Service) {
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn insert_service_mlw_rsw(&self, service: Service) {
         Self::insert_service_impl(service,
                                   &self.service_store,
                                   &self.member_list,
@@ -703,7 +705,7 @@ impl Server {
         let inserting_new_group_member =
             service_store.contains_group_without_member(service_group, member_id);
 
-        if service_store.insert(service) {
+        if service_store.insert_rsw(service) {
             if inserting_new_group_member && !check_quorum(service_group) {
                 if let Some(member_id_to_depart) =
                     service_store.min_member_id_with(service_group, |id| {
@@ -722,17 +724,25 @@ impl Server {
     }
 
     /// Insert a service config rumor into the service store.
-    pub fn insert_service_config(&self, service_config: ServiceConfig) {
+    ///
+    /// # Locking
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn insert_service_config_rsw(&self, service_config: ServiceConfig) {
         let rk = RumorKey::from(&service_config);
-        if self.service_config_store.insert(service_config) {
+        if self.service_config_store.insert_rsw(service_config) {
             self.rumor_heat.start_hot_rumor(rk);
         }
     }
 
     /// Insert a service file rumor into the service file store.
-    pub fn insert_service_file(&self, service_file: ServiceFile) {
+    ///
+    /// # Locking
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn insert_service_file_rsw(&self, service_file: ServiceFile) {
         let rk = RumorKey::from(&service_file);
-        if self.service_file_store.insert(service_file) {
+        if self.service_file_store.insert_rsw(service_file) {
             self.rumor_heat.start_hot_rumor(rk);
         }
     }
@@ -742,7 +752,9 @@ impl Server {
     /// # Locking
     /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
     ///   lock is held.
-    pub fn insert_departure_mlw(&self, departure: Departure) {
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn insert_departure_mlw_rsw(&self, departure: Departure) {
         let rk = RumorKey::from(&departure);
         if *self.member_id == departure.member_id {
             self.departed
@@ -755,7 +767,7 @@ impl Server {
         self.rumor_heat
             .start_hot_rumor(RumorKey::new(RumorType::Member, &departure.member_id, ""));
 
-        if self.departure_store.insert(departure) {
+        if self.departure_store.insert_rsw(departure) {
             self.rumor_heat.start_hot_rumor(rk);
         }
     }
@@ -834,7 +846,9 @@ impl Server {
     /// # Locking
     /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
     ///   lock is held.
-    pub fn start_election_mlr(&self, service_group: &str, term: u64) {
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn start_election_mlr_rsw(&self, service_group: &str, term: u64) {
         let suitability = self.suitability_lookup.get(&service_group);
         let has_quorum = self.check_quorum_mlr(service_group);
         let e = Election::new(self.member_id(),
@@ -847,13 +861,15 @@ impl Server {
         }
         debug!("start_election: {:?}", e);
         self.rumor_heat.start_hot_rumor(RumorKey::from(&e));
-        self.election_store.insert(e);
+        self.election_store.insert_rsw(e);
     }
 
     /// # Locking
     /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
     ///   lock is held.
-    pub fn start_update_election_mlr(&self, service_group: &str, suitability: u64, term: u64) {
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn start_update_election_mlr_rsw(&self, service_group: &str, suitability: u64, term: u64) {
         let has_quorum = self.check_quorum_mlr(service_group);
         let e = ElectionUpdate::new(self.member_id(),
                                     service_group,
@@ -865,7 +881,7 @@ impl Server {
         }
         debug!("start_update_election: {:?}", e);
         self.rumor_heat.start_hot_rumor(RumorKey::from(&e));
-        self.update_store.insert(e);
+        self.update_store.insert_rsw(e);
     }
 
     /// # Locking
@@ -967,7 +983,9 @@ impl Server {
     /// # Locking
     /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
     ///   lock is held.
-    pub fn restart_elections_mlr(&self, feature_flags: FeatureFlag) {
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn restart_elections_mlr_rsw(&self, feature_flags: FeatureFlag) {
         let elections_to_restart =
             self.elections_to_restart_mlr(&self.election_store, feature_flags);
 
@@ -982,14 +1000,14 @@ impl Server {
             let term = old_term + 1;
             warn!("Starting a new election for {} {}", service_group, term);
             self.election_store.remove(&service_group, "election");
-            self.start_election_mlr(&service_group, term);
+            self.start_election_mlr_rsw(&service_group, term);
         }
 
         for (service_group, old_term) in update_elections_to_restart {
             let term = old_term + 1;
             warn!("Starting a new election for {} {}", service_group, term);
             self.update_store.remove(&service_group, "election");
-            self.start_update_election_mlr(&service_group, 0, term);
+            self.start_update_election_mlr_rsw(&service_group, 0, term);
         }
     }
 
@@ -1000,7 +1018,9 @@ impl Server {
     /// # Locking
     /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
     ///   lock is held.
-    pub fn insert_election_mlr(&self, mut election: Election) {
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn insert_election_mlr_rsw(&self, mut election: Election) {
         debug!("insert_election: {:?}", election);
         let rk = RumorKey::from(&election);
 
@@ -1024,7 +1044,7 @@ impl Server {
                 if new_term {
                     debug!("removing old rumor and starting new election");
                     self.election_store.remove(election.key(), election.id());
-                    self.start_election_mlr(&election.service_group, election.term);
+                    self.start_election_mlr_rsw(&election.service_group, election.term);
                 }
                 // If we are the member that this election is voting for, then check to see if the
                 // election is over! If it is, mark this election as final before you process it.
@@ -1074,7 +1094,7 @@ impl Server {
                                               .lock()
                                               .expect("Election timers lock poisoned");
                 existing_timers.insert(election.service_group.clone(), ElectionTimer(timer));
-                self.start_election_mlr(&election.service_group, election.term);
+                self.start_election_mlr_rsw(&election.service_group, election.term);
             }
             if !election.is_finished() {
                 let has_quorum = self.check_quorum_mlr(election.key());
@@ -1085,7 +1105,7 @@ impl Server {
                 }
             }
         }
-        if self.election_store.insert(election) {
+        if self.election_store.insert_rsw(election) {
             self.rumor_heat.start_hot_rumor(rk);
         }
     }
@@ -1093,7 +1113,9 @@ impl Server {
     /// # Locking
     /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
     ///   lock is held.
-    pub fn insert_update_election_mlr(&self, mut election: ElectionUpdate) {
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
+    pub fn insert_update_election_mlr_rsw(&self, mut election: ElectionUpdate) {
         debug!("insert_update_election: {:?}", election);
         let rk = RumorKey::from(&election);
 
@@ -1117,7 +1139,7 @@ impl Server {
                 if new_term {
                     debug!("removing old rumor and starting new election");
                     self.update_store.remove(election.key(), election.id());
-                    self.start_update_election_mlr(&election.service_group, 0, election.term);
+                    self.start_update_election_mlr_rsw(&election.service_group, 0, election.term);
                 }
                 // If we are the member that this election is voting for, then check to see if the
                 // election is over! If it is, mark this election as final before you process it.
@@ -1146,7 +1168,7 @@ impl Server {
             } else {
                 // Otherwise, we need to create a new election object for ourselves prior to
                 // merging.
-                self.start_update_election_mlr(&election.service_group, 0, election.term);
+                self.start_update_election_mlr_rsw(&election.service_group, 0, election.term);
             }
             if !election.is_finished() {
                 let has_quorum = self.check_quorum_mlr(election.key());
@@ -1157,7 +1179,7 @@ impl Server {
                 }
             }
         }
-        if self.update_store.insert(election) {
+        if self.update_store.insert_rsw(election) {
             self.rumor_heat.start_hot_rumor(rk);
         }
     }
@@ -1252,6 +1274,8 @@ impl<'a> Serialize for ServerProxy<'a> {
     /// # Locking
     /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
     ///   lock is held.
+    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
+    ///   is held.
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
         where S: Serializer
     {
@@ -1382,9 +1406,9 @@ mod tests {
                                                              suitability,
                                                              true /* has_quorum */);
         election_with_unknown_leader.finish();
-        elections.insert(election_with_unknown_leader);
+        elections.insert_rsw(election_with_unknown_leader);
 
-        service_store.insert(service.clone());
+        service_store.insert_rsw(service.clone());
 
         let to_restart = Server::elections_to_restart_impl(&elections,
                                                            &service_store,
@@ -1415,9 +1439,9 @@ mod tests {
                                                              suitability,
                                                              true /* has_quorum */);
         election_with_unknown_leader.finish();
-        elections.insert(election_with_unknown_leader);
+        elections.insert_rsw(election_with_unknown_leader);
 
-        service_store.insert(service.clone());
+        service_store.insert_rsw(service.clone());
 
         member_list.insert_mlw(departed_leader, Health::Departed);
 
@@ -1708,14 +1732,14 @@ mod tests {
         fn new_with_corrupt_rumor_file() {
             let tmpdir = TempDir::new().unwrap();
             let mut server = start_with_corrupt_rumor_file(&tmpdir);
-            server.start_mlw_rsr(&Timing::default())
+            server.start_mlw_rsw(&Timing::default())
                   .expect("Server failed to start");
         }
 
         #[test]
         fn start_listener() {
             let mut server = start_server();
-            server.start_mlw_rsr(&Timing::default())
+            server.start_mlw_rsw(&Timing::default())
                   .expect("Server failed to start");
         }
     }

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -607,7 +607,7 @@ impl Server {
             // NOT calling RumorHeat::purge here because we'll be
             // shutting down soon anyway.
             self.rumor_heat
-                .start_hot_rumor(RumorKey::new(RumorType::Member, &self.member_id, ""));
+                .start_hot_rumor(RumorKey::new(RumorType::Member, &*self.member_id, ""));
 
             let check_list = self.member_list.check_list_mlr(&self.member_id);
 
@@ -717,7 +717,7 @@ impl Server {
                     member_list.set_departed_mlw(&member_id_to_depart);
                     rumor_heat.purge(&member_id_to_depart);
                     rumor_heat.start_hot_rumor(RumorKey::new(RumorType::Member,
-                                                             &member_id_to_depart,
+                                                             &*member_id_to_depart,
                                                              ""));
                 }
             }

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -925,7 +925,7 @@ impl Server {
         for (service_group, rumors) in elections.lock_rsr().iter() {
             if service_store.lock_rsr()
                             .service_group(&service_group)
-                            .contains_rumor(myself_member_id)
+                            .contains_id(myself_member_id)
             {
                 // This is safe; there is only one id for an election, and it is "election"
                 let election =
@@ -1027,7 +1027,7 @@ impl Server {
         if self.service_store
                .lock_rsr()
                .service_group(&election.service_group)
-               .contains_rumor(self.member_id())
+               .contains_id(self.member_id())
         {
             trace!("{} is a member of {}",
                    self.member_id(),
@@ -1122,7 +1122,7 @@ impl Server {
         if self.service_store
                .lock_rsr()
                .service_group(&election.service_group)
-               .contains_rumor(self.member_id())
+               .contains_id(self.member_id())
         {
             trace!("{} is a member of {}",
                    self.member_id(),

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -676,7 +676,6 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (write)
-    /// XXX LOCK ORDER: rs -> ml
     pub fn insert_service_rsw_mlw(&self, service: Service) {
         Self::insert_service_impl(service,
                                   &self.service_store,
@@ -777,8 +776,8 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (read)
     /// * `MemberList::entries` (read)
-    // XXX LOCK ORDER: rs -> ml
     fn get_electorate_rsr_mlr(&self, key: &str) -> Vec<String> {
+        // This could be converted to a more FP approach and avoid the need for `mut`
         let mut electorate = vec![];
         for s in self.service_store.lock_rsr().service_group(key).rumors() {
             if self.member_list.health_of_by_id_mlr(&s.member_id) == Some(Health::Alive) {
@@ -802,8 +801,8 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (read)
     /// * `MemberList::entries` (read)
-    // XXX LOCK ORDER: rs -> ml
     fn get_total_population_rsr_mlr(&self, key: &str) -> Vec<String> {
+        // This could be converted to a more FP approach and avoid the need for `mut`
         let mut total_pop = vec![];
         for s in self.service_store.lock_rsr().service_group(key).rumors() {
             if self.check_in_voting_population_by_id_mlr(&s.member_id) {

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -406,11 +406,9 @@ impl Server {
     /// Start the server, along with a `Timing` for outbound connections. Spawns the `inbound`,
     /// `outbound`, and `expire` threads.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (write)
     ///
     /// # Errors
     ///
@@ -496,10 +494,9 @@ impl Server {
         Ok(())
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held. Additionally `with_closure` is called with this lock held, so the closure
-    ///   must not call any functions which take this lock.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read) Additionally `with_closure` is called with this lock held, so
+    ///   the closure must not call any functions which take this lock.
     pub fn need_peer_seeding_mlr(&self) -> bool { self.member_list.is_empty_mlr() }
 
     /// Persistently block a given address, causing no traffic to be seen.
@@ -552,9 +549,8 @@ impl Server {
 
     /// Insert a member to the `MemberList`, and update its `RumorKey` appropriately.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     pub fn insert_member_mlw(&self, member: Member, health: Health) {
         let rk: RumorKey = RumorKey::from(&member);
         // NOTE: This sucks so much right here. Check out how we allocate no matter what, because
@@ -585,9 +581,8 @@ impl Server {
     /// Set our member to departed, then send up to 10 out of order ack messages to other
     /// members to seed our status.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     pub fn set_departed_mlw(&self) {
         if self.socket.is_some() {
             {
@@ -634,9 +629,8 @@ impl Server {
 
     /// Given a membership record and some health, insert it into the Member List.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (write)
     fn insert_member_from_rumor_mlw(&self, member: Member, mut health: Health) {
         let rk: RumorKey = RumorKey::from(&member);
         if member.id == self.member_id() && health != Health::Alive {
@@ -679,11 +673,9 @@ impl Server {
     /// See https://github.com/habitat-sh/habitat/issues/1994
     /// See Server::check_quorum
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (write)
     /// XXX LOCK ORDER: rs -> ml
     pub fn insert_service_rsw_mlw(&self, service: Service) {
         Self::insert_service_impl(service,
@@ -736,9 +728,8 @@ impl Server {
 
     /// Insert a service config rumor into the service store.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
     pub fn insert_service_config_rsw(&self, service_config: ServiceConfig) {
         let rk = RumorKey::from(&service_config);
         if self.service_config_store.insert_rsw(service_config) {
@@ -748,9 +739,8 @@ impl Server {
 
     /// Insert a service file rumor into the service file store.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
     pub fn insert_service_file_rsw(&self, service_file: ServiceFile) {
         let rk = RumorKey::from(&service_file);
         if self.service_file_store.insert_rsw(service_file) {
@@ -760,11 +750,9 @@ impl Server {
 
     /// Insert a departure rumor into the departure store.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (write)
     pub fn insert_departure_rsw_mlw(&self, departure: Departure) {
         let rk = RumorKey::from(&departure);
         if *self.member_id == departure.member_id {
@@ -786,11 +774,9 @@ impl Server {
     /// Get all the Member ID's who are present in a given service group, and eligible to vote
     /// (alive)
     ///
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
+    /// * `MemberList::entries` (read)
     // XXX LOCK ORDER: rs -> ml
     fn get_electorate_rsr_mlr(&self, key: &str) -> Vec<String> {
         let mut electorate = vec![];
@@ -802,9 +788,8 @@ impl Server {
         electorate
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     fn check_in_voting_population_by_id_mlr(&self, member_id: &str) -> bool {
         match self.member_list.health_of_by_id_mlr(member_id) {
             Some(Health::Alive) | Some(Health::Suspect) | Some(Health::Confirmed) => true,
@@ -814,11 +799,9 @@ impl Server {
 
     /// Get all the Member ID's who are present in a given service group, and count towards quorum.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
+    /// * `MemberList::entries` (read)
     // XXX LOCK ORDER: rs -> ml
     fn get_total_population_rsr_mlr(&self, key: &str) -> Vec<String> {
         let mut total_pop = vec![];
@@ -834,11 +817,9 @@ impl Server {
     ///
     /// A group has quorum if a majority of its non-departed members are alive.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
+    /// * `RumorStore::list` (read)
     fn check_quorum_mlr(&self, key: &str) -> bool {
         let electorate = self.get_electorate_rsr_mlr(key);
         let service_group_members = self.get_total_population_rsr_mlr(key);
@@ -860,11 +841,9 @@ impl Server {
     /// Start an election for the given service group, declaring this members suitability and the
     /// term for the election.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (read)
     pub fn start_election_rsw_mlr(&self, service_group: &str, term: u64) {
         let suitability = self.suitability_lookup.get(&service_group);
         let has_quorum = self.check_quorum_mlr(service_group);
@@ -881,11 +860,9 @@ impl Server {
         self.election_store.insert_rsw(e);
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (read)
     pub fn start_update_election_rsw_mlr(&self, service_group: &str, suitability: u64, term: u64) {
         let has_quorum = self.check_quorum_mlr(service_group);
         let e = ElectionUpdate::new(self.member_id(),
@@ -901,11 +878,9 @@ impl Server {
         self.update_store.insert_rsw(e);
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
+    /// * `MemberList::entries` (read)
     fn elections_to_restart_rsr_mlr<T>(&self,
                                        elections: &RumorStore<T>,
                                        feature_flags: FeatureFlag)
@@ -990,11 +965,9 @@ impl Server {
     /// a) We are the leader, and we have lost quorum with the rest of the group.
     /// b) We are not the leader, and we have detected that the leader is confirmed dead.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (read)
     pub fn restart_elections_rsw_mlr(&self, feature_flags: FeatureFlag) {
         let elections_to_restart =
             self.elections_to_restart_rsr_mlr(&self.election_store, feature_flags);
@@ -1025,11 +998,9 @@ impl Server {
     /// member on receipt of an election rumor for a service this server cares about. Also handles
     /// stopping the election if we are the winner and we have enough votes.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (read)
     pub fn insert_election_rsw_mlr(&self, mut election: Election) {
         debug!("insert_election: {:?}", election);
         let rk = RumorKey::from(&election);
@@ -1120,11 +1091,9 @@ impl Server {
         }
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (read)
     pub fn insert_update_election_rsw_mlr(&self, mut election: ElectionUpdate) {
         debug!("insert_update_election: {:?}", election);
         let rk = RumorKey::from(&election);
@@ -1201,11 +1170,9 @@ impl Server {
         message::unwrap_wire(payload, (*self.ring_key).as_ref())
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
+    /// * `MemberList::entries` (read)
     pub fn persist_data_rsr_mlr(&self) {
         if let Some(ref dat_file_lock) = self.dat_file {
             let dat_file = dat_file_lock.lock().expect("DatFile lock poisoned");
@@ -1280,11 +1247,9 @@ impl<'a> ServerProxy<'a> {
 }
 
 impl<'a> Serialize for ServerProxy<'a> {
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
+    /// * `RumorStore::list` (read)
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
         where S: Serializer
     {

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -1454,11 +1454,6 @@ mod tests {
         assert_eq!(to_restart, vec![(service.service_group.to_string(), term)]);
     }
 
-    // TODO remove and make callers do lock_rsr()
-    impl RumorStore<Service> {
-        fn contains(&self, service: &Service) -> bool { self.lock_rsr().contains_rumor(service) }
-    }
-
     #[test]
     fn insert_service_adds_service_to_service_store() {
         let service = mock_service(&Member::default());
@@ -1472,7 +1467,7 @@ mod tests {
                                     &rumor_heat,
                                     check_quorum_returns(false));
 
-        assert!(service_store.contains(&service));
+        assert!(service_store.lock_rsr().contains_rumor(&service));
     }
 
     #[test]

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -1031,12 +1031,11 @@ impl Server {
             if self.election_store
                    .contains_rumor(election.key(), election.id())
             {
-                let mut new_term = false;
-                self.election_store
-                    .with_rumor(election.key(), election.id(), |ce| {
-                        trace!("election_store already contains {:?}", ce);
-                        new_term = election.term > ce.term
-                    });
+                let new_term = self.election_store
+                                   .lock_rsr()
+                                   .get_term(election.key())
+                                   .map(|stored_term| election.term > stored_term)
+                                   .unwrap_or(false);
                 if new_term {
                     debug!("removing old rumor and starting new election");
                     self.election_store
@@ -1127,12 +1126,11 @@ impl Server {
             if self.update_store
                    .contains_rumor(election.key(), election.id())
             {
-                let mut new_term = false;
-                self.update_store
-                    .with_rumor(election.key(), election.id(), |ce| {
-                        trace!("election_store already contains {:?}", ce);
-                        new_term = election.term > ce.term
-                    });
+                let new_term = self.update_store
+                                   .lock_rsr()
+                                   .get_term(election.key())
+                                   .map(|stored_term| election.term > stored_term)
+                                   .unwrap_or(false);
                 if new_term {
                     debug!("removing old rumor and starting new election");
                     self.update_store.remove_rsw(election.key(), election.id());

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -145,9 +145,8 @@ pub fn run_loop(server: &Server, socket: &UdpSocket, tx_outbound: &AckSender) ->
 
 /// Process pingreq messages.
 ///
-/// # Locking
-/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
-///   is held.
+/// # Locking (see locking.md)
+/// * `MemberList::entries` (read)
 fn process_pingreq_mlr(server: &Server, socket: &UdpSocket, addr: SocketAddr, mut msg: PingReq) {
     trace_it!(SWIM: server,
               TraceKind::RecvPingReq,
@@ -175,9 +174,8 @@ fn process_pingreq_mlr(server: &Server, socket: &UdpSocket, addr: SocketAddr, mu
 
 /// Process ack messages; forwards to the outbound thread.
 ///
-/// # Locking
-/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-///   lock is held.
+/// # Locking (see locking.md)
+/// * `MemberList::entries` (write)
 fn process_ack_mlw(server: &Server,
                    socket: &UdpSocket,
                    tx_outbound: &AckSender,
@@ -219,9 +217,8 @@ fn process_ack_mlw(server: &Server,
     }
 }
 
-/// # Locking
-/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-///   lock is held.
+/// # Locking (see locking.md)
+/// * `MemberList::entries` (write)
 fn process_ping_mlw(server: &Server, socket: &UdpSocket, addr: SocketAddr, mut msg: Ping) {
     trace_it!(SWIM: server, TraceKind::RecvPing, &msg.from.id, addr, &msg);
     outbound::ack_mlr(server, socket, &msg.from, addr, msg.forward_to);

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -309,7 +309,7 @@ pub fn populate_membership_rumors_mlr(server: &Server,
         .collect();
 
     for rkey in rumors.iter() {
-        if let Some(member) = server.member_list.membership_for_mlr(&rkey.key()) {
+        if let Some(member) = server.member_list.membership_for_mlr(&rkey.to_string()) {
             swim.membership.push(member);
         }
     }

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -161,9 +161,8 @@ fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timin
 ///
 /// If we don't receive anything at all in the Ping/PingReq loop, we mark the member as Suspect.
 ///
-/// # Locking
-/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-///   lock is held.
+/// # Locking (see locking.md)
+/// * `MemberList::entries` (write)
 fn probe_mlw(server: &Server,
              socket: &UdpSocket,
              rx_inbound: &AckReceiver,
@@ -227,9 +226,8 @@ fn probe_mlw(server: &Server,
 
 /// Listen for an ack from the `Inbound` thread.
 ///
-/// # Locking
-/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-///   lock is held.
+/// # Locking (see locking.md)
+/// * `MemberList::entries` (write)
 fn recv_ack_mlw(server: &Server,
                 rx_inbound: &AckReceiver,
                 timing: &Timing,
@@ -283,9 +281,8 @@ fn recv_ack_mlw(server: &Server,
 
 /// Created a SWIM message from the given `message` template and populate it with rumors.
 ///
-/// # Locking
-/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
-///   is held.
+/// # Locking (see locking.md)
+/// * `MemberList::entries` (read)
 pub fn populate_membership_rumors_mlr(server: &Server,
                                       target: &Member,
                                       message: impl Into<Swim>)
@@ -379,9 +376,8 @@ fn pingreq(server: &Server, // TODO: eliminate this arg
 
 /// Send a Ping.
 ///
-/// # Locking
-/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
-///   is held.
+/// # Locking (see locking.md)
+/// * `MemberList::entries` (read)
 pub fn ping_mlr(server: &Server,
                 socket: &UdpSocket,
                 target: &Member,
@@ -491,9 +487,8 @@ pub fn forward_ack(server: &Server, socket: &UdpSocket, addr: SocketAddr, msg: A
 
 /// Send an Ack.
 ///
-/// # Locking
-/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
-///   is held.
+/// # Locking (see locking.md)
+/// * `MemberList::entries` (read)
 pub fn ack_mlr(server: &Server,
                socket: &UdpSocket,
                target: &Member,

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -118,21 +118,21 @@ fn run_loop(server: &Server) -> ! {
             RumorKind::Membership(membership) => {
                 server.insert_member_from_rumor_mlw(membership.member, membership.health);
             }
-            RumorKind::Service(service) => server.insert_service_mlw(*service),
+            RumorKind::Service(service) => server.insert_service_mlw_rsw(*service),
             RumorKind::ServiceConfig(service_config) => {
-                server.insert_service_config(service_config);
+                server.insert_service_config_rsw(service_config);
             }
             RumorKind::ServiceFile(service_file) => {
-                server.insert_service_file(service_file);
+                server.insert_service_file_rsw(service_file);
             }
             RumorKind::Election(election) => {
-                server.insert_election_mlr(election);
+                server.insert_election_mlr_rsw(election);
             }
             RumorKind::ElectionUpdate(election) => {
-                server.insert_update_election_mlr(election);
+                server.insert_update_election_mlr_rsw(election);
             }
             RumorKind::Departure(departure) => {
-                server.insert_departure_mlw(departure);
+                server.insert_departure_mlw_rsw(departure);
             }
         }
     }

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -118,7 +118,7 @@ fn run_loop(server: &Server) -> ! {
             RumorKind::Membership(membership) => {
                 server.insert_member_from_rumor_mlw(membership.member, membership.health);
             }
-            RumorKind::Service(service) => server.insert_service_mlw_rsw(*service),
+            RumorKind::Service(service) => server.insert_service_rsw_mlw(*service),
             RumorKind::ServiceConfig(service_config) => {
                 server.insert_service_config_rsw(service_config);
             }
@@ -126,13 +126,13 @@ fn run_loop(server: &Server) -> ! {
                 server.insert_service_file_rsw(service_file);
             }
             RumorKind::Election(election) => {
-                server.insert_election_mlr_rsw(election);
+                server.insert_election_rsw_mlr(election);
             }
             RumorKind::ElectionUpdate(election) => {
-                server.insert_update_election_mlr_rsw(election);
+                server.insert_update_election_rsw_mlr(election);
             }
             RumorKind::Departure(departure) => {
-                server.insert_departure_mlw_rsw(departure);
+                server.insert_departure_rsw_mlw(departure);
             }
         }
     }

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -87,7 +87,7 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                         let sc = server.clone();
                         let guard = match thread::Builder::new().name(String::from("push-worker"))
                                                                 .spawn(move || {
-                                                                    send_rumors_mlr_rsr(&sc,
+                                                                    send_rumors_rsr_mlr(&sc,
                                                                                         &member,
                                                                                         &rumors)
                                                                 }) {
@@ -128,16 +128,16 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
 /// method can lose messages.
 ///
 /// # Locking
-/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
-///   is held.
 /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock is
 ///   held.
+/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
+///   is held.
 // If we ever need to modify this function, it would be an excellent opportunity to
 // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
 // but changing it in the absence of other necessity seems like too much risk for the
 // expected reward.
 #[allow(clippy::cognitive_complexity)]
-fn send_rumors_mlr_rsr(server: &Server, member: &Member, rumors: &[RumorKey]) {
+fn send_rumors_rsr_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
     let socket = (**ZMQ_CONTEXT).as_mut()
                                 .socket(zmq::PUSH)
                                 .expect("Failure to create the ZMQ push socket");

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -191,9 +191,7 @@ fn send_rumors_mlr_rsr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 //           TraceKind::SendRumor,
                 //           &member.id,
                 //           &send_rumor);
-                match server.service_store
-                            .encode_rsr(&rumor_key.key, &rumor_key.id)
-                {
+                match server.service_store.lock_rsr().encode_rumor_for(&rumor_key) {
                     Ok(bytes) => bytes,
                     Err(e) => {
                         error!("Could not write our own rumor to bytes; abandoning sending \
@@ -212,7 +210,8 @@ fn send_rumors_mlr_rsr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 //           &member.id,
                 //           &send_rumor);
                 match server.service_config_store
-                            .encode_rsr(&rumor_key.key, &rumor_key.id)
+                            .lock_rsr()
+                            .encode_rumor_for(&rumor_key)
                 {
                     Ok(bytes) => bytes,
                     Err(e) => {
@@ -232,7 +231,8 @@ fn send_rumors_mlr_rsr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 //           &member.id,
                 //           &send_rumor);
                 match server.service_file_store
-                            .encode_rsr(&rumor_key.key, &rumor_key.id)
+                            .lock_rsr()
+                            .encode_rumor_for(&rumor_key)
                 {
                     Ok(bytes) => bytes,
                     Err(e) => {
@@ -248,7 +248,8 @@ fn send_rumors_mlr_rsr(server: &Server, member: &Member, rumors: &[RumorKey]) {
             }
             RumorType::Departure => {
                 match server.departure_store
-                            .encode_rsr(&rumor_key.key, &rumor_key.id)
+                            .lock_rsr()
+                            .encode_rumor_for(&rumor_key)
                 {
                     Ok(bytes) => bytes,
                     Err(e) => {
@@ -268,7 +269,8 @@ fn send_rumors_mlr_rsr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 //           &member.id,
                 //           &send_rumor);
                 match server.election_store
-                            .encode_rsr(&rumor_key.key, &rumor_key.id)
+                            .lock_rsr()
+                            .encode_rumor_for(&rumor_key)
                 {
                     Ok(bytes) => bytes,
                     Err(e) => {
@@ -283,9 +285,7 @@ fn send_rumors_mlr_rsr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 }
             }
             RumorType::ElectionUpdate => {
-                match server.update_store
-                            .encode_rsr(&rumor_key.key, &rumor_key.id)
-                {
+                match server.update_store.lock_rsr().encode_rumor_for(&rumor_key) {
                     Ok(bytes) => bytes,
                     Err(e) => {
                         error!("Could not write our own rumor to bytes; abandoning sending \

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -335,10 +335,10 @@ fn send_rumors_rsr_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
 /// # Locking (see locking.md)
 /// * `MemberList::entries` (read)
 fn create_member_rumor_mlr(server: &Server, rumor_key: &RumorKey) -> Option<RumorEnvelope> {
-    let member = server.member_list.get_cloned_mlr(&rumor_key.key())?;
+    let member = server.member_list.get_cloned_mlr(&rumor_key.to_string())?;
     let payload = Membership { member,
                                health: server.member_list
-                                             .health_of_by_id_mlr(&rumor_key.key())
+                                             .health_of_by_id_mlr(&rumor_key.to_string())
                                              .unwrap() };
     let rumor = RumorEnvelope { r#type:  RumorType::Member,
                                 from_id: server.member_id().to_string(),

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -127,11 +127,9 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
 /// connection and socket open for 1 second longer - so it is possible, but unlikely, that this
 /// method can lose messages.
 ///
-/// # Locking
-/// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock is
-///   held.
-/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
-///   is held.
+/// # Locking (see locking.md)
+/// * `RumorStore::list` (read)
+/// * `MemberList::entries` (read)
 // If we ever need to modify this function, it would be an excellent opportunity to
 // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
 // but changing it in the absence of other necessity seems like too much risk for the
@@ -334,9 +332,8 @@ fn send_rumors_rsr_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
 
 /// Given a rumorkey, creates a protobuf rumor for sharing.
 ///
-/// # Locking
-/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
-///   is held.
+/// # Locking (see locking.md)
+/// * `MemberList::entries` (read)
 fn create_member_rumor_mlr(server: &Server, rumor_key: &RumorKey) -> Option<RumorEnvelope> {
     let member = server.member_list.get_cloned_mlr(&rumor_key.key())?;
     let payload = Membership { member,

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -87,8 +87,9 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                         let sc = server.clone();
                         let guard = match thread::Builder::new().name(String::from("push-worker"))
                                                                 .spawn(move || {
-                                                                    send_rumors_mlr(&sc, &member,
-                                                                                    &rumors)
+                                                                    send_rumors_mlr_rsr(&sc,
+                                                                                        &member,
+                                                                                        &rumors)
                                                                 }) {
                             Ok(guard) => guard,
                             Err(e) => {
@@ -129,12 +130,14 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
 /// # Locking
 /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
 ///   is held.
+/// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock is
+///   held.
 // If we ever need to modify this function, it would be an excellent opportunity to
 // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
 // but changing it in the absence of other necessity seems like too much risk for the
 // expected reward.
 #[allow(clippy::cognitive_complexity)]
-fn send_rumors_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
+fn send_rumors_mlr_rsr(server: &Server, member: &Member, rumors: &[RumorKey]) {
     let socket = (**ZMQ_CONTEXT).as_mut()
                                 .socket(zmq::PUSH)
                                 .expect("Failure to create the ZMQ push socket");
@@ -188,7 +191,9 @@ fn send_rumors_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 //           TraceKind::SendRumor,
                 //           &member.id,
                 //           &send_rumor);
-                match server.service_store.encode(&rumor_key.key, &rumor_key.id) {
+                match server.service_store
+                            .encode_rsr(&rumor_key.key, &rumor_key.id)
+                {
                     Ok(bytes) => bytes,
                     Err(e) => {
                         error!("Could not write our own rumor to bytes; abandoning sending \
@@ -207,7 +212,7 @@ fn send_rumors_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 //           &member.id,
                 //           &send_rumor);
                 match server.service_config_store
-                            .encode(&rumor_key.key, &rumor_key.id)
+                            .encode_rsr(&rumor_key.key, &rumor_key.id)
                 {
                     Ok(bytes) => bytes,
                     Err(e) => {
@@ -227,7 +232,7 @@ fn send_rumors_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 //           &member.id,
                 //           &send_rumor);
                 match server.service_file_store
-                            .encode(&rumor_key.key, &rumor_key.id)
+                            .encode_rsr(&rumor_key.key, &rumor_key.id)
                 {
                     Ok(bytes) => bytes,
                     Err(e) => {
@@ -242,7 +247,9 @@ fn send_rumors_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 }
             }
             RumorType::Departure => {
-                match server.departure_store.encode(&rumor_key.key, &rumor_key.id) {
+                match server.departure_store
+                            .encode_rsr(&rumor_key.key, &rumor_key.id)
+                {
                     Ok(bytes) => bytes,
                     Err(e) => {
                         error!("Could not write our own rumor to bytes; abandoning sending \
@@ -260,7 +267,9 @@ fn send_rumors_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 //           TraceKind::SendRumor,
                 //           &member.id,
                 //           &send_rumor);
-                match server.election_store.encode(&rumor_key.key, &rumor_key.id) {
+                match server.election_store
+                            .encode_rsr(&rumor_key.key, &rumor_key.id)
+                {
                     Ok(bytes) => bytes,
                     Err(e) => {
                         error!("Could not write our own rumor to bytes; abandoning sending \
@@ -274,7 +283,9 @@ fn send_rumors_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
                 }
             }
             RumorType::ElectionUpdate => {
-                match server.update_store.encode(&rumor_key.key, &rumor_key.id) {
+                match server.update_store
+                            .encode_rsr(&rumor_key.key, &rumor_key.id)
+                {
                     Ok(bytes) => bytes,
                     Err(e) => {
                         error!("Could not write our own rumor to bytes; abandoning sending \

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -61,7 +61,7 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
                                  Some(String::from(name)),
                                  None,
                                  Box::new(NSuitability(suitability))).unwrap();
-    server.start_mlw_rsr(&Timing::default())
+    server.start_mlw_rsw(&Timing::default())
           .expect("Cannot start server");
     server
 }
@@ -436,7 +436,7 @@ impl SwimNet {
                              sg,
                              SysInfo::default(),
                              None);
-        self[member].insert_service_mlw(s);
+        self[member].insert_service_mlw_rsw(s);
     }
 
     pub fn add_service_config(&mut self, member: usize, service: &str, config: &str) {
@@ -444,7 +444,7 @@ impl SwimNet {
         let s = ServiceConfig::new(self[member].member_id(),
                                    ServiceGroup::new(None, service, "prod", None).unwrap(),
                                    config_bytes);
-        self[member].insert_service_config(s);
+        self[member].insert_service_config_rsw(s);
     }
 
     pub fn add_service_file(&mut self, member: usize, service: &str, filename: &str, body: &str) {
@@ -453,16 +453,16 @@ impl SwimNet {
                                  ServiceGroup::new(None, service, "prod", None).unwrap(),
                                  filename,
                                  body_bytes);
-        self[member].insert_service_file(s);
+        self[member].insert_service_file_rsw(s);
     }
 
     pub fn add_departure(&mut self, member: usize) {
         let d = Departure::new(self[member].member_id());
-        self[member].insert_departure_mlw(d);
+        self[member].insert_departure_mlw_rsw(d);
     }
 
     pub fn add_election(&mut self, member: usize, service: &str) {
-        self[member].start_election_mlr(&ServiceGroup::new(None, service, "prod", None).unwrap(),
+        self[member].start_election_mlr_rsw(&ServiceGroup::new(None, service, "prod", None).unwrap(),
                                         0);
     }
 }

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -61,7 +61,7 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
                                  Some(String::from(name)),
                                  None,
                                  Box::new(NSuitability(suitability))).unwrap();
-    server.start_mlw(&Timing::default())
+    server.start_mlw_rsr(&Timing::default())
           .expect("Cannot start server");
     server
 }

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -61,7 +61,7 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
                                  Some(String::from(name)),
                                  None,
                                  Box::new(NSuitability(suitability))).unwrap();
-    server.start_mlw_rsw(&Timing::default())
+    server.start_rsw_mlw(&Timing::default())
           .expect("Cannot start server");
     server
 }
@@ -437,7 +437,7 @@ impl SwimNet {
                              sg,
                              SysInfo::default(),
                              None);
-        self[member].insert_service_mlw_rsw(s);
+        self[member].insert_service_rsw_mlw(s);
     }
 
     pub fn add_service_config(&mut self, member: usize, service: &str, config: &str) {
@@ -459,11 +459,11 @@ impl SwimNet {
 
     pub fn add_departure(&mut self, member: usize) {
         let d = Departure::new(self[member].member_id());
-        self[member].insert_departure_mlw_rsw(d);
+        self[member].insert_departure_rsw_mlw(d);
     }
 
     pub fn add_election(&mut self, member: usize, service: &str) {
-        self[member].start_election_mlr_rsw(&ServiceGroup::new(None, service, "prod", None).unwrap(),
+        self[member].start_election_rsw_mlr(&ServiceGroup::new(None, service, "prod", None).unwrap(),
                                         0);
     }
 }

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -6,7 +6,9 @@ use habitat_butterfly::{error::Error,
                                 service::{Service,
                                           SysInfo},
                                 service_config::ServiceConfig,
-                                service_file::ServiceFile},
+                                service_file::ServiceFile,
+                                ConstIdRumor as _,
+                                Election},
                         server::{timing::Timing,
                                  Server,
                                  Suitability},
@@ -284,7 +286,7 @@ impl SwimNet {
             let result = server.election_store
                                .lock_rsr()
                                .service_group(key)
-                               .map_rumor("election", |stored| stored.status == status)
+                               .map_rumor(Election::const_id(), |stored| stored.status == status)
                                .unwrap_or(false);
             if result {
                 return true;
@@ -312,9 +314,9 @@ impl SwimNet {
                                    .lock_rsr();
 
             let result = left_server.service_group(key)
-                                    .map_rumor("election", |l| {
+                                    .map_rumor(Election::const_id(), |l| {
                                         right_server.service_group(key)
-                                                    .map_rumor("election", |r| l == r)
+                                                    .map_rumor(Election::const_id(), |r| l == r)
                                                     .unwrap_or(false)
                                     })
                                     .unwrap_or(false);

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -166,9 +166,8 @@ impl SwimNet {
         from.remove_from_block_list(to.member_id());
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn health_of_mlr(&self, from_entry: usize, to_entry: usize) -> Option<Health> {
         /// To avoid deadlocking in a test, we use `health_of_by_id_with_timeout` rather than
         /// `health_of_by_id`.
@@ -198,9 +197,8 @@ impl SwimNet {
         }
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn network_health_of_mlr(&self, to_check: usize) -> Vec<Option<Health>> {
         let mut health_summary = Vec::with_capacity(self.members.len() - 1);
         let length = self.members.len();
@@ -359,9 +357,8 @@ impl SwimNet {
         }
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn wait_for_health_of_mlr(&self,
                                   from_entry: usize,
                                   to_check: usize,
@@ -385,9 +382,8 @@ impl SwimNet {
         }
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
     pub fn wait_for_network_health_of_mlr(&self, to_check: usize, health: Health) -> bool {
         let rounds_in = self.rounds_in(self.max_rounds());
         loop {

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -13,5 +13,7 @@ fn symmetric_encryption_of_wire_payloads() {
     net.add_service(0, "core/beast/1.2.3/20161208121212");
     net.wait_for_gossip_rounds(2);
     assert!(net[1].service_store
-                  .contains_rumor("beast.prod", net[0].member_id()));
+                  .lock_rsr()
+                  .service_group("beast.prod",)
+                  .contains_rumor(net[0].member_id()));
 }

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -14,6 +14,6 @@ fn symmetric_encryption_of_wire_payloads() {
     net.wait_for_gossip_rounds(2);
     assert!(net[1].service_store
                   .lock_rsr()
-                  .service_group("beast.prod",)
+                  .service_group("beast.prod")
                   .contains_id(net[0].member_id()));
 }

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -15,5 +15,5 @@ fn symmetric_encryption_of_wire_payloads() {
     assert!(net[1].service_store
                   .lock_rsr()
                   .service_group("beast.prod",)
-                  .contains_rumor(net[0].member_id()));
+                  .contains_id(net[0].member_id()));
 }

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -9,7 +9,9 @@ fn two_members_share_departures() {
     net.add_departure(0);
     net.wait_for_gossip_rounds(1);
     assert!(net[1].departure_store
-                  .contains_rumor("departure", net[0].member_id()));
+                  .lock_rsr()
+                  .service_group("departure",)
+                  .contains_rumor(net[0].member_id()));
 }
 
 #[test]
@@ -26,6 +28,8 @@ fn departure_via_client() {
           .expect("Cannot send the departure");
     net.wait_for_gossip_rounds(1);
     assert!(net[2].departure_store
-                  .contains_rumor("departure", net[1].member_id()));
+                  .lock_rsr()
+                  .service_group("departure",)
+                  .contains_rumor(net[1].member_id()));
     assert_wait_for_health_of_mlr!(net, 1, Health::Departed);
 }

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -10,7 +10,6 @@ fn two_members_share_departures() {
     net.wait_for_gossip_rounds(1);
     assert!(net[1].departure_store
                   .lock_rsr()
-                  .service_group("departure",)
                   .contains_id(net[0].member_id()));
 }
 
@@ -29,7 +28,6 @@ fn departure_via_client() {
     net.wait_for_gossip_rounds(1);
     assert!(net[2].departure_store
                   .lock_rsr()
-                  .service_group("departure",)
                   .contains_id(net[1].member_id()));
     assert_wait_for_health_of_mlr!(net, 1, Health::Departed);
 }

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -11,7 +11,7 @@ fn two_members_share_departures() {
     assert!(net[1].departure_store
                   .lock_rsr()
                   .service_group("departure",)
-                  .contains_rumor(net[0].member_id()));
+                  .contains_id(net[0].member_id()));
 }
 
 #[test]
@@ -30,6 +30,6 @@ fn departure_via_client() {
     assert!(net[2].departure_store
                   .lock_rsr()
                   .service_group("departure",)
-                  .contains_rumor(net[1].member_id()));
+                  .contains_id(net[1].member_id()));
     assert_wait_for_health_of_mlr!(net, 1, Health::Departed);
 }

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -63,9 +63,9 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let paused_id = net[paused].member_id();
     assert_wait_for_health_of_mlr!(net, paused, Health::Confirmed);
     if paused == 0 {
-        net[1].restart_elections_mlr_rsw(FeatureFlag::empty());
+        net[1].restart_elections_rsw_mlr(FeatureFlag::empty());
     } else {
-        net[0].restart_elections_mlr_rsw(FeatureFlag::empty());
+        net[0].restart_elections_rsw_mlr(FeatureFlag::empty());
     }
 
     for i in 0..5 {
@@ -135,8 +135,8 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let new_leader_id;
     net.partition(0..2, 2..5);
     assert_wait_for_health_of_mlr!(net, [0..2, 2..5], Health::Confirmed);
-    net[0].restart_elections_mlr_rsw(FeatureFlag::empty());
-    net[4].restart_elections_mlr_rsw(FeatureFlag::empty());
+    net[0].restart_elections_rsw_mlr(FeatureFlag::empty());
+    net[4].restart_elections_rsw_mlr(FeatureFlag::empty());
     assert_wait_for_election_status!(net, 0, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 1, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 2, "witcher.prod", ElectionStatus::Finished);

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -1,5 +1,7 @@
 use habitat_butterfly::{member::Health,
-                        rumor::election::ElectionStatus};
+                        rumor::{election::ElectionStatus,
+                                ConstIdRumor as _,
+                                Election}};
 use habitat_common::FeatureFlag;
 
 use crate::btest;
@@ -49,7 +51,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let leader_id = net[0].election_store
                           .lock_rsr()
                           .service_group("witcher.prod")
-                          .map_rumor("election", |e| e.member_id.clone());
+                          .map_rumor(Election::const_id(), |e| e.member_id.clone());
 
     let mut paused = 0;
     for (index, server) in net.iter_mut().enumerate() {
@@ -83,7 +85,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     net[if paused == 0 { 1 } else { 0 }].election_store
                                         .lock_rsr()
                                         .service_group("witcher.prod")
-                                        .map_rumor("election", |e| {
+                                        .map_rumor(Election::const_id(), |e| {
                                             assert_eq!(e.term, 1);
                                             assert_ne!(e.member_id, paused_id);
                                         });
@@ -118,7 +120,7 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let leader_id = net[0].election_store
                           .lock_rsr()
                           .service_group("witcher.prod")
-                          .map_rumor("election", |e| e.member_id.clone());
+                          .map_rumor(Election::const_id(), |e| e.member_id.clone());
 
     assert_eq!(leader_id, Some(net[0].member_id().to_string()));
 
@@ -145,13 +147,13 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     net[0].election_store
           .lock_rsr()
           .service_group("witcher.prod")
-          .map_rumor("election", |e| {
+          .map_rumor(Election::const_id(), |e| {
               println!("OLD: {:#?}", e);
           });
     new_leader_id = net[2].election_store
                           .lock_rsr()
                           .service_group("witcher.prod")
-                          .map_rumor("election", |e| {
+                          .map_rumor(Election::const_id(), |e| {
                               println!("NEW: {:#?}", e);
                               e.member_id.clone()
                           });
@@ -166,12 +168,12 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     net[4].election_store
           .lock_rsr()
           .service_group("witcher.prod")
-          .map_rumor("election", |e| println!("MAJORITY: {:#?}", e));
+          .map_rumor(Election::const_id(), |e| println!("MAJORITY: {:#?}", e));
 
     net[0].election_store
           .lock_rsr()
           .service_group("witcher.prod")
-          .map_rumor("election", |e| {
+          .map_rumor(Election::const_id(), |e| {
               println!("MINORITY: {:#?}", e);
               assert_eq!(new_leader_id.as_ref(), Some(&e.member_id));
           });

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -62,9 +62,9 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let paused_id = net[paused].member_id();
     assert_wait_for_health_of_mlr!(net, paused, Health::Confirmed);
     if paused == 0 {
-        net[1].restart_elections_mlr(FeatureFlag::empty());
+        net[1].restart_elections_mlr_rsw(FeatureFlag::empty());
     } else {
-        net[0].restart_elections_mlr(FeatureFlag::empty());
+        net[0].restart_elections_mlr_rsw(FeatureFlag::empty());
     }
 
     for i in 0..5 {
@@ -130,8 +130,8 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut new_leader_id = String::from("");
     net.partition(0..2, 2..5);
     assert_wait_for_health_of_mlr!(net, [0..2, 2..5], Health::Confirmed);
-    net[0].restart_elections_mlr(FeatureFlag::empty());
-    net[4].restart_elections_mlr(FeatureFlag::empty());
+    net[0].restart_elections_mlr_rsw(FeatureFlag::empty());
+    net[4].restart_elections_mlr_rsw(FeatureFlag::empty());
     assert_wait_for_election_status!(net, 0, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 1, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 2, "witcher.prod", ElectionStatus::Finished);

--- a/components/butterfly/tests/rumor/service.rs
+++ b/components/butterfly/tests/rumor/service.rs
@@ -7,5 +7,7 @@ fn two_members_share_services() {
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.wait_for_rounds(2);
     assert!(net[1].service_store
-                  .contains_rumor("witcher.prod", net[0].member_id()));
+                  .lock_rsr()
+                  .service_group("witcher.prod")
+                  .contains_rumor(net[0].member_id()));
 }

--- a/components/butterfly/tests/rumor/service.rs
+++ b/components/butterfly/tests/rumor/service.rs
@@ -9,5 +9,5 @@ fn two_members_share_services() {
     assert!(net[1].service_store
                   .lock_rsr()
                   .service_group("witcher.prod")
-                  .contains_rumor(net[0].member_id()));
+                  .contains_id(net[0].member_id()));
 }

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -11,7 +11,7 @@ fn two_members_share_service_config() {
     assert!(net[1].service_config_store
                   .lock_rsr()
                   .service_group("witcher.prod")
-                  .contains_rumor("service_config"));
+                  .contains_id("service_config"));
 }
 
 #[test]
@@ -33,5 +33,5 @@ fn service_config_via_client() {
     assert!(net[1].service_config_store
                   .lock_rsr()
                   .service_group("witcher.prod")
-                  .contains_rumor("service_config"));
+                  .contains_id("service_config"));
 }

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -1,5 +1,7 @@
 use crate::btest;
-use habitat_butterfly::client::Client;
+use habitat_butterfly::{client::Client,
+                        rumor::{ConstIdRumor as _,
+                                ServiceConfig}};
 use habitat_core::service::ServiceGroup;
 
 #[test]
@@ -11,7 +13,7 @@ fn two_members_share_service_config() {
     assert!(net[1].service_config_store
                   .lock_rsr()
                   .service_group("witcher.prod")
-                  .contains_id("service_config"));
+                  .contains_id(ServiceConfig::const_id()));
 }
 
 #[test]
@@ -33,5 +35,5 @@ fn service_config_via_client() {
     assert!(net[1].service_config_store
                   .lock_rsr()
                   .service_group("witcher.prod")
-                  .contains_id("service_config"));
+                  .contains_id(ServiceConfig::const_id()));
 }

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -9,7 +9,9 @@ fn two_members_share_service_config() {
     net.add_service_config(0, "witcher", "tcp-backlog = 128");
     net.wait_for_gossip_rounds(1);
     assert!(net[1].service_config_store
-                  .contains_rumor("witcher.prod", "service_config"));
+                  .lock_rsr()
+                  .service_group("witcher.prod")
+                  .contains_rumor("service_config"));
 }
 
 #[test]
@@ -29,5 +31,7 @@ fn service_config_via_client() {
           .expect("Cannot send the service configuration");
     net.wait_for_gossip_rounds(1);
     assert!(net[1].service_config_store
-                  .contains_rumor("witcher.prod", "service_config"));
+                  .lock_rsr()
+                  .service_group("witcher.prod")
+                  .contains_rumor("service_config"));
 }

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -12,7 +12,9 @@ fn two_members_share_service_files() {
                          "I like to have contents in my file");
     net.wait_for_gossip_rounds(1);
     assert!(net[1].service_file_store
-                  .contains_rumor("witcher.prod", "yeppers"));
+                  .lock_rsr()
+                  .service_group("witcher.prod")
+                  .contains_rumor("yeppers"));
 }
 
 #[test]
@@ -33,5 +35,7 @@ fn service_file_via_client() {
           .expect("Cannot send the service file");
     net.wait_for_gossip_rounds(1);
     assert!(net[1].service_file_store
-                  .contains_rumor("witcher.prod", "devil-wears-prada.txt"));
+                  .lock_rsr()
+                  .service_group("witcher.prod")
+                  .contains_rumor("devil-wears-prada.txt"));
 }

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -14,7 +14,7 @@ fn two_members_share_service_files() {
     assert!(net[1].service_file_store
                   .lock_rsr()
                   .service_group("witcher.prod")
-                  .contains_rumor("yeppers"));
+                  .contains_id("yeppers"));
 }
 
 #[test]
@@ -37,5 +37,5 @@ fn service_file_via_client() {
     assert!(net[1].service_file_store
                   .lock_rsr()
                   .service_group("witcher.prod")
-                  .contains_rumor("devil-wears-prada.txt"));
+                  .contains_id("devil-wears-prada.txt"));
 }

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -203,12 +203,12 @@ pub mod sync {
     /// internally use either a RwLock or a Mutex in order to make it easier to expose erroneous
     /// recursive locking in tests while still using an RwLock in production to avoid deadlocking
     /// as much as possible.
-    #[derive(Debug)]
-    pub struct Lock<T> {
+    #[derive(Debug, Default)]
+    pub struct Lock<T: Default> {
         inner: InnerLock<T>,
     }
 
-    impl<T> Lock<T> {
+    impl<T: Default> Lock<T> {
         pub fn new(val: T) -> Self {
             #[cfg(feature = "lock_as_mutex")]
             println!("Lock::new is using Mutex to help find recursive locking");

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -65,12 +65,12 @@ impl CensusRing {
     }
 
     /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
     #[allow(clippy::too_many_arguments)]
-    pub fn update_from_rumors_mlr_rsr(&mut self,
+    pub fn update_from_rumors_rsr_mlr(&mut self,
                                       cache_key_path: &Path,
                                       service_rumors: &RumorStore<ServiceRumor>,
                                       election_rumors: &RumorStore<ElectionRumor>,
@@ -89,7 +89,7 @@ impl CensusRing {
         {
             self.changed = true;
 
-            self.populate_census_mlr_rsr(service_rumors, member_list);
+            self.populate_census_rsr_mlr(service_rumors, member_list);
             self.update_from_election_store_rsr(election_rumors);
             self.update_from_election_update_store_rsr(election_update_rumors);
             self.update_from_service_config_rsr(cache_key_path, service_config_rumors);
@@ -120,11 +120,11 @@ impl CensusRing {
     /// rest).
     ///
     /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
     ///   is held.
-    fn populate_census_mlr_rsr(&mut self,
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn populate_census_rsr_mlr(&mut self,
                                service_rumors: &RumorStore<ServiceRumor>,
                                member_list: &MemberList) {
         // Populate our census; new groups are created here, as are
@@ -845,7 +845,7 @@ mod tests {
         let service_config_store: RumorStore<ServiceConfigRumor> = RumorStore::default();
         let service_file_store: RumorStore<ServiceFileRumor> = RumorStore::default();
         let mut ring = CensusRing::new("member-b".to_string());
-        ring.update_from_rumors_mlr_rsr(&cache_key_path(Some(&*FS_ROOT)),
+        ring.update_from_rumors_rsr_mlr(&cache_key_path(Some(&*FS_ROOT)),
                                         &service_store,
                                         &election_store,
                                         &election_update_store,

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -64,11 +64,9 @@ impl CensusRing {
                      last_service_file_counter: 0, }
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (read)
     #[allow(clippy::too_many_arguments)]
     pub fn update_from_rumors_rsr_mlr(&mut self,
                                       cache_key_path: &Path,
@@ -119,11 +117,9 @@ impl CensusRing {
     /// (Butterfly provides the health, the ServiceRumors provide the
     /// rest).
     ///
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
+    /// * `MemberList::entries` (read)
     fn populate_census_rsr_mlr(&mut self,
                                service_rumors: &RumorStore<ServiceRumor>,
                                member_list: &MemberList) {
@@ -159,9 +155,8 @@ impl CensusRing {
                    .ok();
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
     fn update_from_election_store_rsr(&mut self, election_rumors: &RumorStore<ElectionRumor>) {
         for (service_group, rumors) in election_rumors.lock_rsr().iter() {
             let election = rumors.get("election").unwrap();
@@ -173,9 +168,8 @@ impl CensusRing {
         }
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
     fn update_from_election_update_store_rsr(&mut self,
                                              election_update_rumors: &RumorStore<ElectionUpdateRumor>)
     {
@@ -189,9 +183,8 @@ impl CensusRing {
         }
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
     fn update_from_service_config_rsr(&mut self,
                                       cache_key_path: &Path,
                                       service_config_rumors: &RumorStore<ServiceConfigRumor>) {
@@ -207,9 +200,8 @@ impl CensusRing {
         }
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
     fn update_from_service_files_rsr(&mut self,
                                      cache_key_path: &Path,
                                      service_file_rumors: &RumorStore<ServiceFileRumor>) {

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -10,6 +10,7 @@ use habitat_butterfly::{member::{Health,
                                           SysInfo},
                                 service_config::ServiceConfig as ServiceConfigRumor,
                                 service_file::ServiceFile as ServiceFileRumor,
+                                ConstIdRumor as _,
                                 RumorStore}};
 use habitat_common::outputln;
 use habitat_core::{self,
@@ -159,7 +160,7 @@ impl CensusRing {
     /// * `RumorStore::list` (read)
     fn update_from_election_store_rsr(&mut self, election_rumors: &RumorStore<ElectionRumor>) {
         for (service_group, rumors) in election_rumors.lock_rsr().iter() {
-            let election = rumors.get("election").unwrap();
+            let election = rumors.get(ElectionRumor::const_id()).unwrap();
             if let Ok(sg) = service_group_from_str(service_group) {
                 if let Some(census_group) = self.census_groups.get_mut(&sg) {
                     census_group.update_from_election_rumor(election);
@@ -176,7 +177,7 @@ impl CensusRing {
         for (service_group, rumors) in election_update_rumors.lock_rsr().iter() {
             if let Ok(sg) = service_group_from_str(service_group) {
                 if let Some(census_group) = self.census_groups.get_mut(&sg) {
-                    let election = rumors.get("election").unwrap();
+                    let election = rumors.get(ElectionUpdateRumor::const_id()).unwrap();
                     census_group.update_from_election_update_rumor(election);
                 }
             }
@@ -190,7 +191,7 @@ impl CensusRing {
                                       service_config_rumors: &RumorStore<ServiceConfigRumor>) {
         for (service_group, rumors) in service_config_rumors.lock_rsr().iter() {
             if let Ok(sg) = service_group_from_str(service_group) {
-                if let Some(service_config) = rumors.get("service_config") {
+                if let Some(service_config) = rumors.get(ServiceConfigRumor::const_id()) {
                     if let Some(census_group) = self.census_groups.get_mut(&sg) {
                         census_group.update_from_service_config_rumor(cache_key_path,
                                                                       service_config);

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -805,9 +805,9 @@ mod tests {
                                               sys_info.clone(),
                                               None);
 
-        service_store.insert(service_one);
-        service_store.insert(service_two);
-        service_store.insert(service_three);
+        service_store.insert_rsw(service_one);
+        service_store.insert_rsw(service_two);
+        service_store.insert_rsw(service_three);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
         let mut election = ElectionRumor::new("member-a",
@@ -816,7 +816,7 @@ mod tests {
                                               10,
                                               true /* has_quorum */);
         election.finish();
-        election_store.insert(election);
+        election_store.insert_rsw(election);
 
         let election_update_store: RumorStore<ElectionUpdateRumor> = RumorStore::default();
         let mut election_update = ElectionUpdateRumor::new("member-b",
@@ -825,7 +825,7 @@ mod tests {
                                                            10,
                                                            true /* has_quorum */);
         election_update.finish();
-        election_update_store.insert(election_update);
+        election_update_store.insert_rsw(election_update);
 
         let member_list = MemberList::new();
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -204,7 +204,7 @@ fn sub_run_mlw_imlw_rsr(m: &ArgMatches,
     } else {
         None
     };
-    manager.run_mlw_imlw_rsr(svc)
+    manager.run_mlw_imlw_rsw(svc)
 }
 
 fn sub_sh() -> Result<()> { command::shell::sh() }

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
     logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
-    let result = start_mlr(flags);
+    let result = start_mlw_imlw_rsr(flags);
     let exit_code = match result {
         Ok(_) => 0,
         Err(ref err) => {
@@ -111,9 +111,13 @@ fn boot() -> Option<LauncherCli> {
 }
 
 /// # Locking
-/// * `MemberList::entries` (read) This method must not be called while any MemberList::entries lock
-///   is held.
-fn start_mlr(feature_flags: FeatureFlag) -> Result<()> {
+/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+///   lock is held.
+/// * `MemberList::intitial_entries` (write) This method must not be called while any
+///   MemberList::intitial_entries lock is held.
+/// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock is
+///   held.
+fn start_mlw_imlw_rsr(feature_flags: FeatureFlag) -> Result<()> {
     if feature_flags.contains(FeatureFlag::TEST_BOOT_FAIL) {
         outputln!("Simulating boot failure");
         return Err(Error::TestBootFail);
@@ -143,7 +147,7 @@ fn start_mlr(feature_flags: FeatureFlag) -> Result<()> {
         ("bash", Some(_)) => sub_bash(),
         ("run", Some(m)) => {
             let launcher = launcher.ok_or(Error::NoLauncher)?;
-            sub_run_mlw_imlw(m, launcher, feature_flags)
+            sub_run_mlw_imlw_rsr(m, launcher, feature_flags)
         }
         ("sh", Some(_)) => sub_sh(),
         ("term", Some(_)) => sub_term(),
@@ -158,10 +162,12 @@ fn sub_bash() -> Result<()> { command::shell::bash() }
 ///   lock is held.
 /// * `MemberList::intitial_entries` (write) This method must not be called while any
 ///   MemberList::intitial_entries lock is held.
-fn sub_run_mlw_imlw(m: &ArgMatches,
-                    launcher: LauncherCli,
-                    feature_flags: FeatureFlag)
-                    -> Result<()> {
+/// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock is
+///   held.
+fn sub_run_mlw_imlw_rsr(m: &ArgMatches,
+                        launcher: LauncherCli,
+                        feature_flags: FeatureFlag)
+                        -> Result<()> {
     set_supervisor_logging_options(m);
 
     let cfg = mgrcfg_from_sup_run_matches(m, feature_flags)?;
@@ -198,7 +204,7 @@ fn sub_run_mlw_imlw(m: &ArgMatches,
     } else {
         None
     };
-    manager.run_mlw_imlw(svc)
+    manager.run_mlw_imlw_rsr(svc)
 }
 
 fn sub_sh() -> Result<()> { command::shell::sh() }

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -110,13 +110,10 @@ fn boot() -> Option<LauncherCli> {
     }
 }
 
-/// # Locking
-/// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock is
-///   held.
-/// * `MemberList::intitial_entries` (write) This method must not be called while any
-///   MemberList::intitial_entries lock is held.
-/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-///   lock is held.
+/// # Locking (see locking.md)
+/// * `RumorStore::list` (read)
+/// * `MemberList::initial_members` (write)
+/// * `MemberList::entries` (write)
 fn start_rsr_imlw_mlw(feature_flags: FeatureFlag) -> Result<()> {
     if feature_flags.contains(FeatureFlag::TEST_BOOT_FAIL) {
         outputln!("Simulating boot failure");
@@ -157,13 +154,10 @@ fn start_rsr_imlw_mlw(feature_flags: FeatureFlag) -> Result<()> {
 
 fn sub_bash() -> Result<()> { command::shell::bash() }
 
-/// # Locking
-/// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock is
-///   held.
-/// * `MemberList::intitial_entries` (write) This method must not be called while any
-///   MemberList::intitial_entries lock is held.
-/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-///   lock is held.
+/// # Locking (see locking.md)
+/// * `RumorStore::list` (read)
+/// * `MemberList::initial_members` (write)
+/// * `MemberList::entries` (write)
 fn sub_run_rsr_imlw_mlw(m: &ArgMatches,
                         launcher: LauncherCli,
                         feature_flags: FeatureFlag)

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
     logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
-    let result = start_mlw_imlw_rsr(flags);
+    let result = start_rsr_imlw_mlw(flags);
     let exit_code = match result {
         Ok(_) => 0,
         Err(ref err) => {
@@ -111,13 +111,13 @@ fn boot() -> Option<LauncherCli> {
 }
 
 /// # Locking
-/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-///   lock is held.
-/// * `MemberList::intitial_entries` (write) This method must not be called while any
-///   MemberList::intitial_entries lock is held.
 /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock is
 ///   held.
-fn start_mlw_imlw_rsr(feature_flags: FeatureFlag) -> Result<()> {
+/// * `MemberList::intitial_entries` (write) This method must not be called while any
+///   MemberList::intitial_entries lock is held.
+/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+///   lock is held.
+fn start_rsr_imlw_mlw(feature_flags: FeatureFlag) -> Result<()> {
     if feature_flags.contains(FeatureFlag::TEST_BOOT_FAIL) {
         outputln!("Simulating boot failure");
         return Err(Error::TestBootFail);
@@ -147,7 +147,7 @@ fn start_mlw_imlw_rsr(feature_flags: FeatureFlag) -> Result<()> {
         ("bash", Some(_)) => sub_bash(),
         ("run", Some(m)) => {
             let launcher = launcher.ok_or(Error::NoLauncher)?;
-            sub_run_mlw_imlw_rsr(m, launcher, feature_flags)
+            sub_run_rsr_imlw_mlw(m, launcher, feature_flags)
         }
         ("sh", Some(_)) => sub_sh(),
         ("term", Some(_)) => sub_term(),
@@ -158,13 +158,13 @@ fn start_mlw_imlw_rsr(feature_flags: FeatureFlag) -> Result<()> {
 fn sub_bash() -> Result<()> { command::shell::bash() }
 
 /// # Locking
-/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-///   lock is held.
-/// * `MemberList::intitial_entries` (write) This method must not be called while any
-///   MemberList::intitial_entries lock is held.
 /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock is
 ///   held.
-fn sub_run_mlw_imlw_rsr(m: &ArgMatches,
+/// * `MemberList::intitial_entries` (write) This method must not be called while any
+///   MemberList::intitial_entries lock is held.
+/// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+///   lock is held.
+fn sub_run_rsr_imlw_mlw(m: &ArgMatches,
                         launcher: LauncherCli,
                         feature_flags: FeatureFlag)
                         -> Result<()> {
@@ -204,7 +204,7 @@ fn sub_run_mlw_imlw_rsr(m: &ArgMatches,
     } else {
         None
     };
-    manager.run_mlw_imlw_rsw(svc)
+    manager.run_rsw_imlw_mlw(svc)
 }
 
 fn sub_sh() -> Result<()> { command::shell::sh() }

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1202,9 +1202,9 @@ impl Manager {
     fn gossip_latest_service_rumor_mlw_rsw(&self, service: &Service) {
         let incarnation = self.butterfly
                               .service_store
-                              .map_rumor_rsr(&service.service_group, &self.sys.member_id, |rumor| {
-                                  rumor.incarnation + 1
-                              })
+                              .lock_rsr()
+                              .service_group(&service.service_group)
+                              .map_rumor(&self.sys.member_id, |rumor| rumor.incarnation + 1)
                               .unwrap_or(1);
 
         self.butterfly

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -425,9 +425,8 @@ impl Manager {
     /// The returned Manager will be pre-populated with any cached data from disk from a previous
     /// run if available.
     ///
-    /// # Locking
-    /// * `MemberList::intitial_entries` (write) This method must not be called while any
-    ///   MemberList::intitial_entries lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::initial_members` (write)
     pub fn load_imlw(cfg: ManagerConfig, launcher: LauncherCli) -> Result<Manager> {
         let state_path = cfg.sup_root();
         let fs_cfg = FsCfg::new(state_path);
@@ -457,9 +456,8 @@ impl Manager {
         }
     }
 
-    /// # Locking
-    /// * `MemberList::intitial_entries` (write) This method must not be called while any
-    ///   MemberList::intitial_entries lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::initial_members` (write)
     fn new_imlw(cfg: ManagerConfig, fs_cfg: FsCfg, launcher: LauncherCli) -> Result<Manager> {
         debug!("new(cfg: {:?}, fs_cfg: {:?}", cfg, fs_cfg);
         let current = PackageIdent::from_str(&format!("{}/{}", SUP_PKG_IDENT, VERSION)).unwrap();
@@ -633,11 +631,9 @@ impl Manager {
         Ok(())
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (write)
     fn add_service_rsw_mlw(&mut self, spec: &ServiceSpec) {
         // JW TODO: This clone sucks, but our data structures are a bit messy here. What we really
         // want is the service to hold the spec and, on failure, return an error with the spec
@@ -719,13 +715,10 @@ impl Manager {
     // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::intitial_entries` (write) This method must not be called while any
-    ///   MemberList::intitial_entries lock is held.
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::initial_members` (write)
+    /// * `MemberList::entries` (write)
     #[allow(clippy::cognitive_complexity)]
     pub fn run_rsw_imlw_mlw(mut self,
                             svc: Option<habitat_sup_protocol::ctl::SvcLoad>)
@@ -1130,11 +1123,9 @@ impl Manager {
     /// Builder. These are removed from the internal `services` vec
     /// for further transformation into futures.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (read)
     #[rustfmt::skip]
     fn take_services_with_updates_rsw_mlr(&mut self) -> Vec<Service> {
         let mut updater = self.updater.lock().expect("Updater lock poisoned");
@@ -1172,11 +1163,9 @@ impl Manager {
     /// Returns a Vec of futures for shutting down those services that
     /// need to be updated.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (read)
     // TODO (CM): In the future, when service start up is
     // future-based, we'll want to have an actual "restart"
     // future, that queues up the start future after the stop
@@ -1194,11 +1183,9 @@ impl Manager {
     }
 
     // Creates a rumor for the specified service.
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (write)
     fn gossip_latest_service_rumor_rsw_mlw(&self, service: &Service) {
         let incarnation = self.butterfly
                               .service_store
@@ -1242,11 +1229,9 @@ impl Manager {
         }
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
+    /// * `MemberList::entries` (read)
     fn persist_state_rsr_mlr(&self) {
         debug!("Updating census state");
         self.persist_census_state();
@@ -1266,11 +1251,9 @@ impl Manager {
             .census_data = json;
     }
 
-    /// # Locking
-    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (read)
+    /// * `MemberList::entries` (read)
     fn persist_butterfly_state_rsr_mlr(&self) {
         let bs = ServerProxy::new(&self.butterfly);
         let json = serde_json::to_string(&bs).unwrap();
@@ -1332,11 +1315,9 @@ impl Manager {
 
     /// Check if any elections need restarting.
     ///
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
+    /// * `RumorStore::list` (write)
     fn restart_elections_rsw_mlr(&mut self, feature_flags: FeatureFlag) {
         self.butterfly.restart_elections_rsw_mlr(feature_flags);
     }
@@ -1444,11 +1425,9 @@ impl Manager {
     /// operations will be performed directly as a consequence of
     /// calling this method.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (write)
     fn maybe_spawn_service_futures_rsw_mlw(&mut self, runtime: &mut Runtime) {
         let ops = self.compute_service_operations();
         for f in self.operations_into_futures_rsw_mlw(ops) {
@@ -1473,11 +1452,9 @@ impl Manager {
     /// operations; starts are performed synchronously, while
     /// shutdowns and restarts are turned into futures.
     ///
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (write)
     fn operations_into_futures_rsw_mlw<O>(&mut self,
                                           ops: O)
                                           -> Vec<impl Future<Item = (), Error = ()>>
@@ -1625,11 +1602,9 @@ impl Manager {
                   .collect()
     }
 
-    /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
-    /// * `MemberList::intitial_entries` (write) This method must not be called while any
-    ///   MemberList::intitial_entries lock is held.
+    /// # Locking (see locking.md)
+    /// * `MemberList::entries` (read)
+    /// * `MemberList::initial_members` (write)
     fn update_peers_from_watch_file_mlr_imlw(&mut self) -> Result<()> {
         if !self.butterfly.need_peer_seeding_mlr() {
             return Ok(());

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -721,8 +721,12 @@ impl Manager {
     ///   lock is held.
     /// * `MemberList::intitial_entries` (write) This method must not be called while any
     ///   MemberList::intitial_entries lock is held.
+    /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
+    ///   is held.
     #[allow(clippy::cognitive_complexity)]
-    pub fn run_mlw_imlw(mut self, svc: Option<habitat_sup_protocol::ctl::SvcLoad>) -> Result<()> {
+    pub fn run_mlw_imlw_rsr(mut self,
+                            svc: Option<habitat_sup_protocol::ctl::SvcLoad>)
+                            -> Result<()> {
         let main_hist = RUN_LOOP_DURATION.with_label_values(&["sup"]);
         let service_hist = RUN_LOOP_DURATION.with_label_values(&["service"]);
         let mut next_cpu_measurement = SteadyTime::now();
@@ -763,7 +767,7 @@ impl Manager {
 
         outputln!("Starting gossip-listener on {}",
                   self.butterfly.gossip_addr());
-        self.butterfly.start_mlw(&Timing::default())?;
+        self.butterfly.start_mlw_rsr(&Timing::default())?;
         debug!("gossip-listener started");
         self.persist_state_mlr();
         let http_listen_addr = self.sys.http_listen();
@@ -1104,7 +1108,7 @@ impl Manager {
                .expect("Error waiting on Tokio runtime to shutdown");
 
         release_process_lock(&self.fs_cfg);
-        self.butterfly.persist_data_mlr();
+        self.butterfly.persist_data_mlr_rsr();
 
         match shutdown_mode {
             ShutdownMode::Normal | ShutdownMode::Restarting => Ok(()),

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1014,13 +1014,13 @@ impl Manager {
 
             self.restart_elections_mlr_rsw(self.feature_flags);
             self.census_ring
-                .update_from_rumors_mlr(&self.state.cfg.cache_key_path,
-                                        &self.butterfly.service_store,
-                                        &self.butterfly.election_store,
-                                        &self.butterfly.update_store,
-                                        &self.butterfly.member_list,
-                                        &self.butterfly.service_config_store,
-                                        &self.butterfly.service_file_store);
+                .update_from_rumors_mlr_rsr(&self.state.cfg.cache_key_path,
+                                            &self.butterfly.service_store,
+                                            &self.butterfly.election_store,
+                                            &self.butterfly.update_store,
+                                            &self.butterfly.member_list,
+                                            &self.butterfly.service_config_store,
+                                            &self.butterfly.service_file_store);
 
             if self.check_for_changed_services() {
                 self.persist_state_mlr_rsr();

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -634,11 +634,11 @@ impl Manager {
     }
 
     /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
-    fn add_service_mlw_rsw(&mut self, spec: &ServiceSpec) {
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn add_service_rsw_mlw(&mut self, spec: &ServiceSpec) {
         // JW TODO: This clone sucks, but our data structures are a bit messy here. What we really
         // want is the service to hold the spec and, on failure, return an error with the spec
         // back to us. Since we consume and deconstruct the spec in `Service::new()` which
@@ -684,10 +684,10 @@ impl Manager {
             return;
         }
 
-        self.gossip_latest_service_rumor_mlw_rsw(&service);
+        self.gossip_latest_service_rumor_rsw_mlw(&service);
         if service.topology == Topology::Leader {
             self.butterfly
-                .start_election_mlr_rsw(&service.service_group, 0);
+                .start_election_rsw_mlr(&service.service_group, 0);
         }
 
         if let Err(e) = self.user_config_watcher
@@ -720,14 +720,14 @@ impl Manager {
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
     /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
-    /// * `MemberList::intitial_entries` (write) This method must not be called while any
-    ///   MemberList::intitial_entries lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
+    /// * `MemberList::intitial_entries` (write) This method must not be called while any
+    ///   MemberList::intitial_entries lock is held.
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
     #[allow(clippy::cognitive_complexity)]
-    pub fn run_mlw_imlw_rsw(mut self,
+    pub fn run_rsw_imlw_mlw(mut self,
                             svc: Option<habitat_sup_protocol::ctl::SvcLoad>)
                             -> Result<()> {
         let main_hist = RUN_LOOP_DURATION.with_label_values(&["sup"]);
@@ -766,13 +766,13 @@ impl Manager {
 
         // This serves to start up any services that need starting
         // (which will be all of them at this point!)
-        self.maybe_spawn_service_futures_mlw_rsw(&mut runtime);
+        self.maybe_spawn_service_futures_rsw_mlw(&mut runtime);
 
         outputln!("Starting gossip-listener on {}",
                   self.butterfly.gossip_addr());
-        self.butterfly.start_mlw_rsw(&Timing::default())?;
+        self.butterfly.start_rsw_mlw(&Timing::default())?;
         debug!("gossip-listener started");
-        self.persist_state_mlr_rsr();
+        self.persist_state_rsr_mlr();
         let http_listen_addr = self.sys.http_listen();
         let ctl_listen_addr = self.sys.ctl_listen();
         let ctl_secret_key = ctl_gateway::readgen_secret_key(&self.fs_cfg.sup_root)?;
@@ -1002,19 +1002,19 @@ impl Manager {
                 // event in the specs directory is registered, or
                 // another service finishes shutting down).
                 self.services_need_reconciliation.toggle_if_set();
-                self.maybe_spawn_service_futures_mlw_rsw(&mut runtime);
+                self.maybe_spawn_service_futures_rsw_mlw(&mut runtime);
             }
 
             self.update_peers_from_watch_file_mlr_imlw()?;
             self.update_running_services_from_user_config_watcher();
 
-            for f in self.stop_services_with_updates_mlr_rsw() {
+            for f in self.stop_services_with_updates_rsw_mlr() {
                 runtime.spawn(f);
             }
 
-            self.restart_elections_mlr_rsw(self.feature_flags);
+            self.restart_elections_rsw_mlr(self.feature_flags);
             self.census_ring
-                .update_from_rumors_mlr_rsr(&self.state.cfg.cache_key_path,
+                .update_from_rumors_rsr_mlr(&self.state.cfg.cache_key_path,
                                             &self.butterfly.service_store,
                                             &self.butterfly.election_store,
                                             &self.butterfly.update_store,
@@ -1023,11 +1023,11 @@ impl Manager {
                                             &self.butterfly.service_file_store);
 
             if self.check_for_changed_services() {
-                self.persist_state_mlr_rsr();
+                self.persist_state_rsr_mlr();
             }
 
             if self.census_ring.changed() {
-                self.persist_state_mlr_rsr();
+                self.persist_state_rsr_mlr();
             }
 
             for service in self.state
@@ -1041,7 +1041,7 @@ impl Manager {
                 #[allow(unused_variables)]
                 let service_timer = service_hist.start_timer();
                 if service.tick(&self.census_ring, &self.launcher, &runtime.executor()) {
-                    self.gossip_latest_service_rumor_mlw_rsw(&service);
+                    self.gossip_latest_service_rumor_rsw_mlw(&service);
                 }
             }
 
@@ -1111,7 +1111,7 @@ impl Manager {
                .expect("Error waiting on Tokio runtime to shutdown");
 
         release_process_lock(&self.fs_cfg);
-        self.butterfly.persist_data_mlr_rsr();
+        self.butterfly.persist_data_rsr_mlr();
 
         match shutdown_mode {
             ShutdownMode::Normal | ShutdownMode::Restarting => Ok(()),
@@ -1131,12 +1131,12 @@ impl Manager {
     /// for further transformation into futures.
     ///
     /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
     #[rustfmt::skip]
-    fn take_services_with_updates_mlr_rsw(&mut self) -> Vec<Service> {
+    fn take_services_with_updates_rsw_mlr(&mut self) -> Vec<Service> {
         let mut updater = self.updater.lock().expect("Updater lock poisoned");
 
         let mut state_services = self.state
@@ -1148,7 +1148,7 @@ impl Manager {
                 if service.needs_restart {
                     Some(current_ident.clone())
                 } else if let Some(new_ident) =
-                    updater.check_for_updated_package_mlr_rsw(&service, &self.census_ring)
+                    updater.check_for_updated_package_rsw_mlr(&service, &self.census_ring)
                 {
                     outputln!("Updating from {} to {}", current_ident, new_ident);
                     event::service_update_started(&service, &new_ident);
@@ -1173,10 +1173,10 @@ impl Manager {
     /// need to be updated.
     ///
     /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
     // TODO (CM): In the future, when service start up is
     // future-based, we'll want to have an actual "restart"
     // future, that queues up the start future after the stop
@@ -1186,8 +1186,8 @@ impl Manager {
     // our specfile reconciliation logic to catch the fact that
     // the service needs to be restarted. At that point, this function
     // can be renamed; right now, it says exactly what it's doing.
-    fn stop_services_with_updates_mlr_rsw(&mut self) -> Vec<impl Future<Item = (), Error = ()>> {
-        self.take_services_with_updates_mlr_rsw()
+    fn stop_services_with_updates_rsw_mlr(&mut self) -> Vec<impl Future<Item = (), Error = ()>> {
+        self.take_services_with_updates_rsw_mlr()
             .into_iter()
             .map(|service| self.stop(service))
             .collect()
@@ -1195,11 +1195,11 @@ impl Manager {
 
     // Creates a rumor for the specified service.
     /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
-    fn gossip_latest_service_rumor_mlw_rsw(&self, service: &Service) {
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn gossip_latest_service_rumor_rsw_mlw(&self, service: &Service) {
         let incarnation = self.butterfly
                               .service_store
                               .lock_rsr()
@@ -1208,7 +1208,7 @@ impl Manager {
                               .unwrap_or(1);
 
         self.butterfly
-            .insert_service_mlw_rsw(service.to_rumor(incarnation));
+            .insert_service_rsw_mlw(service.to_rumor(incarnation));
     }
 
     fn check_for_departure(&self) -> bool { self.butterfly.is_departed() }
@@ -1243,15 +1243,15 @@ impl Manager {
     }
 
     /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
     ///   is held.
-    fn persist_state_mlr_rsr(&self) {
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn persist_state_rsr_mlr(&self) {
         debug!("Updating census state");
         self.persist_census_state();
         debug!("Updating butterfly state");
-        self.persist_butterfly_state_mlr_rsr();
+        self.persist_butterfly_state_rsr_mlr();
         debug!("Updating services state");
         self.persist_services_state();
     }
@@ -1267,11 +1267,11 @@ impl Manager {
     }
 
     /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (read) This method must not be called while any RumorStore::list lock
     ///   is held.
-    fn persist_butterfly_state_mlr_rsr(&self) {
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn persist_butterfly_state_rsr_mlr(&self) {
         let bs = ServerProxy::new(&self.butterfly);
         let json = serde_json::to_string(&bs).unwrap();
         self.state
@@ -1337,8 +1337,8 @@ impl Manager {
     ///   lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
-    fn restart_elections_mlr_rsw(&mut self, feature_flags: FeatureFlag) {
-        self.butterfly.restart_elections_mlr_rsw(feature_flags);
+    fn restart_elections_rsw_mlr(&mut self, feature_flags: FeatureFlag) {
+        self.butterfly.restart_elections_rsw_mlr(feature_flags);
     }
 
     /// Create a future for stopping a Service. The Service is assumed
@@ -1445,13 +1445,13 @@ impl Manager {
     /// calling this method.
     ///
     /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
-    fn maybe_spawn_service_futures_mlw_rsw(&mut self, runtime: &mut Runtime) {
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn maybe_spawn_service_futures_rsw_mlw(&mut self, runtime: &mut Runtime) {
         let ops = self.compute_service_operations();
-        for f in self.operations_into_futures_mlw_rsw(ops) {
+        for f in self.operations_into_futures_rsw_mlw(ops) {
             runtime.spawn(f);
         }
     }
@@ -1474,11 +1474,11 @@ impl Manager {
     /// shutdowns and restarts are turned into futures.
     ///
     /// # Locking
-    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
-    fn operations_into_futures_mlw_rsw<O>(&mut self,
+    /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
+    ///   lock is held.
+    fn operations_into_futures_rsw_mlw<O>(&mut self,
                                           ops: O)
                                           -> Vec<impl Future<Item = (), Error = ()>>
         where O: IntoIterator<Item = ServiceOperation>
@@ -1509,7 +1509,7 @@ impl Manager {
                        f
                    }
                    ServiceOperation::Start(spec) => {
-                       self.add_service_mlw_rsw(&spec);
+                       self.add_service_rsw_mlw(&spec);
                        None // No future to return (currently synchronous!)
                    }
                }

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1191,7 +1191,6 @@ impl Manager {
                                                    .service_store
                                                    .list
                                                    .read()
-                                                   .expect("Rumor store lock poisoned")
                                                    .get(&*service.service_group)
                                                    .and_then(|r| r.get(&self.sys.member_id))
         {

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1187,14 +1187,12 @@ impl Manager {
     /// * `MemberList::entries` (write) This method must not be called while any MemberList::entries
     ///   lock is held.
     fn gossip_latest_service_rumor_mlw(&self, service: &Service) {
-        let incarnation = if let Some(rumor) = self.butterfly
-                                                   .service_store
-                                                   .list
-                                                   .read()
-                                                   .get(&*service.service_group)
-                                                   .and_then(|r| r.get(&self.sys.member_id))
+        let incarnation = if let Some(rumor) =
+            self.butterfly
+                .service_store
+                .get_rumor_cloned(&service.service_group, &self.sys.member_id)
         {
-            rumor.clone().incarnation + 1
+            rumor.incarnation + 1
         } else {
             1
         };

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -711,13 +711,13 @@ mod tests {
         let service_file_store: RumorStore<ServiceFileRumor> = RumorStore::default();
 
         let mut ring = CensusRing::new("member-a");
-        ring.update_from_rumors_mlr(&cache_key_path(Some(&*FS_ROOT)),
-                                    &service_store,
-                                    &election_store,
-                                    &election_update_store,
-                                    &member_list,
-                                    &service_config_store,
-                                    &service_file_store);
+        ring.update_from_rumors_mlr_rsr(&cache_key_path(Some(&*FS_ROOT)),
+                                        &service_store,
+                                        &election_store,
+                                        &election_update_store,
+                                        &member_list,
+                                        &service_config_store,
+                                        &service_file_store);
 
         let bindings = iter::empty::<&ServiceBind>();
 

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -711,7 +711,7 @@ mod tests {
         let service_file_store: RumorStore<ServiceFileRumor> = RumorStore::default();
 
         let mut ring = CensusRing::new("member-a");
-        ring.update_from_rumors_mlr_rsr(&cache_key_path(Some(&*FS_ROOT)),
+        ring.update_from_rumors_rsr_mlr(&cache_key_path(Some(&*FS_ROOT)),
                                         &service_store,
                                         &election_store,
                                         &election_update_store,

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -692,7 +692,7 @@ mod tests {
 
         let service_store: RumorStore<ServiceRumor> = RumorStore::default();
         let service_one = ServiceRumor::new("member-a", &pg_id, sg_one.clone(), sys_info, None);
-        service_store.insert(service_one);
+        service_store.insert_rsw(service_one);
 
         let election_store: RumorStore<ElectionRumor> = RumorStore::default();
         let mut election = ElectionRumor::new("member-a",
@@ -701,7 +701,7 @@ mod tests {
                                               10,
                                               true /* has_quorum */);
         election.finish();
-        election_store.insert(election);
+        election_store.insert_rsw(election);
 
         let election_update_store: RumorStore<ElectionUpdateRumor> = RumorStore::default();
 

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -147,12 +147,12 @@ impl ServiceUpdater {
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
     /// # Locking
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
     /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
     ///   is held.
+    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
+    ///   lock is held.
     #[allow(clippy::cognitive_complexity)]
-    pub fn check_for_updated_package_mlr_rsw(&mut self,
+    pub fn check_for_updated_package_rsw_mlr(&mut self,
                                              service: &Service,
                                              // TODO (CM): Strictly speaking, we don't need to
                                              // pass CensusRing down into here, just the census
@@ -193,7 +193,7 @@ impl ServiceUpdater {
                                     u64::max_value()
                                 };
                                 self.butterfly
-                                    .start_update_election_mlr_rsw(&service.service_group,
+                                    .start_update_election_rsw_mlr(&service.service_group,
                                                                    suitability,
                                                                    0);
                                 *st = RollingState::InElection
@@ -203,7 +203,7 @@ impl ServiceUpdater {
                     } else {
                         debug!("Rolling update, using default suitability");
                         self.butterfly
-                            .start_update_election_mlr_rsw(&service.service_group, 0, 0);
+                            .start_update_election_rsw_mlr(&service.service_group, 0, 0);
                         *st = RollingState::InElection;
                     }
                 }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -149,15 +149,16 @@ impl ServiceUpdater {
     /// # Locking
     /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
     ///   lock is held.
+    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
+    ///   is held.
     #[allow(clippy::cognitive_complexity)]
-    pub fn check_for_updated_package_mlr(&mut self,
-                                         service: &Service,
-                                         // TODO (CM): Strictly speaking, we don't need to pass
-                                         // CensusRing down into here, just the census group for
-                                         // our
-                                         // service.
-                                         census_ring: &CensusRing)
-                                         -> Option<PackageIdent> {
+    pub fn check_for_updated_package_mlr_rsw(&mut self,
+                                             service: &Service,
+                                             // TODO (CM): Strictly speaking, we don't need to
+                                             // pass CensusRing down into here, just the census
+                                             // group for our service.
+                                             census_ring: &CensusRing)
+                                             -> Option<PackageIdent> {
         debug!("Checking for updated package!");
 
         // TODO (CM): can we do without this?
@@ -192,9 +193,9 @@ impl ServiceUpdater {
                                     u64::max_value()
                                 };
                                 self.butterfly
-                                    .start_update_election_mlr(&service.service_group,
-                                                               suitability,
-                                                               0);
+                                    .start_update_election_mlr_rsw(&service.service_group,
+                                                                   suitability,
+                                                                   0);
                                 *st = RollingState::InElection
                             }
                             _ => return None,
@@ -202,7 +203,7 @@ impl ServiceUpdater {
                     } else {
                         debug!("Rolling update, using default suitability");
                         self.butterfly
-                            .start_update_election_mlr(&service.service_group, 0, 0);
+                            .start_update_election_mlr_rsw(&service.service_group, 0, 0);
                         *st = RollingState::InElection;
                     }
                 }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -146,11 +146,9 @@ impl ServiceUpdater {
     // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
     // but changing it in the absence of other necessity seems like too much risk for the
     // expected reward.
-    /// # Locking
-    /// * `RumorStore::list` (write) This method must not be called while any RumorStore::list lock
-    ///   is held.
-    /// * `MemberList::entries` (read) This method must not be called while any MemberList::entries
-    ///   lock is held.
+    /// # Locking (see locking.md)
+    /// * `RumorStore::list` (write)
+    /// * `MemberList::entries` (read)
     #[allow(clippy::cognitive_complexity)]
     pub fn check_for_updated_package_rsw_mlr(&mut self,
                                              service: &Service,

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,0 +1,17 @@
+# Habitat Development Documentation
+
+This directory contains links to development documentation for both new and
+seasoned contributors. They explain how to build, test, and contribute to
+Habitat, as well as describe conventions and philosophy for design and
+implementation details.
+
+## How-To Guides
+
+- [Contributing](../../CONTRIBUTING.md)
+- [Building](../../BUILDING.md)
+- [UX Principles](../../UX_PRINCIPLES.md)
+- [Verification Testing](../../VERIFICATION_TESTING.md)
+
+## Design Documents
+
+- [Locking](./design_documents/locking.md)

--- a/docs/dev/design_documents/locking.md
+++ b/docs/dev/design_documents/locking.md
@@ -1,0 +1,75 @@
+# Locking
+
+In order to support its high degree of parallelism at runtime, Habitat uses
+a number of different lock types. To avoid deadlock, we rely on conventions
+around how these locks are acquired, held and released.
+
+## Documenting behavior
+
+Functions which acquire locks should have the details described in their doc
+comment. Additionally, a suffix is applied to the function name to indicate
+the locks that are acquired either directly or indirectly. The suffix is an
+abbreviation of the lock name (e.g., `ml` for `MemberList::entries`) and an
+`r` or `w` to indicate a read or write lock, if applicable. If a function
+takes both a read and write lock `w` suffices. The ordering of the suffixes
+and doc comments should reflect the lock ordering.
+
+When adding code which takes a lock, it's important add the appropriate doc
+comment and suffix to the name of the function, and then propagate that
+information up the call chain. Without this, it can be easy to violate the
+lock ordering because a lock is acquired through a series of function calls.
+
+For example, a caller which wishes to insert a new service rumor may not be
+aware of the implementation details involved and mistakenly hold a
+`MemberList` lock while doing the insert. This could lead to deadlock, so
+to make this clear the function for inserting a service is named
+`insert_service_rsw_mlw` to make it clear that both `RumorStore::list` and
+`MemberList::entries` locks may be acquired during the execution of
+`insert_service_rsw_mlw`.
+
+## Lock Ordering
+
+Whenever a thread needs to hold multiple locks concurrently, they
+must be acquired in the conventional order and released in the reverse order:
+
+1. `RumorStore::list`
+1. `MemberList::initial_members`
+1. `MemberList::entries`
+
+Any function which is documented to acquire a lock should not be called with
+any lock that occurs later in the lock order held. For example, since
+`insert_service_config_rsw` calls functions which acquire the
+`RumorStore::list` lock, calling it with the `MemberList::entries` lock held
+violates the lock order and may lead to deadlock.
+
+It's not necessary to acquire all intermediate locks. For example, a thread
+may take `RumorStore::list`, followed by `MemberList::entries`, without
+taking `MemberList::initial_members`. However, once `MemberList::entries`
+is taken, subsequent logic must not take `MemberList::initial_members`,
+unless `MemberList::entries` is released first.
+
+Additional lock types will be added as work on https://github.com/habitat-sh/habitat/issues/6435
+progresses.
+
+See https://en.wikipedia.org/wiki/Dining_philosophers_problem
+
+## Recursion
+
+Recursive locking adds complexity, risks deadlock with the `std::sync` locks
+(since the behavior is undefined) and precludes fairness. No locks should be
+acquired recursively. Though recursive locking does exist in the codebase,
+https://github.com/habitat-sh/habitat/issues/6435 tracks the process of
+eliminating it.
+
+Any function which is documented to acquire a lock should not be called with
+that same lock already held.
+
+## `std::sync` vs `parking_lot`
+
+The interfaces for `Mutex` and `RwLock` are very similar between the stdlib
+and the `parking_lot` crate, but the latter has better performance and more
+features, including defined recursion semantics and the option to try to
+acquire a lock with a timeout.
+
+In general we prefer to move to the `parking_lot` implementations, but this
+is a gradual process and should be undertaken with care.

--- a/docs/dev/design_documents/locking.md
+++ b/docs/dev/design_documents/locking.md
@@ -9,10 +9,10 @@ around how these locks are acquired, held and released.
 Functions which acquire locks should have the details described in their doc
 comment. Additionally, a suffix is applied to the function name to indicate
 the locks that are acquired either directly or indirectly. The suffix is an
-abbreviation of the lock name (e.g., `ml` for `MemberList::entries`) and an
-`r` or `w` to indicate a read or write lock, if applicable. If a function
-takes both a read and write lock `w` suffices. The ordering of the suffixes
-and doc comments should reflect the lock ordering.
+abbreviation of the lock name (see [Lock Ordering](#lock-ordering) section)
+and an `r` or `w` to indicate a read or write lock, if applicable. If a
+function takes both a read and write lock `w` suffices. The ordering of the
+suffixes and doc comments should reflect the lock ordering.
 
 When adding code which takes a lock, it's important add the appropriate doc
 comment and suffix to the name of the function, and then propagate that
@@ -32,9 +32,9 @@ to make this clear the function for inserting a service is named
 Whenever a thread needs to hold multiple locks concurrently, they
 must be acquired in the conventional order and released in the reverse order:
 
-1. `RumorStore::list`
-1. `MemberList::initial_members`
-1. `MemberList::entries`
+1. `RumorStore::list` (`rs`)
+1. `MemberList::initial_members` (`iml`)
+1. `MemberList::entries` (`ml`)
 
 Any function which is documented to acquire a lock should not be called with
 any lock that occurs later in the lock order held. For example, since


### PR DESCRIPTION
Revamp the locking in `RumorStore` to prevent deadlocks.

There's quite a bit here; reading the individual commit messages should make motivations fairly clear. I'd also suggest viewing the diff with whitespace changes hidden. The major points:

- `RumorStore` now uses `habitat_common::sync::Lock`, which is a facade for `parking_lot` that allows us to switch between `RwLock` and `Mutex` via a feature flag to help test for recursive locking.
- Make `RumorStore` lock fields private to keep management of locking code tractable.
- Add `IterableGuard` and `ServiceGroupRumors` so consumers can use `for` loops and iterator adapters safely on the data behind the `RumorStore` lock.
- Annotate all the callers with `rsr`/`rsw` to indicate what code paths take `RumorStore` locks all the way up the stack.
- Document our approach to locking and avoiding deadlock.
- Various cleanups, removals and simplification.

See https://github.com/habitat-sh/habitat/issues/6435

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/habitat-sh/habitat/6674)
<!-- Reviewable:end -->
