### PR TITLE
Make the plans' build use rust-toolchain version

### DIFF
--- a/components/hab/habitat/plan.ps1
+++ b/components/hab/habitat/plan.ps1
@@ -14,7 +14,7 @@ $pkg_deps=@(
 $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust",
+    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
     "core/cacerts"
 )
 

--- a/components/hab/habitat/plan.sh
+++ b/components/hab/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_build_deps=(core/musl
                 core/openssl-musl
                 core/libsodium-musl
                 core/coreutils
-                core/rust
+                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
                 core/gcc)
 pkg_bin_dirs=(bin)
 

--- a/components/launcher/habitat/plan.ps1
+++ b/components/launcher/habitat/plan.ps1
@@ -13,7 +13,7 @@ $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @(
     "core/visual-cpp-redist-2015",
     "core/visual-cpp-build-tools-2015",
-    "core/rust",
+    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
     "core/cacerts",
     "core/git"
 )

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -10,7 +10,7 @@ pkg_deps=(core/glibc
           core/libsodium
           core/openssl)
 pkg_build_deps=(core/coreutils
-                core/rust
+                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
                 core/gcc
                 core/git
                 core/protobuf)

--- a/components/pkg-export-docker/habitat/plan.ps1
+++ b/components/pkg-export-docker/habitat/plan.ps1
@@ -15,7 +15,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust",
+    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
     "core/cacerts"
 )
 

--- a/components/pkg-export-docker/habitat/plan.sh
+++ b/components/pkg-export-docker/habitat/plan.sh
@@ -16,7 +16,7 @@ pkg_build_deps=(core/musl
                 core/openssl-musl
                 core/libsodium-musl
                 core/coreutils
-                core/rust
+                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
                 core/gcc
                 core/make)
 pkg_bin_dirs=(bin)

--- a/components/pkg-export-helm/habitat/plan.sh
+++ b/components/pkg-export-helm/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_build_deps=(core/musl
                 core/openssl-musl
                 core/libsodium-musl
                 core/coreutils
-                core/rust
+                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
                 core/gcc
                 core/make)
 pkg_bin_dirs=(bin)

--- a/components/pkg-export-kubernetes/habitat/plan.sh
+++ b/components/pkg-export-kubernetes/habitat/plan.sh
@@ -14,7 +14,7 @@ pkg_build_deps=(core/musl
                 core/openssl-musl
                 core/libsodium-musl
                 core/coreutils
-                core/rust
+                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
                 core/gcc
                 core/make)
 pkg_bin_dirs=(bin)

--- a/components/pkg-export-tar/habitat/plan.ps1
+++ b/components/pkg-export-tar/habitat/plan.ps1
@@ -15,7 +15,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust",
+    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
     "core/cacerts"
 )
 

--- a/components/pkg-export-tar/habitat/plan.sh
+++ b/components/pkg-export-tar/habitat/plan.sh
@@ -14,7 +14,7 @@ pkg_build_deps=(core/musl
                 core/openssl-musl
                 core/libsodium-musl
                 core/coreutils
-                core/rust
+                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
                 core/gcc
                 core/make)
 pkg_bin_dirs=(bin)

--- a/components/sup/habitat/plan.ps1
+++ b/components/sup/habitat/plan.ps1
@@ -16,7 +16,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust",
+    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
     "core/cacerts",
     "core/raml2html"
 )

--- a/components/sup/habitat/plan.sh
+++ b/components/sup/habitat/plan.sh
@@ -15,7 +15,7 @@ pkg_deps=(core/busybox-static
 pkg_build_deps=(core/coreutils
                 core/cacerts
                 core/make
-                core/rust
+                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
                 core/gcc
                 core/raml2html
                 core/protobuf)

--- a/components/sup/static/plan.sh
+++ b/components/sup/static/plan.sh
@@ -7,7 +7,7 @@ pkg_deps=(core/busybox-static)
 pkg_build_deps=(
   core/musl core/zlib-musl core/xz-musl core/bzip2-musl core/libarchive-musl
   core/openssl-musl core/libsodium-musl
-  core/coreutils core/cacerts core/rust core/gcc
+  core/coreutils core/cacerts core/rust/"$(cat "$SRC_PATH/../../../rust-toolchain")" core/gcc
 )
 
 do_begin() {


### PR DESCRIPTION
Set the particular version of `core/rust` that the habitat components depend upon to build based on the `rust-toolchain` file that governs plain `cargo`-based builds of these crates.