### PR TITLE
redux: cross platform binstubs with package environment

### DIFF
--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -22,9 +22,15 @@ const COMMENT_MARKER: &str = "REM";
 #[cfg(unix)]
 const COMMENT_MARKER: &str = "#";
 #[cfg(windows)]
+const PATH_SEPARATOR: char = ';';
+#[cfg(unix)]
+const PATH_SEPARATOR: char = ':';
+#[cfg(windows)]
 const SET_OR_EXPORT: &str = "SET";
 #[cfg(unix)]
 const SET_OR_EXPORT: &str = "export";
+
+const DEFAULT_INTERPRETER: &str = "/bin/sh";
 
 pub fn start(ui: &mut UI,
              ident: &PackageIdent,
@@ -35,10 +41,10 @@ pub fn start(ui: &mut UI,
              -> Result<()> {
     let dst_path = fs_root_path.join(dest_path.strip_prefix("/")?);
     ui.begin(format!("Binlinking {} from {} into {}",
-                     &binary,
-                     &ident,
+                     binary,
+                     ident,
                      dst_path.display()))?;
-    let pkg_install = PackageInstall::load(&ident, Some(fs_root_path))?;
+    let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;
     let mut src = match hfs::find_command_in_pkg(binary, &pkg_install, fs_root_path)? {
         Some(c) => c,
         None => {
@@ -55,29 +61,28 @@ pub fn start(ui: &mut UI,
                   format!("parent directory {}", dst_path.display()))?;
         fs::create_dir_all(&dst_path)?
     }
-    let binlink = Binlink::new(&src, &dst_path)?;
+
+    let binlink = Binlink::new(&src, &dst_path, &PathBuf::from(DEFAULT_INTERPRETER))?;
     let ui_binlinked = format!("Binlinked {} from {} to {}",
-                               &binary,
-                               &pkg_install.ident(),
-                               &binlink.dest.display(),);
-    match Binlink::from_file(&binlink.dest) {
+                               binary,
+                               pkg_install.ident(),
+                               binlink.link.display(),);
+    match Binlink::from_file(&binlink.link) {
         Ok(link) => {
-            if force && link.src != src {
-                fs::remove_file(&link.dest)?;
+            if force {
+                fs::remove_file(link.link)?;
                 binlink.link(pkg_install.environment_for_command()?)?;
-                ui.end(&ui_binlinked)?;
-            } else if link.src != src {
+                ui.end(ui_binlinked)?;
+            } else {
                 ui.warn(format!("Skipping binlink because {} already exists at {}. Use --force \
                                  to overwrite",
-                                &binary,
-                                &link.dest.display(),))?;
-            } else {
-                ui.end(&ui_binlinked)?;
+                                binary,
+                                link.link.display(),))?;
             }
         }
         Err(_) => {
             binlink.link(pkg_install.environment_for_command()?)?;
-            ui.end(&ui_binlinked)?;
+            ui.end(ui_binlinked)?;
         }
     }
 
@@ -96,7 +101,7 @@ pub fn binlink_all_in_pkg(ui: &mut UI,
                           fs_root_path: &Path,
                           force: bool)
                           -> Result<()> {
-    let pkg_path = PackageInstall::load(&pkg_ident, Some(fs_root_path))?;
+    let pkg_path = PackageInstall::load(pkg_ident, Some(fs_root_path))?;
     for bin_path in pkg_path.paths()? {
         for bin in fs::read_dir(fs_root_path.join(bin_path.strip_prefix("/")?))? {
             let bin_file = bin?;
@@ -134,7 +139,7 @@ pub fn binlink_all_in_pkg(ui: &mut UI,
                     continue;
                 }
             };
-            self::start(ui, &pkg_ident, &bin_name, dest_path, &fs_root_path, force)?;
+            self::start(ui, pkg_ident, &bin_name, dest_path, fs_root_path, force)?;
         }
     }
     Ok(())
@@ -148,42 +153,64 @@ fn is_dest_on_path(dest_dir: &Path) -> bool {
     }
 }
 
+#[allow(dead_code)]
 struct Binlink {
-    dest: PathBuf,
-    src:  PathBuf,
+    link:                PathBuf,
+    target:              PathBuf,
+    default_interpreter: PathBuf,
 }
 
 impl Binlink {
-    pub fn new(src: &Path, dest_dir: &Path) -> Result<Self> {
-        Ok(Self { dest: Self::binstub_path(&src, dest_dir)?,
-                  src:  src.to_path_buf(), })
+    pub fn new(target: &Path, link: &Path, default_interpreter: &Path) -> Result<Self> {
+        Ok(Self { link:                Self::binstub_path(&target, link)?,
+                  target:              target.to_path_buf(),
+                  default_interpreter: default_interpreter.to_path_buf(), })
     }
 
     pub fn from_file(path: &Path) -> Result<Self> {
-        use toml::Value::Table;
+        // its possible the link could already exist as a symlink either
+        // because a previous version of habitat did the binlinking or
+        // the symlink created outside of habitat
+        fs::read_link(path).map(|target| Self::with_default_interpreter(target, path.into()))
+                           .or_else(|_| Self::try_from_script(path))
+    }
 
+    fn try_from_script(path: &Path) -> Result<Self> {
         let file = File::open(path)?;
         for line in BufReader::new(file).lines() {
             let ln = line?;
             if ln.to_uppercase().starts_with(COMMENT_MARKER) {
                 let (_, rest) = ln.split_at(COMMENT_MARKER.len());
-                if let Ok(Table(toml_exp)) = rest.parse() {
-                    if let Some(src) = toml_exp.get("source") {
-                        if let Some(val) = src.as_str() {
-                            return Ok(Binlink { dest: path.to_path_buf(),
-                                                src:  PathBuf::from(val), });
-                        }
-                    }
+                if let Some(target) = Self::get_target_from_toml(rest) {
+                    return Ok(Self::with_default_interpreter(target.into(), path.into()));
                 }
             }
         }
-        Err(Error::CannotParseBinlinkSource(path.to_path_buf()))
+        Err(Error::CannotParseBinlinkTarget(path.to_path_buf()))
+    }
+
+    fn with_default_interpreter(target: PathBuf, link: PathBuf) -> Self {
+        Self { link,
+               target,
+               default_interpreter: PathBuf::from(DEFAULT_INTERPRETER) }
+    }
+
+    fn get_target_from_toml(toml: &str) -> Option<String> {
+        toml.parse()
+            .ok()
+            .as_ref()
+            .and_then(toml::value::Value::as_table)
+            // Prior to 0.84.0, we used 'source' so we fallback
+            // to 'source' for links created with older versions
+            .and_then(|toml_table| toml_table.get("target").or_else(|| toml_table.get("source")))
+            .and_then(toml::value::Value::as_str)
+            .map(String::from)
     }
 
     pub fn link(&self, env: HashMap<String, String>) -> Result<()> {
         #[cfg(windows)]
         {
-            fs::write(&self.dest, self.stub_template(env).as_bytes())?;
+            fs::write(&self.link, self.stub_template(env)?.as_bytes())?;
             Ok(())
         }
 
@@ -195,49 +222,79 @@ impl Binlink {
                                   .write(true)
                                   .truncate(true)
                                   .mode(0o775)
-                                  .open(&self.dest)?
-                                  .write_all(self.stub_template(env).as_bytes())?;
+                                  .open(&self.link)?
+                                  .write_all(self.stub_template(env)?.as_bytes())?;
             Ok(())
         }
     }
 
-    fn binstub_path(src: &Path, dest_dir: &Path) -> Result<PathBuf> {
+    fn binstub_path(target: &Path, link: &Path) -> Result<PathBuf> {
         #[cfg(windows)]
         {
-            let bin_name = match src.file_stem() {
+            let bin_name = match target.file_stem() {
                 Some(name) => name,
-                None => return Err(Error::CannotParseBinlinkSource(src.to_path_buf())),
+                None => return Err(Error::CannotParseBinlinkTarget(target.to_path_buf())),
             };
-            let mut path = dest_dir.join(bin_name);
+            let mut path = link.join(bin_name);
             path.set_extension("bat");
             Ok(path)
         }
 
         #[cfg(unix)]
-        match src.file_name() {
-            Some(name) => Ok(dest_dir.join(name)),
-            None => Err(Error::CannotParseBinlinkSource(src.to_path_buf())),
+        match target.file_name() {
+            Some(name) => Ok(link.join(name)),
+            None => Err(Error::CannotParseBinlinkTarget(target.to_path_buf())),
         }
     }
 
-    fn stub_template(&self, env: HashMap<String, String>) -> String {
+    fn stub_template(&self, env: HashMap<String, String>) -> Result<String> {
         let mut exports = String::new();
-        for (key, value) in env.into_iter() {
+        for (key, mut value) in env.into_iter() {
+            if key == "PATH" {
+                value.push(PATH_SEPARATOR);
+                value.push_str(&Self::interpolated_var("PATH"));
+            }
             exports.push_str(&format!("{} {}={}\n", SET_OR_EXPORT, key, value));
         }
 
         #[cfg(windows)]
         {
-            format!(include_str!("../../../static/template_binstub.bat"),
-                    src = self.src.display(),
-                    env = exports)
+            Ok(format!(include_str!("../../../static/template_binstub.\
+                                     bat"),
+                       target = self.target.display(),
+                       env = exports))
         }
 
         #[cfg(unix)]
         {
-            format!(include_str!("../../../static/template_binstub.sh"),
-                    src = self.src.display(),
-                    env = exports)
+            // We need to prevent the binstub from using itself as an interpreter.
+            // On linux we use `/bin/sh` as the binstub interpreter and if this package
+            // includes a `sh` binary, we risk a circularly linked interpreter. We can
+            // detect if the link path is the same as the interpreter and if so, use the
+            // target binary as the interpreter.
+            let interpreter = {
+                if self.default_interpreter.canonicalize()? == self.link {
+                    &self.target
+                } else {
+                    &self.default_interpreter
+                }
+            };
+
+            Ok(format!(include_str!("../../../static/template_binstub.sh"),
+                       target = self.target.display(),
+                       env = exports,
+                       interpreter = interpreter.display()))
+        }
+    }
+
+    fn interpolated_var(name: &str) -> String {
+        #[cfg(windows)]
+        {
+            format!("%{}%", name)
+        }
+        #[cfg(unix)]
+        {
+            format!(r#""${}""#, name)
         }
     }
 }
@@ -294,6 +351,9 @@ mod test {
         let hypnoanalyze_link = "hypnoanalyze.exe";
         #[cfg(target_os = "windows")]
         let hypnoanalyze_link = "hypnoanalyze.bat";
+        let curr_path = format!("{}{}",
+                                super::PATH_SEPARATOR,
+                                Binlink::interpolated_var("PATH"));
 
         start(&mut ui,
               &ident,
@@ -301,10 +361,10 @@ mod test {
               &dst_path,
               rootfs.path(),
               force).unwrap();
-        assert!(fs::read_to_string(rootfs_bin_dir.join(magicate_link)).unwrap().contains(&format!("PATH={}", rootfs_src_dir.to_string_lossy())));
+        assert!(fs::read_to_string(rootfs_bin_dir.join(magicate_link)).unwrap().contains(&format!("PATH={}{}", rootfs_src_dir.to_string_lossy(), curr_path)));
         assert_eq!(rootfs_src_dir.join("magicate.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(magicate_link)).unwrap()
-                                                                          .src);
+                                                                          .target);
 
         start(&mut ui,
               &ident,
@@ -312,10 +372,29 @@ mod test {
               &dst_path,
               rootfs.path(),
               force).unwrap();
-        assert!(fs::read_to_string(rootfs_bin_dir.join(hypnoanalyze_link)).unwrap().contains(&format!("PATH={}", rootfs_src_dir.to_string_lossy())));
+        assert!(fs::read_to_string(rootfs_bin_dir.join(hypnoanalyze_link)).unwrap().contains(&format!("PATH={}{}", rootfs_src_dir.to_string_lossy(), curr_path)));
         assert_eq!(rootfs_src_dir.join("hypnoanalyze.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(hypnoanalyze_link)).unwrap()
-                                                                              .src);
+                                                                              .target);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn link_points_to_interpreter() {
+        use std::path::PathBuf;
+
+        let rootfs = TempDir::new().unwrap();
+        let rootfs_bin_dir = rootfs.path().join("bin");
+        let rootfs_bin_sh = rootfs_bin_dir.join("sh");
+        fs::create_dir_all(&rootfs_bin_dir).unwrap();
+
+        let link = Binlink::new(&PathBuf::from("/src/binary/sh"),
+                                &rootfs_bin_dir,
+                                &rootfs_bin_sh).unwrap();
+        link.link(HashMap::new()).unwrap();
+
+        assert!(fs::read_to_string(rootfs_bin_sh).unwrap()
+                                                 .contains("#!/src/binary/sh"));
     }
 
     #[test]
@@ -353,13 +432,13 @@ mod test {
 
         assert_eq!(rootfs_src_dir.join("bin/magicate.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(magicate_link)).unwrap()
-                                                                          .src);
+                                                                          .target);
         assert_eq!(rootfs_src_dir.join("bin/hypnoanalyze.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(hypnoanalyze_link)).unwrap()
-                                                                              .src);
+                                                                              .target);
         assert_eq!(rootfs_src_dir.join("sbin/securitize.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(securitize_link)).unwrap()
-                                                                            .src);
+                                                                            .target);
     }
 
     #[test]
@@ -383,7 +462,7 @@ mod test {
 
         assert_eq!(rootfs_src_dir.join("bin/magicate.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join("magicate.bat")).unwrap()
-                                                                           .src);
+                                                                           .target);
         assert!(Binlink::from_file(&rootfs_bin_dir.join("hypnoanalyze.bat")).is_err());
     }
 
@@ -425,10 +504,10 @@ mod test {
 
         assert_eq!(rootfs_src_dir.join("bin/magicate.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(magicate_link)).unwrap()
-                                                                          .src);
+                                                                          .target);
         assert_eq!(rootfs_src_dir.join("bin/moar/bonus-round.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(bonus_round_link)).unwrap()
-                                                                             .src);
+                                                                             .target);
     }
 
     fn ui() -> (UI, OutputBuffer, OutputBuffer) {

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -1,10 +1,9 @@
-#[cfg(windows)]
-use std::fs::File;
-#[cfg(windows)]
-use std::io::{BufRead,
-              BufReader};
-use std::{env,
-          fs,
+use std::{collections::HashMap,
+          env,
+          fs::{self,
+               File},
+          io::{BufRead,
+               BufReader},
           path::{Path,
                  PathBuf}};
 
@@ -19,7 +18,13 @@ use crate::error::{Error,
                    Result};
 
 #[cfg(windows)]
-const BAT_COMMENT_MARKER: &str = "REM";
+const COMMENT_MARKER: &str = "REM";
+#[cfg(unix)]
+const COMMENT_MARKER: &str = "#";
+#[cfg(windows)]
+const SET_OR_EXPORT: &str = "SET";
+#[cfg(unix)]
+const SET_OR_EXPORT: &str = "export";
 
 pub fn start(ui: &mut UI,
              ident: &PackageIdent,
@@ -59,7 +64,7 @@ pub fn start(ui: &mut UI,
         Ok(link) => {
             if force && link.src != src {
                 fs::remove_file(&link.dest)?;
-                binlink.link()?;
+                binlink.link(pkg_install.environment_for_command()?)?;
                 ui.end(&ui_binlinked)?;
             } else if link.src != src {
                 ui.warn(format!("Skipping binlink because {} already exists at {}. Use --force \
@@ -71,7 +76,7 @@ pub fn start(ui: &mut UI,
             }
         }
         Err(_) => {
-            binlink.link()?;
+            binlink.link(pkg_install.environment_for_command()?)?;
             ui.end(&ui_binlinked)?;
         }
     }
@@ -135,9 +140,9 @@ pub fn binlink_all_in_pkg(ui: &mut UI,
     Ok(())
 }
 
-fn is_dest_on_path<T: AsRef<Path>>(dest_dir: T) -> bool {
+fn is_dest_on_path(dest_dir: &Path) -> bool {
     if let Some(val) = env::var_os("PATH") {
-        env::split_paths(&val).any(|p| p == dest_dir.as_ref())
+        env::split_paths(&val).any(|p| p == dest_dir)
     } else {
         false
     }
@@ -148,76 +153,96 @@ struct Binlink {
     src:  PathBuf,
 }
 
-#[cfg(not(target_os = "windows"))]
 impl Binlink {
-    pub fn new<T: AsRef<Path>>(src: T, dest_dir: T) -> Result<Self> {
-        let bin_name = match src.as_ref().file_name() {
-            Some(name) => name,
-            None => return Err(Error::CannotParseBinlinkSource(src.as_ref().to_path_buf())),
-        };
-
-        Ok(Self { dest: dest_dir.as_ref().join(bin_name),
-                  src:  src.as_ref().to_path_buf(), })
+    pub fn new(src: &Path, dest_dir: &Path) -> Result<Self> {
+        Ok(Self { dest: Self::binstub_path(&src, dest_dir)?,
+                  src:  src.to_path_buf(), })
     }
 
-    pub fn from_file<T: AsRef<Path>>(dest: T) -> Result<Self> {
-        Ok(Binlink { dest: dest.as_ref().to_path_buf(),
-                     src:  fs::read_link(&dest)?, })
-    }
-
-    pub fn link(&self) -> Result<()> {
-        use crate::hcore::os::filesystem;
-
-        filesystem::symlink(&self.src, &self.dest)?;
-        Ok(())
-    }
-}
-
-#[cfg(target_os = "windows")]
-impl Binlink {
-    pub fn new<T: AsRef<Path>>(src: T, dest_dir: T) -> Result<Self> {
-        let bin_name = match src.as_ref().file_stem() {
-            Some(name) => name,
-            None => return Err(Error::CannotParseBinlinkSource(src.as_ref().to_path_buf())),
-        };
-        let mut path = dest_dir.as_ref().join(bin_name);
-        path.set_extension("bat");
-
-        Ok(Binlink { dest: path,
-                     src:  src.as_ref().to_path_buf(), })
-    }
-
-    pub fn from_file<T: AsRef<Path>>(path: T) -> Result<Self> {
+    pub fn from_file(path: &Path) -> Result<Self> {
         use toml::Value::Table;
 
-        let file = File::open(&path)?;
+        let file = File::open(path)?;
         for line in BufReader::new(file).lines() {
             let ln = line?;
-            if ln.to_uppercase().starts_with(BAT_COMMENT_MARKER) {
-                let (_, rest) = ln.split_at(BAT_COMMENT_MARKER.len());
+            if ln.to_uppercase().starts_with(COMMENT_MARKER) {
+                let (_, rest) = ln.split_at(COMMENT_MARKER.len());
                 if let Ok(Table(toml_exp)) = rest.parse() {
                     if let Some(src) = toml_exp.get("source") {
                         if let Some(val) = src.as_str() {
-                            return Ok(Binlink { dest: path.as_ref().to_path_buf(),
+                            return Ok(Binlink { dest: path.to_path_buf(),
                                                 src:  PathBuf::from(val), });
                         }
                     }
                 }
             }
         }
-        Err(Error::CannotParseBinlinkSource(path.as_ref().to_path_buf()))
+        Err(Error::CannotParseBinlinkSource(path.to_path_buf()))
     }
 
-    pub fn link(&self) -> Result<()> {
-        let template = format!("@echo off\nREM source='{0}'\n\"{0}\" %*",
-                               self.src.display());
-        fs::write(&self.dest, template)?;
-        Ok(())
+    pub fn link(&self, env: HashMap<String, String>) -> Result<()> {
+        #[cfg(windows)]
+        {
+            fs::write(&self.dest, self.stub_template(env).as_bytes())?;
+            Ok(())
+        }
+
+        #[cfg(unix)]
+        {
+            use std::{io::Write,
+                      os::unix::fs::OpenOptionsExt};
+            fs::OpenOptions::new().create(true)
+                                  .write(true)
+                                  .truncate(true)
+                                  .mode(0o775)
+                                  .open(&self.dest)?
+                                  .write_all(self.stub_template(env).as_bytes())?;
+            Ok(())
+        }
+    }
+
+    fn binstub_path(src: &Path, dest_dir: &Path) -> Result<PathBuf> {
+        #[cfg(windows)]
+        {
+            let bin_name = match src.file_stem() {
+                Some(name) => name,
+                None => return Err(Error::CannotParseBinlinkSource(src.to_path_buf())),
+            };
+            let mut path = dest_dir.join(bin_name);
+            path.set_extension("bat");
+            Ok(path)
+        }
+
+        #[cfg(unix)]
+        match src.file_name() {
+            Some(name) => Ok(dest_dir.join(name)),
+            None => Err(Error::CannotParseBinlinkSource(src.to_path_buf())),
+        }
+    }
+
+    fn stub_template(&self, env: HashMap<String, String>) -> String {
+        let mut exports = String::new();
+        for (key, value) in env.into_iter() {
+            exports.push_str(&format!("{} {}={}\n", SET_OR_EXPORT, key, value));
+        }
+
+        #[cfg(windows)]
+        {
+            format!(include_str!("../../../static/template_binstub.bat"),
+                    src = self.src.display(),
+                    env = exports)
+        }
+
+        #[cfg(unix)]
+        {
+            format!(include_str!("../../../static/template_binstub.sh"),
+                    src = self.src.display(),
+                    env = exports)
+        }
     }
 }
 
 #[cfg(test)]
-#[cfg(any(target_os = "linux", target_os = "windows"))]
 mod test {
     use std::{collections::HashMap,
               env,
@@ -276,9 +301,10 @@ mod test {
               &dst_path,
               rootfs.path(),
               force).unwrap();
+        assert!(fs::read_to_string(rootfs_bin_dir.join(magicate_link)).unwrap().contains(&format!("PATH={}", rootfs_src_dir.to_string_lossy())));
         assert_eq!(rootfs_src_dir.join("magicate.exe"),
-                   Binlink::from_file(rootfs_bin_dir.join(magicate_link)).unwrap()
-                                                                         .src);
+                   Binlink::from_file(&rootfs_bin_dir.join(magicate_link)).unwrap()
+                                                                          .src);
 
         start(&mut ui,
               &ident,
@@ -286,9 +312,10 @@ mod test {
               &dst_path,
               rootfs.path(),
               force).unwrap();
+        assert!(fs::read_to_string(rootfs_bin_dir.join(hypnoanalyze_link)).unwrap().contains(&format!("PATH={}", rootfs_src_dir.to_string_lossy())));
         assert_eq!(rootfs_src_dir.join("hypnoanalyze.exe"),
-                   Binlink::from_file(rootfs_bin_dir.join(hypnoanalyze_link)).unwrap()
-                                                                             .src);
+                   Binlink::from_file(&rootfs_bin_dir.join(hypnoanalyze_link)).unwrap()
+                                                                              .src);
     }
 
     #[test]
@@ -325,14 +352,14 @@ mod test {
         binlink_all_in_pkg(&mut ui, &ident, &dst_path, rootfs.path(), force).unwrap();
 
         assert_eq!(rootfs_src_dir.join("bin/magicate.exe"),
-                   Binlink::from_file(rootfs_bin_dir.join(magicate_link)).unwrap()
-                                                                         .src);
+                   Binlink::from_file(&rootfs_bin_dir.join(magicate_link)).unwrap()
+                                                                          .src);
         assert_eq!(rootfs_src_dir.join("bin/hypnoanalyze.exe"),
-                   Binlink::from_file(rootfs_bin_dir.join(hypnoanalyze_link)).unwrap()
-                                                                             .src);
+                   Binlink::from_file(&rootfs_bin_dir.join(hypnoanalyze_link)).unwrap()
+                                                                              .src);
         assert_eq!(rootfs_src_dir.join("sbin/securitize.exe"),
-                   Binlink::from_file(rootfs_bin_dir.join(securitize_link)).unwrap()
-                                                                           .src);
+                   Binlink::from_file(&rootfs_bin_dir.join(securitize_link)).unwrap()
+                                                                            .src);
     }
 
     #[test]
@@ -355,9 +382,9 @@ mod test {
         binlink_all_in_pkg(&mut ui, &ident, &dst_path, rootfs.path(), force).unwrap();
 
         assert_eq!(rootfs_src_dir.join("bin/magicate.exe"),
-                   Binlink::from_file(rootfs_bin_dir.join("magicate.bat")).unwrap()
-                                                                          .src);
-        assert!(Binlink::from_file(rootfs_bin_dir.join("hypnoanalyze.bat")).is_err());
+                   Binlink::from_file(&rootfs_bin_dir.join("magicate.bat")).unwrap()
+                                                                           .src);
+        assert!(Binlink::from_file(&rootfs_bin_dir.join("hypnoanalyze.bat")).is_err());
     }
 
     #[test]
@@ -397,11 +424,11 @@ mod test {
         binlink_all_in_pkg(&mut ui, &ident, &dst_path, rootfs.path(), force).unwrap();
 
         assert_eq!(rootfs_src_dir.join("bin/magicate.exe"),
-                   Binlink::from_file(rootfs_bin_dir.join(magicate_link)).unwrap()
-                                                                         .src);
+                   Binlink::from_file(&rootfs_bin_dir.join(magicate_link)).unwrap()
+                                                                          .src);
         assert_eq!(rootfs_src_dir.join("bin/moar/bonus-round.exe"),
-                   Binlink::from_file(rootfs_bin_dir.join(bonus_round_link)).unwrap()
-                                                                            .src);
+                   Binlink::from_file(&rootfs_bin_dir.join(bonus_round_link)).unwrap()
+                                                                             .src);
     }
 
     fn ui() -> (UI, OutputBuffer, OutputBuffer) {

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
     ArgumentError(&'static str),
     ButterflyError(String),
     CannotParseBinlinkBinaryName(PathBuf),
-    CannotParseBinlinkSource(PathBuf),
+    CannotParseBinlinkTarget(PathBuf),
     CannotRemoveDockerStudio,
     CannotRemoveFromChannel((String, String)),
     CannotRemovePackage(hcore::package::PackageIdent, usize),
@@ -77,8 +77,8 @@ impl fmt::Display for Error {
             Error::CannotParseBinlinkBinaryName(ref p) => {
                 format!("Cannot parse binlink binary name from {}.", p.display())
             }
-            Error::CannotParseBinlinkSource(ref p) => {
-                format!("Cannot parse binlink source path from {}.", p.display())
+            Error::CannotParseBinlinkTarget(ref p) => {
+                format!("Cannot parse binlink target path from {}.", p.display())
             }
             Error::CannotRemoveDockerStudio => {
                 "Docker Studios are not persistent and cannot be removed".to_string()
@@ -186,7 +186,7 @@ impl error::Error for Error {
             Error::ArgumentError(_) => "There was an error parsing an error or with it's value",
             Error::ButterflyError(_) => "Butterfly has had an error",
             Error::CannotParseBinlinkBinaryName(_) => "Cannot parse binlink binary name",
-            Error::CannotParseBinlinkSource(_) => "Cannot parse binlink source path",
+            Error::CannotParseBinlinkTarget(_) => "Cannot parse binlink target path",
             Error::CannotRemoveFromChannel(_) => {
                 "Package cannot be removed from the specified channel"
             }

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -17,6 +17,7 @@ extern crate log;
 extern crate serde_derive;
 
 extern crate serde_json;
+extern crate toml;
 
 #[cfg(windows)]
 extern crate widestring;

--- a/components/hab/static/template_binstub.bat
+++ b/components/hab/static/template_binstub.bat
@@ -1,0 +1,4 @@
+@echo off
+REM source='{src}'
+{env}
+"{src}" %*

--- a/components/hab/static/template_binstub.bat
+++ b/components/hab/static/template_binstub.bat
@@ -1,4 +1,4 @@
 @echo off
-REM source='{src}'
+REM target='{target}'
 {env}
-"{src}" %*
+"{target}" %*

--- a/components/hab/static/template_binstub.sh
+++ b/components/hab/static/template_binstub.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# source='{src}'
+{env}
+exec {src} "$@"

--- a/components/hab/static/template_binstub.sh
+++ b/components/hab/static/template_binstub.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
-# source='{src}'
+#!{interpreter}
+# target='{target}'
 {env}
-exec {src} "$@"
+exec {target} "$@"

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -854,8 +854,7 @@ mod test {
         use super::{super::*,
                     *};
         use crate::common::ui::UI;
-        use std::{fs,
-                  io::{self,
+        use std::{io::{self,
                        Cursor,
                        Write},
                   sync::{Arc,
@@ -889,6 +888,8 @@ mod test {
         #[cfg(unix)]
         #[test]
         fn link_binaries() {
+            use std::fs;
+
             let rootfs = TempDir::new().unwrap();
             let (mut ui, ..) = ui();
             let base_pkgs = base_pkgs(rootfs.path());

--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -854,7 +854,8 @@ mod test {
         use super::{super::*,
                     *};
         use crate::common::ui::UI;
-        use std::{io::{self,
+        use std::{fs,
+                  io::{self,
                        Cursor,
                        Write},
                   sync::{Arc,
@@ -894,19 +895,15 @@ mod test {
             build_spec().link_binaries(&mut ui, rootfs.path(), &base_pkgs)
                         .unwrap();
 
-            assert_eq!(hcore::fs::pkg_install_path(base_pkgs.busybox.as_ref().unwrap(),
-                                                   None::<&Path>).join("bin/busybox"),
-                       rootfs.path().join("bin/busybox").read_link().unwrap(),
-                       "busybox program is symlinked into /bin");
-            assert_eq!(
-                hcore::fs::pkg_install_path(&base_pkgs.busybox.unwrap(), None::<&Path>)
-                    .join("bin/sh"),
-                rootfs.path().join("bin/sh").read_link().unwrap(),
-                "busybox's sh program is symlinked into /bin"
-            );
-            assert_eq!(hcore::fs::pkg_install_path(&base_pkgs.hab, None::<&Path>).join("bin/hab"),
-                       rootfs.path().join("bin/hab").read_link().unwrap(),
-                       "hab program is symlinked into /bin");
+            assert!(fs::read_to_string(rootfs.path().join("bin/busybox")).unwrap().contains(hcore::fs::pkg_install_path(base_pkgs.busybox.as_ref().unwrap(),
+                                                   None::<&Path>).join("bin/busybox").to_str().unwrap()),
+                       "busybox program is binlinked into /bin");
+            assert!(fs::read_to_string(rootfs.path().join("bin/sh")).unwrap().contains(hcore::fs::pkg_install_path(&base_pkgs.busybox.unwrap(),
+                                                   None::<&Path>).join("bin/sh").to_str().unwrap()),
+                       "busybox's sh program is binlinked into /bin");
+            assert!(fs::read_to_string(rootfs.path().join("bin/hab")).unwrap().contains(hcore::fs::pkg_install_path(&base_pkgs.hab,
+                                                   None::<&Path>).join("bin/hab").to_str().unwrap()),
+                       "hab program is binlinked into /bin");
         }
 
         #[cfg(unix)]

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -27,7 +27,7 @@ find . -type f \
       -or -exec sh -c 'file -b "$1" | grep -q "shell script"' -- {} \; \) \
   -and \! -path "*.sample" \
   -and \! -path "*.ps1" \
-  -and \! -path "./components/hab/static/template_plan.sh" \
+  -and \! -path "./components/hab/static/*" \
   -and \! -path "./target/*" \
   -and \! -path "./test/integration/helpers.bash" \
   -and \! -path "./test/integration/test_helper/bats-assert/*" \


### PR DESCRIPTION
This can be considered a continuation of #6670 which was reverted after we found that the binstubs in a linux studio were resulting in recursive symlinks. This is because the binstub interpreter is `/bin/sh` and if you binlinked a package including `sh`, it would link to itself as an interpreter.

Note: To tease out what changed between this PR and the original #6670, you may just want to look at the commit(s) after the first one that reverts the revert.

In summary, this makes the following changes:
* changes the interpreter from `/bin/sh` to the source of the link IF the link destination is also `/bin/sh`.
* Look for symlinks when checking for existing links. This will catch links from previous versions or one that was maybe manually created. Because we were not looking for these before, we were not removing the existing the link and thus writing the binstub was following the link and overwriting the source binary.
* overwrite existing links with `--force` even if the source binary path matches. This will allow a user to overwrite the old style links with these new ones if they want.
* Append the existing `PATH` to the `PATH` being set in the link

### Notes on appending existing `PATH`
There are some scenarios where a binary may need something on the path that could never be anticipated at build time. Examples would be:
* `sh`/`bash` where a script needs stuff on the path unrelated to bash itself
* `rust` where a `build.rs` expects something on the path unrelated to `cargo`
* `inspec` where it calls into `Windows Powershell` (not PS Core) that installs with windows and is not packaged.

The current binlinking behavior simply symlinks binaries to a known directory on the `PATH` (`/bin` by default) and therefore they include whatever is currently on the `PATH` so limiting the `PATH` to the binary's runtime deps could potentially be a breaking change but should work in the vast majority of cases.

Note that both the Supervisor and the build system also retain the existing `PATH` entries when running package hooks and building a plan. `hab pkg exec` does not but there is an [issue](https://github.com/habitat-sh/habitat/issues/6657) proposing that we append the existing `PATH` entries for `hab pkg exec` as well.