### PR TITLE
Refactor DatFile, again

### DIFF
--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -529,9 +529,10 @@ mod tests {
         original.insert_offset_for_rumor(Departure::MESSAGE_ID, rand::random::<u64>());
 
         let bytes = original.write_to_bytes();
-        let (size_of_header, restored) = Header::from_bytes(&bytes, HEADER_VERSION);
-        assert_eq!(bytes.len() as u64, size_of_header);
-        assert_eq!(original, restored);
+        let restored = Header::from_bytes(&bytes, HEADER_VERSION);
+        assert_eq!(bytes.len() as u64, restored.size);
+        assert_eq!(original.offsets, restored.offsets);
+        assert_eq!(original.version, restored.version);
     }
 
     /// This has to actually touch the file system because the nature of the bug its testing

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -75,14 +75,17 @@ impl DatFile {
                               update_store: &RumorStore<ElectionUpdate>,
                               departure_store: &RumorStore<Departure>)
                               -> Result<Self> {
-        let file = OpenOptions::new().create(true)
-                                     .read(true)
-                                     .write(true)
-                                     .open(&data_path)
-                                     .map_err(|err| Error::DatFileIO(data_path.clone(), err))?;
-        let size = file.metadata()
-                       .map_err(|err| Error::DatFileIO(data_path.clone(), err))?
-                       .len();
+        let size = {
+            let file = OpenOptions::new().create(true)
+                                         .read(true)
+                                         .write(true)
+                                         .open(&data_path)
+                                         .map_err(|err| Error::DatFileIO(data_path.clone(), err))?;
+            file.metadata()
+                .map_err(|err| Error::DatFileIO(data_path.clone(), err))?
+                .len()
+        };
+
         let mut dat_file = DatFile { path:   data_path,
                                      header: Header::default(), };
 

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -548,14 +548,14 @@ mod tests {
 
         assert!(!file_path.exists());
 
-        let result = DatFile::read_or_create_mlr(file_path.to_path_buf(),
-                                                 &MemberList::new(),
-                                                 &RumorStore::default(),
-                                                 &RumorStore::default(),
-                                                 &RumorStore::default(),
-                                                 &RumorStore::default(),
-                                                 &RumorStore::default(),
-                                                 &RumorStore::default());
+        let result = DatFileReader::read_or_create_mlr(file_path.to_path_buf(),
+                                                       &MemberList::new(),
+                                                       &RumorStore::default(),
+                                                       &RumorStore::default(),
+                                                       &RumorStore::default(),
+                                                       &RumorStore::default(),
+                                                       &RumorStore::default(),
+                                                       &RumorStore::default());
 
         assert!(result.is_ok(), "{}", result.unwrap_err());
         assert!(file_path.is_file());

--- a/components/rst-reader/src/main.rs
+++ b/components/rst-reader/src/main.rs
@@ -13,7 +13,7 @@ use habitat_butterfly::rumor::{dat_file,
                                ServiceConfig,
                                ServiceFile};
 use log::error;
-use std::{path::Path,
+use std::{path::PathBuf,
           process};
 
 pub mod error;
@@ -35,12 +35,12 @@ fn main() {
 
     let file = matches.value_of("FILE").unwrap();
     let stats = matches.is_present("STATS");
-    let dat_file = dat_file::DatFileReader::read(Path::new(file)).unwrap_or_else(|e| {
-                                                                     error!("Could not read dat \
-                                                                             file {}: {}",
-                                                                            file, e);
-                                                                     process::exit(1);
-                                                                 });
+    let dat_file = dat_file::DatFileReader::read(PathBuf::from(file)).unwrap_or_else(|e| {
+                                                                         error!("Could not read \
+                                                                                 dat file {}: {}",
+                                                                                file, e);
+                                                                         process::exit(1);
+                                                                     });
 
     let result = if stats {
         output_stats(dat_file)

--- a/components/rst-reader/src/main.rs
+++ b/components/rst-reader/src/main.rs
@@ -35,12 +35,12 @@ fn main() {
 
     let file = matches.value_of("FILE").unwrap();
     let stats = matches.is_present("STATS");
-    let dat_file = dat_file::DatFile::read(Path::new(file)).unwrap_or_else(|e| {
-                                                               error!("Could not read dat file \
-                                                                       {}: {}",
-                                                                      file, e);
-                                                               process::exit(1);
-                                                           });
+    let dat_file = dat_file::DatFileReader::read(Path::new(file)).unwrap_or_else(|e| {
+                                                                     error!("Could not read dat \
+                                                                             file {}: {}",
+                                                                            file, e);
+                                                                     process::exit(1);
+                                                                 });
 
     let result = if stats {
         output_stats(dat_file)
@@ -54,42 +54,39 @@ fn main() {
     }
 }
 
-fn output_rumors(mut dat_file: dat_file::DatFile) -> Result<()> {
-    let mut reader = dat_file.reader()?;
-
-    for member in dat_file.read_members(&mut reader)? {
+fn output_rumors(mut dat_file: dat_file::DatFileReader) -> Result<()> {
+    for member in dat_file.read_members()? {
         println!("{}", member);
     }
 
-    for service in dat_file.read_rumors::<Service>(&mut reader)? {
+    for service in dat_file.read_rumors::<Service>()? {
         println!("{}", service);
     }
 
-    for service_config in dat_file.read_rumors::<ServiceConfig>(&mut reader)? {
+    for service_config in dat_file.read_rumors::<ServiceConfig>()? {
         println!("{}", service_config);
     }
 
-    for service_file in dat_file.read_rumors::<ServiceFile>(&mut reader)? {
+    for service_file in dat_file.read_rumors::<ServiceFile>()? {
         println!("{}", service_file);
     }
 
-    for election in dat_file.read_rumors::<Election>(&mut reader)? {
+    for election in dat_file.read_rumors::<Election>()? {
         println!("{}", election);
     }
 
-    for update_election in dat_file.read_rumors::<ElectionUpdate>(&mut reader)? {
+    for update_election in dat_file.read_rumors::<ElectionUpdate>()? {
         println!("{}", update_election);
     }
 
-    for departure in dat_file.read_rumors::<Departure>(&mut reader)? {
+    for departure in dat_file.read_rumors::<Departure>()? {
         println!("{}", departure);
     }
 
     Ok(())
 }
 
-fn output_stats(mut dat_file: dat_file::DatFile) -> Result<()> {
-    let mut reader = dat_file.reader()?;
+fn output_stats(mut dat_file: dat_file::DatFileReader) -> Result<()> {
     let mut membership = 0;
     let mut services = 0;
     let mut service_configs = 0;
@@ -98,13 +95,13 @@ fn output_stats(mut dat_file: dat_file::DatFile) -> Result<()> {
     let mut update_elections = 0;
     let mut departures = 0;
 
-    membership += dat_file.read_members(&mut reader)?.len();
-    services += dat_file.read_rumors::<Service>(&mut reader)?.len();
-    service_configs += dat_file.read_rumors::<ServiceConfig>(&mut reader)?.len();
-    service_files += dat_file.read_rumors::<ServiceFile>(&mut reader)?.len();
-    elections += dat_file.read_rumors::<Election>(&mut reader)?.len();
-    update_elections += dat_file.read_rumors::<ElectionUpdate>(&mut reader)?.len();
-    departures += dat_file.read_rumors::<Departure>(&mut reader)?.len();
+    membership += dat_file.read_members()?.len();
+    services += dat_file.read_rumors::<Service>()?.len();
+    service_configs += dat_file.read_rumors::<ServiceConfig>()?.len();
+    service_files += dat_file.read_rumors::<ServiceFile>()?.len();
+    elections += dat_file.read_rumors::<Election>()?.len();
+    update_elections += dat_file.read_rumors::<ElectionUpdate>()?.len();
+    departures += dat_file.read_rumors::<Departure>()?.len();
 
     println!("Summary:");
     println!();

--- a/components/rst-reader/src/main.rs
+++ b/components/rst-reader/src/main.rs
@@ -55,31 +55,33 @@ fn main() {
 }
 
 fn output_rumors(mut dat_file: dat_file::DatFile) -> Result<()> {
-    for member in dat_file.read_members()? {
+    let mut reader = dat_file.reader()?;
+
+    for member in dat_file.read_members(&mut reader)? {
         println!("{}", member);
     }
 
-    for service in dat_file.read_rumors::<Service>()? {
+    for service in dat_file.read_rumors::<Service>(&mut reader)? {
         println!("{}", service);
     }
 
-    for service_config in dat_file.read_rumors::<ServiceConfig>()? {
+    for service_config in dat_file.read_rumors::<ServiceConfig>(&mut reader)? {
         println!("{}", service_config);
     }
 
-    for service_file in dat_file.read_rumors::<ServiceFile>()? {
+    for service_file in dat_file.read_rumors::<ServiceFile>(&mut reader)? {
         println!("{}", service_file);
     }
 
-    for election in dat_file.read_rumors::<Election>()? {
+    for election in dat_file.read_rumors::<Election>(&mut reader)? {
         println!("{}", election);
     }
 
-    for update_election in dat_file.read_rumors::<ElectionUpdate>()? {
+    for update_election in dat_file.read_rumors::<ElectionUpdate>(&mut reader)? {
         println!("{}", update_election);
     }
 
-    for departure in dat_file.read_rumors::<Departure>()? {
+    for departure in dat_file.read_rumors::<Departure>(&mut reader)? {
         println!("{}", departure);
     }
 
@@ -87,6 +89,7 @@ fn output_rumors(mut dat_file: dat_file::DatFile) -> Result<()> {
 }
 
 fn output_stats(mut dat_file: dat_file::DatFile) -> Result<()> {
+    let mut reader = dat_file.reader()?;
     let mut membership = 0;
     let mut services = 0;
     let mut service_configs = 0;
@@ -95,13 +98,13 @@ fn output_stats(mut dat_file: dat_file::DatFile) -> Result<()> {
     let mut update_elections = 0;
     let mut departures = 0;
 
-    membership += dat_file.read_members()?.len();
-    services += dat_file.read_rumors::<Service>()?.len();
-    service_configs += dat_file.read_rumors::<ServiceConfig>()?.len();
-    service_files += dat_file.read_rumors::<ServiceFile>()?.len();
-    elections += dat_file.read_rumors::<Election>()?.len();
-    update_elections += dat_file.read_rumors::<ElectionUpdate>()?.len();
-    departures += dat_file.read_rumors::<Departure>()?.len();
+    membership += dat_file.read_members(&mut reader)?.len();
+    services += dat_file.read_rumors::<Service>(&mut reader)?.len();
+    service_configs += dat_file.read_rumors::<ServiceConfig>(&mut reader)?.len();
+    service_files += dat_file.read_rumors::<ServiceFile>(&mut reader)?.len();
+    elections += dat_file.read_rumors::<Election>(&mut reader)?.len();
+    update_elections += dat_file.read_rumors::<ElectionUpdate>(&mut reader)?.len();
+    departures += dat_file.read_rumors::<Departure>(&mut reader)?.len();
 
     println!("Summary:");
     println!();


### PR DESCRIPTION
It turns out that when DatFile owns the BufReader, it keeps the file
open and prevents AtomicWriter from renaming the file on Windows.
Previously, a single BufReader was created and passed around between all
the different functions and that is the solution I've gone back to here
as well.

![](https://media.giphy.com/media/X92pmIty2ZJp6/giphy.gif)

At first, I thought it should be possible to just create a BufReader
whenever necessary, but it turns out that BufReader keeps track of where
it is in the file, and our current implementation is dependent on
reading the rumors in the same order that they're written in.

![](https://media.giphy.com/media/uq6ILNBI6g3As/giphy.gif)

Since we store the offsets for all the different rumors, in theory it
should be possible to use that to calculate where to go and how much to
read, but in practice, it proved trickier to implement correctly than
I had originally anticipated.

![](https://media.giphy.com/media/xUySTCy0JHxUxw4fao/giphy.gif)

In the interest of time and sanity, we now pass the same BufReader
around, like we used to. Eventually, when someone has the time and
energy, this whole module should be overhauled.

![](https://media.giphy.com/media/5nsiFjdgylfK3csZ5T/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>