### PR TITLE
Cleanup expeditor config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -56,6 +56,7 @@ subscriptions:
           - 'Expeditor: Exclude from Changelog'
           - 'Expeditor: Skip All'
       - trigger_pipeline:release_habitat:
+          only_if: built_in:bump_version
           post_commit: true
 
   - workload: buildkite_build_passed:{{agent_id}}:release_habitat:*

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -10,10 +10,6 @@ github:
   # details from the Pull Request via the `built_in:update_changelog` merge_action.
   changelog_file: "CHANGELOG_FAKE.md"
   delete_branch_on_merge: true
-  release_branch:
-    - master:
-        # Version constraint at this point is arbitrary but represents 1.0.0
-        version_constraint: 1*
 
 # Slack channel in Chef Software slack to send notifications about Expeditor actions
 slack:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -30,11 +30,6 @@ merge_actions:
         - "Expeditor: Exclude from Changelog"
         - "Expeditor: Skip All"
 
-subscriptions:
-  - workload: pull_request_opened:{{agent_id}}:*
-    actions:
-      - post_github_comment:.expeditor/templates/welcome.mustache
-
 changelog:
   categories:
     - "X-change": "Behavioral Changes"
@@ -61,6 +56,10 @@ staging_areas:
 
 subscriptions:
   # These actions are taken, in order they are specified
+  - workload: pull_request_opened:{{agent_id}}:*
+    actions:
+      - post_github_comment:.expeditor/templates/welcome.mustache
+
   - workload: pull_request_merged:{{agent_id}}:*
     actions:
       - trigger_pipeline:release_habitat

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -15,17 +15,6 @@ github:
 slack:
   notify_channel: habitat-notify
 
-# These actions are taken, in order they are specified, anytime a Pull Request is merged.
-merge_actions:
-  - built_in:bump_version:
-      ignore_labels:
-        - "Expeditor: Skip Version Bump"
-        - "Expeditor: Skip All"
-  - built_in:update_changelog:
-      ignore_labels:
-        - "Expeditor: Exclude from Changelog"
-        - "Expeditor: Skip All"
-
 changelog:
   categories:
     - "X-change": "Behavioral Changes"
@@ -58,6 +47,14 @@ subscriptions:
 
   - workload: pull_request_merged:{{agent_id}}:*
     actions:
+      - built_in:bump_version:
+          ignore_labels:
+          - 'Expeditor: Skip Version Bump'
+          - 'Expeditor: Skip All'
+      - built_in:update_changelog:
+          ignore_labels:
+          - 'Expeditor: Exclude from Changelog'
+          - 'Expeditor: Skip All'
       - trigger_pipeline:release_habitat:
           post_commit: true
 

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -62,7 +62,8 @@ subscriptions:
 
   - workload: pull_request_merged:{{agent_id}}:*
     actions:
-      - trigger_pipeline:release_habitat
+      - trigger_pipeline:release_habitat:
+          post_commit: true
 
   - workload: buildkite_build_passed:{{agent_id}}:release_habitat:*
     actions:


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

- We should only have 1 subscription section.
- We want to ensure the pipeline triggers post merge to master
- We no longer need a version constraint, as the `release_branch` defaults to the master branch. This was used during development to use a separate release branch a while ago and is no longer needed.
- We also want to ensure that the changelog and version get bumped correctly before we do the merge and kick off the pipeline, so moved those to a subscription.