### PR TITLE
Fix a crash when starting butterfly with no rumor file

### DIFF
--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -84,9 +84,10 @@ impl DatFile {
 
         if size == 0 {
             dat_file.write_mlr(server)?;
+        } else {
+            dat_file.read_header()?;
         }
 
-        dat_file.read_header()?;
         Ok(dat_file)
     }
 


### PR DESCRIPTION
This fixes an issue with the `DatFile` refactoring where if butterfly started up and there was no rumor file to ingest, it would write an empty file and then try to read it back in, but error on being unable to fill the buffer.

![](https://media.giphy.com/media/3o6Zt8QsdsCdZMp0ha/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>