### PR TITLE
Fixing typo public->secret in origin secret key download

### DIFF
--- a/components/hab/src/command/origin/key/download.rs
+++ b/components/hab/src/command/origin/key/download.rs
@@ -99,7 +99,7 @@ fn handle_secret(ui: &mut UI,
 
     ui.begin(format!("Downloading secret origin keys for {}", origin))?;
     download_secret_key(ui, &api_client, origin, token.unwrap(), cache)?; // unwrap is safe because we already checked it above
-    ui.end(format!("Download of {} public origin keys completed.", &origin))?;
+    ui.end(format!("Download of {} secret origin keys completed.", &origin))?;
     Ok(())
 }
 


### PR DESCRIPTION
Resolves #6752

Signed-off-by: Siraj Rauff <sirajrauff@gmail.com>