### PR TITLE
do not overwrite PSModulePath when setting up build environment

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -1267,7 +1267,7 @@ function Invoke-SetupEnvironmentWrapper {
     # the real environment, except for PATH; for that, push the
     # runtime path onto the front of the system path
     foreach($k in $env["Runtime"].keys) {
-        if(@("PATH", "LIB", "INCLUDE") -contains $k) {
+        if(@("PATH", "LIB", "INCLUDE", "PSMODULEPATH") -contains $k) {
             $currentVal = ""
             if(Test-path env:\$k) {
                 $currentVal = Get-Content env:\$k
@@ -1464,34 +1464,6 @@ function __env_var_type($VarName) {
         # We know nothing about it; treat it as a primitive
         Write-Warning "Treating `$$varName as a primitive type. If you would like to change this, add `"HAB_ENV_${VarName}_TYPE='aggregate'`" to your plan."
         'primitive'
-    }
-}
-
-# Simply converts contents of pkg_bin_dirs, pkg_lib_dirs and pkg_include_dirs
-# into a PATH, LIB and INCLUDE variable
-function __process_paths($Environment) {
-    if($Environment -ne "Runtime") { return }
-
-    # Contents of `pkg_xxx_dirs` are relative to the plan root;
-    # prepend the full path to this release so everything resolves
-    # properly once the package is installed.
-    $prefixDrive = (Resolve-Path $originalPath).Drive.Root
-    $strippedPrefix = $pkg_prefix.Substring($prefixDrive.length)
-    if(!$strippedPrefix.StartsWith('\')) { $strippedPrefix = "\$strippedPrefix" }
-
-    if ($pkg_bin_dirs.Length -gt 0) {
-        $path = $($pkg_bin_dirs | % { "$strippedPrefix\$_" }) -join ';'
-        __push_env $Environment "PATH" $path ";" "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-    }
-
-    if ($pkg_lib_dirs.Length -gt 0) {
-        $lib = $($pkg_lib_dirs | % { "$strippedPrefix\$_" }) -join ';'
-        __push_env $Environment "LIB" $lib ";" "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
-    }
-
-    if ($pkg_include_dirs.Length -gt 0) {
-        $include = $($pkg_include_dirs | % { "$strippedPrefix\$_" }) -join ';'
-        __push_env $Environment "INCLUDE" $include ";" "${pkg_origin}/${pkg_name}/${pkg_version}/${pkg_release}"
     }
 }
 

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -231,6 +231,7 @@ function New-Studio {
   )
 
   $env:PATH = [String]::Join(";", $pathArray)
+  $env:PSModulePath = "$PSScriptRoot\powershell\Modules"
 
   if($env:HAB_ORIGIN_KEYS) {
     $secret_keys = @()


### PR DESCRIPTION
The `PSModulePath` environment variable is where Powershell looks for modules. When entering a powershell shell, powershell will ensure that its own `modules` directory which include the built in modules that ship with powershell are added to this variable when the shell starts.

If a plan includes something like:
```
function Invoke-SetupEnvironment {
    Push-RuntimeEnv "PSModulePath" "\hab\pkgs\$pkg_origin\$pkg_name\$pkg_version\$pkg_release\Modules"
}
```
This will overwrite the existing `PSModulePath` and potentially cause powershell commands that leverage the distribution bundled modules to fail.

An example would be any plan that takes a dep on `core/dsc-core` which includes the above code.

This PR does 3 things:
1. Sets the `PSModulePath` in the Studio creation code so that any module paths other than those included with the powershell vendored in the studio are not included.
2. Add `PSModulePath` to the list of variables in `hab-plan-build` that should not be overwritten.
3. Removes a function I found to be entirely dead code.

Signed-off-by: mwrock <matt@mattwrock.com>