### PR TITLE
Fixing up some End-to-End Supervisor Tests

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -111,8 +111,6 @@ steps:
     command:
       - .expeditor/scripts/setup_environment.sh DEV
       - test/end-to-end/test_socket_file_cleanup.sh
-    # TODO - FIX ME
-    soft_fail: true
     expeditor:
       executor:
         docker:

--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -97,9 +97,8 @@ steps:
     command:
       - .expeditor/scripts/setup_environment.sh DEV
       - test/end-to-end/test_launcher_restarts_supervisor.sh
-    # TODO - FIX ME
-    soft_fail: true
-    timeout_in_minutes: 2 # this will timeout every time for some reason
+    artifact_paths:
+      - sup.log
     expeditor:
       executor:
         docker:

--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -121,9 +121,7 @@ steps:
   - label: "[:linux: test_tar_export]"
     command:
       - .expeditor/scripts/setup_environment.sh DEV
-      - test/end-to-end/test_tar_export.sh core/gzip
-    # TODO - FIX ME
-    soft_fail: true
+      - test/end-to-end/test_tar_export.sh
     expeditor:
       executor:
         docker:

--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -28,7 +28,6 @@ steps:
           privileged: true
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
-            - HAB_BLDR_URL=$ACCEPTANCE_HAB_BLDR_URL
 
   - label: "[:linux: hup-does-not-abandon-services]"
     command:
@@ -107,7 +106,6 @@ steps:
           privileged: true
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
-            - HAB_BLDR_URL=$ACCEPTANCE_HAB_BLDR_URL
 
   - label: "[:linux: test_socket_file_cleanup]"
     command:
@@ -121,7 +119,6 @@ steps:
           privileged: true
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
-            - HAB_BLDR_URL=$ACCEPTANCE_HAB_BLDR_URL
 
   - label: "[:linux: test_tar_export]"
     command:
@@ -135,4 +132,3 @@ steps:
           privileged: true
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
-            - HAB_BLDR_URL=$ACCEPTANCE_HAB_BLDR_URL

--- a/test/end-to-end/test_launcher_restarts_supervisor.sh
+++ b/test/end-to-end/test_launcher_restarts_supervisor.sh
@@ -8,6 +8,13 @@
 
 set -eou pipefail
 
+
+find_if_exists() {
+  command -v "${1}" || { log "Required utility '${1}' cannot be found!  Aborting."; exit 1; }
+}
+
+find_if_exists pgrep
+
 wait_for_sup_to_start() {
 	until pgrep hab-sup &>/dev/null; do
 		echo -n .
@@ -21,14 +28,13 @@ if pgrep hab-launch &>/dev/null; then
 	exit 1
 fi
 
-TESTING_FS_ROOT=$(mktemp -d)
-export TESTING_FS_ROOT
-sup_log="$TESTING_FS_ROOT/hab/sup/default/sup.log"
+sup_log="sup.log"
 exit_file=$(mktemp)
 exit_code=${1:-1}
 
 mkdir -p "$(dirname "$sup_log")"
-echo -n "Starting launcher with root $TESTING_FS_ROOT (logging to $sup_log)..."
+echo -n "Starting launcher (logging to $sup_log)..."
+
 env HAB_FEAT_TEST_EXIT="$exit_file" hab sup run &> "$sup_log" &
 trap 'hab sup term' INT TERM EXIT
 

--- a/test/end-to-end/test_socket_file_cleanup.sh
+++ b/test/end-to-end/test_socket_file_cleanup.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Regression test to address https://github.com/habitat-sh/habitat/issues/4673
+# Fixed in https://github.com/habitat-sh/habitat/pull/5365
+
 set -exou pipefail
 
 find_socket_files() {
@@ -31,14 +34,15 @@ hab sup term
 echo "--- Waiting for launcher to exit..."
 wait
 
+echo "--- Checking for socket files left behind..."
 socket_files_after=$(mktemp)
 find_socket_files > "$socket_files_after"
 
-echo "--- Checking for socket files left behind..."
 if grep -vf "$socket_files_before" "$socket_files_after"; then
 	echo "--- Failure! Dumping supervisor log:"
 	cat "$sup_log"
 	exit 1
 else
-	echo "--- Success! No socket file left behind"
+    echo "--- Success! No socket file left behind; Supervisor logs follow:"
+    cat "$sup_log"
 fi

--- a/test/end-to-end/test_tar_export.sh
+++ b/test/end-to-end/test_tar_export.sh
@@ -2,47 +2,61 @@
 
 set -euo pipefail
 
-print_help() {
-    program=$(basename "$0")
-    echo "$program
+# Test the Habitat tar exporter.
+#
+# Uses the `HAB_INTERNAL_BLDR_CHANNEL` environment variable to control
+# the base packages channel for the exporter.
 
-Test hab pkg tar export
+# Extract the identifier of a particular Habitat package in a tarball.
+#
+# Provide just the package name; the origin is always assumed to be
+# "core"
+#
+#     echo $(extract_ident my.tar.gz hab)
+#     # -> core/hab/0.83.0/20190712231625
+extract_ident() {
+    local tar_archive=${1}
+    local package_name=${2}
 
-USAGE:
-        $program <PKG_IDENT>
+    # Extract the path to the IDENT file for a given "core/XXX" package that
+    # should be present in the tarball.
+    local ident_file
+    ident_file=$(tar \
+                     --list \
+                     --file="${tar_archive}" | \
+                 grep --basic-regexp \
+                      "hab/pkgs/core/${package_name}/.*/.*/IDENT")
 
-ARGS:
-    <PKG_IDENT>  The origin and name of the package to schedule a job for (eg: core/redis) or
-                 A fully qualified package identifier (ex: core/busybox-static/1.42.2/20170513215502)
-"
+    if [[ -n "${ident_file}" ]]; then
+        # Extract the *contents* of that IDENT file
+        tar --extract \
+            --to-stdout \
+            --file="${tar_archive}" \
+            "${ident_file}"
+    else
+        return 1
+    fi
 }
-
-if [ -n "${DEBUG:-}" ]; then
-    set -x
-    export DEBUG
-fi
-
-if [[ $# -eq 0 ]] ; then
-    print_help
-    echo
-    echo "<PKG_IDENT> must be specified"
-    exit 1
-else
-    pkg_ident="$1"
-fi
 
 # Remove tarball if already present
 rm -f ./*.tar.gz
 
-hab pkg export tar "$pkg_ident" --base-pkgs-channel=DEV
+hab pkg export tar core/gzip --base-pkgs-channel="${HAB_INTERNAL_BLDR_CHANNEL}"
+
+tarball=$(find . -maxdepth 1 -type f -name "*.tar.gz")
 
 # Check if tarball is present
-
-if [ "$(find . -maxdepth 1 -type f -name "*.tar.gz")" ] ; then
+if [ -f "${tarball}" ] ; then
     echo "--- Package was successfully exported to a tarball"
 else
     echo "--- Package was NOT successfully exported"
     exit 1
 fi
 
-echo "--- Woo!"
+# Query contents for core Habitat packages
+hab_ident=$(extract_ident "${tarball}" hab)
+echo "core/hab in tarball = ${hab_ident}"
+launcher_ident=$(extract_ident "${tarball}" hab-launcher)
+echo "core/hab-launcher in tarball = ${launcher_ident}"
+sup_ident=$(extract_ident "${tarball}" hab-sup)
+echo "core/hab-sup in tarball = ${sup_ident}"


### PR DESCRIPTION
Enables the following end-to-end tests in our end-to-end pipeline:

* [`test_launcher_restarts_supervisor.sh`](https://github.com/habitat-sh/habitat/blob/master/test/end-to-end/test_launcher_restarts_supervisor.sh) 
* [`test_socket_file_cleanup.sh`](https://github.com/habitat-sh/habitat/blob/master/test/end-to-end/test_socket_file_cleanup.sh) 
* [`test_tar_export.sh`](https://github.com/habitat-sh/habitat/blob/master/test/end-to-end/test_tar_export.sh)