### PR TITLE
Revert "cross platform binstubs with package environment"

### DIFF
--- a/components/hab/static/template_binstub.bat
+++ b/components/hab/static/template_binstub.bat
@@ -1,4 +1,0 @@
-@echo off
-REM source='{src}'
-{env}
-"{src}" %*

--- a/components/hab/static/template_binstub.sh
+++ b/components/hab/static/template_binstub.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# source='{src}'
-{env}
-exec {src} "$@"

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -854,8 +854,7 @@ mod test {
         use super::{super::*,
                     *};
         use crate::common::ui::UI;
-        use std::{fs,
-                  io::{self,
+        use std::{io::{self,
                        Cursor,
                        Write},
                   sync::{Arc,
@@ -895,15 +894,19 @@ mod test {
             build_spec().link_binaries(&mut ui, rootfs.path(), &base_pkgs)
                         .unwrap();
 
-            assert!(fs::read_to_string(rootfs.path().join("bin/busybox")).unwrap().contains(hcore::fs::pkg_install_path(base_pkgs.busybox.as_ref().unwrap(),
-                                                   None::<&Path>).join("bin/busybox").to_str().unwrap()),
-                       "busybox program is binlinked into /bin");
-            assert!(fs::read_to_string(rootfs.path().join("bin/sh")).unwrap().contains(hcore::fs::pkg_install_path(&base_pkgs.busybox.unwrap(),
-                                                   None::<&Path>).join("bin/sh").to_str().unwrap()),
-                       "busybox's sh program is binlinked into /bin");
-            assert!(fs::read_to_string(rootfs.path().join("bin/hab")).unwrap().contains(hcore::fs::pkg_install_path(&base_pkgs.hab,
-                                                   None::<&Path>).join("bin/hab").to_str().unwrap()),
-                       "hab program is binlinked into /bin");
+            assert_eq!(hcore::fs::pkg_install_path(base_pkgs.busybox.as_ref().unwrap(),
+                                                   None::<&Path>).join("bin/busybox"),
+                       rootfs.path().join("bin/busybox").read_link().unwrap(),
+                       "busybox program is symlinked into /bin");
+            assert_eq!(
+                hcore::fs::pkg_install_path(&base_pkgs.busybox.unwrap(), None::<&Path>)
+                    .join("bin/sh"),
+                rootfs.path().join("bin/sh").read_link().unwrap(),
+                "busybox's sh program is symlinked into /bin"
+            );
+            assert_eq!(hcore::fs::pkg_install_path(&base_pkgs.hab, None::<&Path>).join("bin/hab"),
+                       rootfs.path().join("bin/hab").read_link().unwrap(),
+                       "hab program is symlinked into /bin");
         }
 
         #[cfg(unix)]

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -27,7 +27,7 @@ find . -type f \
       -or -exec sh -c 'file -b "$1" | grep -q "shell script"' -- {} \; \) \
   -and \! -path "*.sample" \
   -and \! -path "*.ps1" \
-  -and \! -path "./components/hab/static/*" \
+  -and \! -path "./components/hab/static/template_plan.sh" \
   -and \! -path "./target/*" \
   -and \! -path "./test/integration/helpers.bash" \
   -and \! -path "./test/integration/test_helper/bats-assert/*" \


### PR DESCRIPTION
We discovered some downsides of this, particularly when making a binstub of `core/bash`'s `sh` when that binstub gets dropped into a studio at `/bin/sh`... the shebang line is `#!/bin/sh`, which results in an infinite recursion.

We suspect it may be as simple as not binstubbing `sh` when we're dealing with a studio, but we want to ensure that that's actually the fix, and that there aren't additional subtleties at play. Once that's sorted out, we intend to reintroduce this work.

Reverts habitat-sh/habitat#6670