### PR TITLE
Stop health check futures when upgrading the Supervisor

### DIFF
--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1065,7 +1065,17 @@ impl Manager {
         ctl_shutdown_tx.send(()).ok();
 
         match shutdown_mode {
-            ShutdownMode::Restarting => {}
+            ShutdownMode::Restarting => {
+                outputln!("Preparing services for Supervisor restart");
+                for (_ident, svc) in self.state
+                                         .services
+                                         .write()
+                                         .expect("Services lock is poisoned!")
+                                         .iter_mut()
+                {
+                    svc.detach();
+                }
+            }
             ShutdownMode::Normal | ShutdownMode::Departed => {
                 outputln!("Gracefully departing from butterfly network.");
                 self.butterfly.set_departed_mlw();

--- a/test/end-to-end/hup-does-not-abandon-services.exp
+++ b/test/end-to-end/hup-does-not-abandon-services.exp
@@ -72,6 +72,10 @@ expect {
     }
 }
 
+# Let the control gateway come up. :/
+# Alternatively, use `nc -wv localhost 9632`
+sleep 1
+
 # Load up Redis on that Supervisor
 spawn hab svc load core/redis
 expect {
@@ -115,7 +119,7 @@ expect {
     }
 }
 expect {
-    "Reattached to redis.default" {
+    "Reattaching to redis.default" {
         log "Supervisor reattached"
     }
     timeout {


### PR DESCRIPTION
When we shut down the Supervisor normally, we stop the long-running
control gateway future, and then spawn a bunch of service shutdown
futures. Those aren't "infinite" futures, so they'll eventually be
driven to completion. Then, we just wait for all the futures on the
reactor to finish and we shut down.

When we shut down for a Supervisor upgrade, however, we _don't_ shut
down the services. Since their health checks now run in an infinite
future, these futures will effectively prevent the Supervisor from
shutting down.

This commit introduces a "detach" method for services, which is now
called in the Supervisor upgrade scenario. It currently just stops
health checks, but can be augmented to do more as we transition more
functionality over to asynchronous futures.

Similarly, the existing "reattach" logic is now extracted into a
"reattach" method, which will now restart health checking.

Fixes #6712

Signed-off-by: Christopher Maier <cmaier@chef.io>