### PR TITLE
[hab] Allow flexible whitespace in HAB_DOCKER_OPTS

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -226,7 +226,7 @@ fn run_container<I, J, S, T>(docker_cmd: PathBuf,
 
     if let Ok(opts) = henv::var(DOCKER_OPTS_ENVVAR) {
         let opts = opts
-            .split(' ')
+            .split_whitespace()
             .map(|v| v.into())
             // Ensure we're not passing something like `--tty` again here.
             .filter(|v| !cmd_args.contains(v))


### PR DESCRIPTION
This partially fixes #5115. To fix it completely, we would have to lex
the string to identify quoted whitespace.

But, I think this improves the common case at a rather low cost.

Signed-off-by: Steven Danna <steve@chef.io>