### PR TITLE
Convert all our manual whitespace splitting to use split_whitespace()

### DIFF
--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -265,7 +265,7 @@ impl PackageArchive {
     pub fn exposes(&mut self) -> Result<Vec<u16>> {
         match self.read_metadata(MetaFile::Exposes) {
             Ok(Some(data)) => {
-                let ports: Vec<u16> = data.split(' ')
+                let ports: Vec<u16> = data.split_whitespace()
                                           .filter_map(|port| port.parse::<u16>().ok())
                                           .collect();
                 Ok(ports)

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -299,7 +299,7 @@ impl PackageInstall {
                         None => return Err(Error::MetaFileBadBind),
                     };
                     let binds: Result<Vec<BindMapping>> = match parts.next() {
-                        Some(binds) => binds.split(' ').map(str::parse).collect(),
+                        Some(binds) => binds.split_whitespace().map(str::parse).collect(),
                         None => Err(Error::MetaFileBadBind),
                     };
                     bind_map.insert(package, binds?);
@@ -365,7 +365,7 @@ impl PackageInstall {
     pub fn exposes(&self) -> Result<Vec<String>> {
         match self.read_metafile(MetaFile::Exposes) {
             Ok(body) => {
-                let v: Vec<String> = body.split(' ')
+                let v: Vec<String> = body.split_whitespace()
                                          .map(|x| String::from(x.trim_end_matches('\n')))
                                          .collect();
                 Ok(v)

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -47,7 +47,7 @@ impl FromStr for Bind {
         };
         let exports = match parts.next() {
             None => return Err(Error::MetaFileBadBind),
-            Some(exports) => exports.split(' ').map(str::to_string).collect(),
+            Some(exports) => exports.split_whitespace().map(str::to_string).collect(),
         };
         Ok(Bind { service, exports })
     }

--- a/components/launcher/src/server.rs
+++ b/components/launcher/src/server.rs
@@ -526,10 +526,10 @@ fn setup_connection(server: IpcOneShotServer<Vec<u8>>) -> Result<(Receiver, Send
 /// hab-sup 0.62.0-dev
 fn is_supported_supervisor_version(version_output: &str) -> bool {
     if let Some(version_str) = version_output
-        .split(' ') //                      ["hab-sup", <version-number>]
-        .last() //                          drop "hab-sup", keep <version-number>
-        .unwrap() //                        split() always returns an 1+ element iterator
-        .split(|c| c == '/' || c == '-') // strip "-dev" or "/build"
+        .split_whitespace()                 // ["hab-sup", <version-number>]
+        .last()                             // drop "hab-sup", keep <version-number>
+        .unwrap()                           // split() always returns an 1+ element iterator
+        .split(|c| c == '/' || c == '-')    // strip "-dev" or "/build"
         .next()
     {
         debug!("Checking Supervisor version '{}' against requirement '{}'",


### PR DESCRIPTION
https://github.com/habitat-sh/habitat/pull/6749 fixes one instance where `split(' ')` produced incorrect results because it only splits on a single space, even when multiple spaces are present.

That made me wonder - why aren't we using [split_whitespace()](https://doc.rust-lang.org/std/primitive.str.html#method.split_whitespace) everywhere?  I can't think of a scenario where the behavior of [split_whitespace()](https://doc.rust-lang.org/std/primitive.str.html#method.split_whitespace) is _not_ what we want, and for some reason, we actually depend on the behavior of `split(' ')` when multiple consecutive whitespace characters are present.

So I did a find/replace.

![](https://media.giphy.com/media/nFptMetxIdCow/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>