### PR TITLE
Add unrunnable services

### DIFF
--- a/components/sup-protocol/build.rs
+++ b/components/sup-protocol/build.rs
@@ -22,6 +22,8 @@ use prost_types::{DescriptorProto,
                   FileDescriptorProto,
                   FileDescriptorSet};
 
+const GENERATED_OUT_DIR: &'static str = "src/generated";
+
 type Module = Vec<String>;
 
 fn main() {
@@ -34,6 +36,7 @@ fn generate_protocols() {
     let mut config = prost_build::Config::new();
     config.type_attribute(".", "#[derive(Serialize, Deserialize)]");
     config.type_attribute(".", "#[serde(rename_all = \"kebab-case\")]");
+    config.out_dir(GENERATED_OUT_DIR);
     config.compile_protos(&protocol_files(), &protocol_includes())
           .expect("protocols");
     compile_proto_impls(&protocol_files(), &protocol_includes()).expect("protocol-impls");
@@ -59,7 +62,7 @@ fn protocol_includes() -> Vec<String> { vec!["protocols".to_string()] }
 fn compile_proto_impls<P>(protos: &[P], includes: &[P]) -> Result<()>
     where P: AsRef<Path>
 {
-    let target = PathBuf::from("src/generated");
+    let target = PathBuf::from(GENERATED_OUT_DIR);
     let tmp = tempfile::TempDir::new()?;
     let descriptor_set = tmp.path().join("prost-descriptor-set");
 

--- a/components/sup-protocol/protocols/types.proto
+++ b/components/sup-protocol/protocols/types.proto
@@ -95,6 +95,12 @@ message ServiceStatus {
   optional DesiredState desired_state = 5;
 }
 
+message UnrunnableServiceStatus {
+  required PackageIdent ident = 1;
+  // A description of why this service failed
+  required string error = 2;
+}
+
 message HealthCheckInterval {
   required uint64 seconds = 1;
 }

--- a/components/sup-protocol/src/generated/sup.types.impl.rs
+++ b/components/sup-protocol/src/generated/sup.types.impl.rs
@@ -21,6 +21,9 @@ impl message::MessageStatic for ServiceGroup {
 impl message::MessageStatic for ServiceStatus {
     const MESSAGE_ID: &'static str = "ServiceStatus";
 }
+impl message::MessageStatic for UnrunnableServiceStatus {
+    const MESSAGE_ID: &'static str = "UnrunnableServiceStatus";
+}
 impl message::MessageStatic for HealthCheckInterval {
     const MESSAGE_ID: &'static str = "HealthCheckInterval";
 }

--- a/components/sup-protocol/src/generated/sup.types.rs
+++ b/components/sup-protocol/src/generated/sup.types.rs
@@ -90,6 +90,16 @@ pub struct ServiceStatus {
 #[derive(Clone, PartialEq, ::prost::Message)]
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+pub struct UnrunnableServiceStatus {
+    #[prost(message, required, tag="1")]
+    pub ident: PackageIdent,
+    /// A description of why this service failed
+    #[prost(string, required, tag="2")]
+    pub error: std::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct HealthCheckInterval {
     #[prost(uint64, required, tag="1")]
     pub seconds: u64,

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -280,6 +280,7 @@ impl Server {
 
 fn services_routes() -> Scope {
     web::scope("/services").route("", web::get().to(services))
+                           .route("/unrunnable", web::get().to(unrunnable_services))
                            .route("/{svc}/{group}", web::get().to(service_without_org))
                            .route("/{svc}/{group}/config", web::get().to(config_without_org))
                            .route("/{svc}/{group}/health", web::get().to(health_without_org))
@@ -330,6 +331,15 @@ fn services(state: Data<AppState>) -> HttpResponse {
                      .read()
                      .expect("GatewayState lock is poisoned")
                      .services_data;
+    json_response(data.to_string())
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn unrunnable_services(state: Data<AppState>) -> HttpResponse {
+    let data = &state.gateway_state
+                     .read()
+                     .expect("GatewayState lock is poisoned")
+                     .unrunnable_services_data;
     json_response(data.to_string())
 }
 

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -353,6 +353,7 @@ pub fn service_status(mgr: &ManagerState,
                       req: &mut CtlRequest,
                       opts: protocol::ctl::SvcStatus)
                       -> NetResult<()> {
+    #[allow(clippy::large_enum_variant)]
     enum StatusWrapper {
         Status(ServiceStatus),
         FailedStatus(UnrunnableService),
@@ -369,10 +370,10 @@ pub fn service_status(mgr: &ManagerState,
     let unrunnable_statuses: Vec<UnrunnableService> =
         serde_json::from_str(&unrunnable_services_data).map_err(Error::ServiceDeserializationError)?;
     let mut all_statuses = statuses.into_iter()
-                                   .map(|s| StatusWrapper::Status(s))
+                                   .map(StatusWrapper::Status)
                                    .collect::<Vec<_>>();
     all_statuses.extend(unrunnable_statuses.into_iter()
-                                           .map(|s| StatusWrapper::FailedStatus(s)));
+                                           .map(StatusWrapper::FailedStatus));
 
     if let Some(ident) = opts.ident {
         for status in all_statuses {


### PR DESCRIPTION
Resolves #4494

This does not fix the core issue of #4494. That was already fixed by previous refactoring. Instead, this PR fixes `hab status` not reporting all loaded services. This problem is alluded to in #4494. The problem is explained concretely below.  

## The Problem
If I have a package `dem/test` that has one bind `database`, after running `hab svc load dem/test` I get the following messages
- the supervisor says `Unable to start dem/test, Missing required bind(s), database`
- `hab svc status` says `No services loaded.`
- `hab svc load dem/test --bind database:redis.default` fails with `Service already loaded, unload 'dem/test' and try again`

After explicitly unloading `dem/test` or loading with `--force` the service successfully starts. However, it seems incorrect that I get contradictory messages: one stating there are no services loaded and another that `dem/test` is already loaded.

## Solution
Previously, I was under the impression a service could be in one of three states: `LoadedUp`, `LoadedDown`, and `Unloaded`. This PR acknowledges that there is really a forth state `LoadedUnrunnable`. This state occurs when a service's spec file cannot be loaded. One way to get into this state is unsatisfied binds like in the example above. The majority of this PR is simply tracking what services are in the `LoadedUnrunnable` state and adding the plumbing necessary to get this information to those who care about it. Previously `hab status` provided no information on services in the `LoadedAndUnrunnable` state.

I am not overly enthusiastic about this solution. I would have preferred to simplify the problem and completely disallow the `LoadedUnrunnable` state. At first, this seems straightforward. We simply fail the load if binds are not met. Unfortunately, we can also get in this state following a package update if the new version added binds. One solution would be to automatically unload a service that entered this state, but I thought from a UX perspective that was too surprising. I would love to hear other solutions and thoughts.

## New Behavior
For the example above, `hab status` would now output the following:
```
package                           type        desired  state   elapsed (s)  pid     group           error
core/etcd/v3.3.10/20190305234020  standalone  up       up      52           24866   etcd.default    <none>
core/consul/1.5.2/20190701155502  standalone  up       up      52           24892   consul.default  <none>
dem/test                          standalone  <none>   <none>  <none>       <none>  <none>          Missing required bind(s), database
```
This addes a new `error` column that allows services in the `LoadedUnrunnable` state a place to report why they are unrunnable

## Questions for Reviewers
- This [comment](https://github.com/habitat-sh/habitat/blob/b57cb638461c9db4511667c277874f61a28b9412/components/hab/src/main.rs#L1597) implies that the output of `hab status` needs to be machine-readable. Is this the case? Do special considerations need to be made for the addition of the `error` column?
- I needed to add [this line](https://github.com/habitat-sh/habitat/blob/b57cb638461c9db4511667c277874f61a28b9412/components/sup-protocol/build.rs#L39) to make the build correctly output protocol buffer types. Could someone verify that this is in fact necessary? This should probably have been in a different commit?
- I added a `/services/unrunnable` http endpoint [here](https://github.com/habitat-sh/habitat/blob/b57cb638461c9db4511667c277874f61a28b9412/components/sup/src/http_gateway.rs#L283). I have no specific use for this so maybe it should be removed, but I was mirroring what the `/services` endpoint does. 

Signed-off-by: David McNeil <mcneil.david2@gmail.com>