### PR TITLE
Add e2e test to ensure studio auto-installs

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -126,3 +126,15 @@ steps:
           privileged: true
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
+
+  - label: "[:linux: test_studio_auto_installs]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_studio_auto_installs.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+            - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh

--- a/test/end-to-end/test_studio_auto_installs.sh
+++ b/test/end-to-end/test_studio_auto_installs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This test is designed to catch the regression described in 
+# https://github.com/habitat-sh/habitat/issues/6771
+# 
+# When a user runs `hab studio enter` for the first time after installing a
+# new Habitat release, the `core/hab-studio` package won't be present on the 
+# system and the cli will automatically download and install the appropirate 
+# package. Since we always install the studio as part of our build process to 
+# ensure we're using the correct version, this behavior needs to be exercised 
+# as its own test. 
+
+set -euo pipefail
+
+# Ensure there are no studios installed
+while [ -d /hab/pkgs/core/hab-studio ]; do 
+  hab pkg uninstall core/hab-studio
+done
+
+# 'studio enter' requires a signing key to be present for the current origin
+echo "--- Generating signing key for $HAB_ORIGIN"
+hab origin key generate "$HAB_ORIGIN" 
+
+echo "--- Creating new studio"
+hab studio new
+
+echo "--- $(hab studio version)"


### PR DESCRIPTION
Addresses #6771 

This is a first pass at adding end-to-end tests for the studio. The goal of this test is to ensure that the auto-install behavior of the chroot-based studio is preserved when making changes to the `hab studio *` commands. 


Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>