### PR TITLE
Do not allow unrunnable services

### DIFF
--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -283,10 +283,15 @@ impl From<habitat_api_client::Error> for Error {
     fn from(err: habitat_api_client::Error) -> Error { Error::APIClient(err) }
 }
 
-// TODO (CM): not sure if this works or not
 impl From<Error> for habitat_sup_protocol::net::NetErr {
     fn from(err: Error) -> habitat_sup_protocol::net::NetErr {
-        habitat_sup_protocol::net::err(habitat_sup_protocol::net::ErrCode::Internal, err)
+        match err {
+            Error::MissingRequiredBind(_) | Error::InvalidBinds(_) => {
+                habitat_sup_protocol::net::err(habitat_sup_protocol::net::ErrCode::InvalidPayload,
+                                               err)
+            }
+            _ => habitat_sup_protocol::net::err(habitat_sup_protocol::net::ErrCode::Internal, err),
+        }
     }
 }
 

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -209,11 +209,7 @@ pub fn service_load(mgr: &ManagerState,
     // If a package exists on disk that satisfies the desired package identifier, it will be used.
     // Otherwise, we'll install the latest suitable version from the specified Builder channel.
     let package = util::pkg::satisfy_or_install(req, &source, &spec.bldr_url, &spec.channel)?;
-    if let Err(e) = spec.validate(&package) {
-        return Err(net::err(ErrCode::InvalidPayload,
-                            format!("Failed to validate '{}' due to '{}'",
-                                    ident, e)));
-    }
+    spec.validate(&package)?;
     mgr.cfg.save_spec_for(&spec)?;
 
     req.info(format!("The {} service was successfully loaded", spec.ident))?;

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -205,7 +205,12 @@ pub fn service_load(mgr: &ManagerState,
             // desired package identifier, it will be used;
             // otherwise, we'll install the latest suitable
             // version from the specified Builder channel.
-            util::pkg::satisfy_or_install(req, &source, &bldr_url, &bldr_channel)?;
+            let package = util::pkg::satisfy_or_install(req, &source, &bldr_url, &bldr_channel)?;
+            if let Err(e) = spec.validate(&package) {
+                return Err(net::err(ErrCode::InvalidPayload,
+                                    format!("Failed to validate '{}' due to '{}'",
+                                            ident, e)));
+            }
 
             mgr.cfg.save_spec_for(&spec)?;
             req.info(format!("The {} service was successfully loaded", spec.ident))?;
@@ -233,7 +238,13 @@ pub fn service_load(mgr: &ManagerState,
             //
             // Also make sure you're pulling from where you're
             // supposed to be pulling from!
-            util::pkg::satisfy_or_install(req, &source, &spec.bldr_url, &spec.channel)?;
+            let package =
+                util::pkg::satisfy_or_install(req, &source, &spec.bldr_url, &spec.channel)?;
+            if let Err(e) = spec.validate(&package) {
+                return Err(net::err(ErrCode::InvalidPayload,
+                                    format!("Failed to validate '{}' due to '{}'",
+                                            ident, e)));
+            }
 
             mgr.cfg.save_spec_for(&spec)?;
             req.info(format!("The {} service was successfully loaded", spec.ident))?;

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -186,14 +186,10 @@ pub fn service_load(mgr: &ManagerState,
     let ident: PackageIdent = opts.ident.clone().ok_or_else(err_update_client)?.into();
     let source = InstallSource::Ident(ident.clone(), PackageTarget::active_target());
     let mut spec = if let Some(spec) = mgr.cfg.spec_for_ident(source.as_ref()) {
-        let force = opts.force.unwrap_or(false);
-        // We've seen this service  before. Thus `load`
-        // basically acts as a way to edit spec files on the
-        // command line. As a result, we a) check that you
-        // *really* meant to change an existing spec, and b) DO
-        // NOT download a potentially new version of the package
-        // in question
-        if !force {
+        // We've seen this service before. Thus `load` basically acts as a way to edit spec files on
+        // the command line. As a result, we check that you *really* meant to change an existing
+        // spec.
+        if !opts.force.unwrap_or(false) {
             return Err(net::err(ErrCode::Conflict,
                                 format!("Service already loaded, unload '{}' \
                                          and try again",

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -238,6 +238,16 @@ pub fn service_load(mgr: &ManagerState,
             //
             // Also make sure you're pulling from where you're
             // supposed to be pulling from!
+
+            // TODO (DM): Why do we use `spec.bldr_url` and `spec.channel` here?
+            // `opts.into_spec` will override these fields if they are defined in the `ServiceLoad`
+            // so we are essentially always using `bldr_url` and `bldr_channel`. In fact `bldr_url`
+            // and `bldr_channel` are not even neccessary, we could just always use what
+            // is in `spec` because `opts.into_spec` will set it appropriatly.
+            // Potentially, I could see the reason for the use of `spec` here trying to
+            // prevent updating the `bldr_url` and `channel` on a --force reload, but that
+            // is not the current behavior. With this change this method could be greatly
+            // simplified.
             let package =
                 util::pkg::satisfy_or_install(req, &source, &spec.bldr_url, &spec.channel)?;
             if let Err(e) = spec.validate(&package) {

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -162,10 +162,9 @@ pub struct ServiceSpec {
 
 impl ServiceSpec {
     pub fn default_for(ident: PackageIdent) -> Self {
-        let mut spec = Self::default();
-        spec.ident = ident;
-        spec.bldr_url = habitat_sup_protocol::DEFAULT_BLDR_URL.to_string();
-        spec
+        Self { ident,
+               bldr_url: DEFAULT_BLDR_URL.to_string(),
+               ..Default::default() }
     }
 
     fn to_toml_string(&self) -> Result<String> {

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -164,6 +164,7 @@ impl ServiceSpec {
     pub fn default_for(ident: PackageIdent) -> Self {
         let mut spec = Self::default();
         spec.ident = ident;
+        spec.bldr_url = habitat_sup_protocol::DEFAULT_BLDR_URL.to_string();
         spec
     }
 


### PR DESCRIPTION
Resolves #4494

For background please see my [first attempt](https://github.com/habitat-sh/habitat/pull/6719). Overall, I believe this is a much better solution. However, it does change existing behavior as described below.

The change consists of two steps that can be followed in the commit history.

1. Disallow the `LoadedAndUnrunnable` service state. This state would occur when [loading a service](https://github.com/habitat-sh/habitat/blob/128f5429d54031f563f0c57fd076930836a9cede/components/sup/src/manager.rs#L1276) would fail, but we would swallow the error and keep the package loaded. Now if the load fails the service is automatically unloaded. The two primary conditions in which a load can fail are 1. if the spec file cannot be found and 2. if the service has unsatisfied binds.
2. Do not allow loading a service with unsatisfied binds. As a result of 1, if a service was loaded with unsatisfied binds it would be immediately unloaded, but the cli would still show the message `service was successfully loaded`. This seemed like very bad UX. Now the cli gives an error when trying to load a service with unsatisfied binds.

Note, a service can still be automatically unloaded for unsatisfied binds if a package update adds binds. Does this seem like reasonable behavior?