### PR TITLE
Fix event stream reconnect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ratsio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ratsio 0.2.1 (git+https://github.com/habitat-sh/ratsio.git?rev=f78bc37ad82202791f753c593d9b60bb3ea2570b)",
  "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2785,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "ratsio"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/habitat-sh/ratsio.git?rev=f78bc37ad82202791f753c593d9b60bb3ea2570b#f78bc37ad82202791f753c593d9b60bb3ea2570b"
 dependencies = [
  "atomic-counter 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4379,7 +4379,7 @@ dependencies = [
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-"checksum ratsio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "78a24e7d8d62fd9728ba17a3f814a2991aca1e98a6013c268ec8a0a70ed4c771"
+"checksum ratsio 0.2.1 (git+https://github.com/habitat-sh/ratsio.git?rev=f78bc37ad82202791f753c593d9b60bb3ea2570b)" = "<none>"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -51,7 +51,7 @@ prost = "*"
 prost-derive = "*"
 prost-types = "0.5.0" # This is current stable, but for some reason gets pulled in as 0.4.0 if we use "*" (2019-03-28)
 rand = "*"
-ratsio = "*"
+ratsio = {git = "https://github.com/habitat-sh/ratsio.git", rev = "f78bc37ad82202791f753c593d9b60bb3ea2570b"}
 regex = "*"
 rustls = "*"
 serde = { version = "*", features = ["rc"] }

--- a/components/sup/src/event/ratsio.rs
+++ b/components/sup/src/event/ratsio.rs
@@ -56,24 +56,29 @@ pub(super) fn init_stream(conn_info: EventConnectionInfo) -> Result<EventStream>
                                              .expect("Couldn't synchronize event thread!");
 
                                       event_rx.for_each(move |event: Vec<u8>| {
-                                          if client.nats_client.get_state() == NatsClientState::Connected {
-                                              let stan_msg =
-                                                  StanMessage::new(HABITAT_SUBJECT.into(),
-                                                                   event);
-                                              let publish_event = client
-                                                  .send(stan_msg)
-                                                  .map_err(|e| {
-                                                      error!("Error publishing event: {}", e)
-                                                  });
-                                              executor::spawn(publish_event);
-                                          } else {
-                                              trace!(
-                                                  "Unable to send event because client is in state {:?}",
-                                                  client.nats_client.get_state()
-                                              );
-                                          }
-                                          Ok(())
-                                      })
+                                                  // If we are connected to the nats client send
+                                                  // the event. Otherwise, we intentially drop
+                                                  // the event.
+                                                  match client.nats_client.get_state() {
+                                                      NatsClientState::Connected => {
+                                                          let stan_msg = StanMessage::new(
+                                                              HABITAT_SUBJECT.into(),
+                                                              event);
+                                                          let publish_event = client
+                                                            .send(stan_msg)
+                                                            .map_err(|e|
+                                                                error!("Error publishing event: {}",
+                                                                    e));
+                                                          executor::spawn(publish_event);
+                                                      }
+                                                      state => {
+                                                          trace!("Unable to send event because \
+                                                                  client is in state {:?}",
+                                                                 state)
+                                                      }
+                                                  }
+                                                  Ok(())
+                                              })
                                   });
 
                               ThreadRuntime::new().expect("Couldn't create event stream runtime!")


### PR DESCRIPTION
This address three issues with the forked [ratsio library's](https://github.com/habitat-sh/ratsio) reconnect logic:

- [`CONNECT`](https://nats-io.github.io/docs/nats_protocol/nats-protocol.html#connect) messages were not being sent on reconnect
- The STAN client reconnect logic is not completed before we actually consider the client reconnected. If we try and publish messages before this is complete it causes the client to be invalidated by the server.
- The STAN reconnect logic occasionally hangs. A timeout was added as a temporary workaround.

The [ratsio library](https://github.com/habitat-sh/ratsio) may need additional vetting and cleanup. I am not sure if this should be completed as part of this PR or as follow on work.

Resolves #6737 