### PR TITLE
hab: don't start analytics thread if analytics is disabled

### DIFF
--- a/components/hab/src/analytics.rs
+++ b/components/hab/src/analytics.rs
@@ -419,7 +419,7 @@ pub fn is_opted_in<T>(analytics_path: T) -> Option<bool>
 }
 
 /// Returns true if analytics are enabled and false otherwise.
-fn analytics_enabled() -> bool {
+pub fn analytics_enabled() -> bool {
     match is_opted_in(hcore::fs::cache_analytics_path(None::<String>)) {
         // If the value is explicitly true or false, return the unwrapped value
         Some(val) => val,

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -109,7 +109,11 @@ fn main() {
     env_logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
-    thread::spawn(analytics::instrument_subcommand);
+
+    if analytics::analytics_enabled() {
+        thread::spawn(analytics::instrument_subcommand);
+    }
+
     if let Err(e) = start(&mut ui, flags) {
         ui.fatal(e).unwrap();
         std::process::exit(1)


### PR DESCRIPTION
This will introduce a few calls to stat(2) into the startup of Habitat
in exchange for not starting the analytics thread.

The actual motivation here is that this thread is involved in the
conditions that appear to be triggering:

https://github.com/habitat-sh/habitat/issues/6252

While we should fix that bug, not starting a thread we don't need
seems like an easy way to lower the impact of the bug quickly.

Typically, I can reproduce 6252 in between 10k-250k invocations of
hab. With this fix in place, I've been able to run 5M+ invocations of
hab without issue.

Signed-off-by: Steven Danna <steve@chef.io>