### PR TITLE
Ensure studio is installed

### DIFF
--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -133,7 +133,7 @@ mod inner {
                     }
                     debug!("Running: {}", display_args);
 
-                    command 
+                    command
                 }
             };
 

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -114,6 +114,7 @@ mod inner {
                     let ident = PackageIdent::from_str(&format!("{}/{}",
                                                                 super::STUDIO_PACKAGE_IDENT,
                                                                 version[0]))?;
+                    let command = exec::command_from_min_pkg(ui, super::STUDIO_CMD, &ident)?
                     // This is a duplicate of the code in `hab pkg exec` and
                     // should be refactored as part of or after:
                     // https://github.com/habitat-sh/habitat/issues/6633
@@ -132,7 +133,7 @@ mod inner {
                     }
                     debug!("Running: {}", display_args);
 
-                    exec::command_from_min_pkg(ui, super::STUDIO_CMD, &ident)?
+                    command 
                 }
             };
 

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -114,7 +114,7 @@ mod inner {
                     let ident = PackageIdent::from_str(&format!("{}/{}",
                                                                 super::STUDIO_PACKAGE_IDENT,
                                                                 version[0]))?;
-                    let command = exec::command_from_min_pkg(ui, super::STUDIO_CMD, &ident)?
+                    let command = exec::command_from_min_pkg(ui, super::STUDIO_CMD, &ident)?;
                     // This is a duplicate of the code in `hab pkg exec` and
                     // should be refactored as part of or after:
                     // https://github.com/habitat-sh/habitat/issues/6633


### PR DESCRIPTION
Closes #6771 

Previously, `studio enter` would ensure that the appropriate `core/hab-studio` package was installed before attempting to invoke it.  With the change in #6549, we attempt to read the metadata from the studio package, assuming it is already installed which isn't the case after installing a new release of Habitat. 

This corrects that by ensuring the studio package is installed before attempting to read the metadata. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>