### PR TITLE
Extract a curlbash_hab function

### DIFF
--- a/.expeditor/scripts/promote_packages.sh
+++ b/.expeditor/scripts/promote_packages.sh
@@ -9,7 +9,7 @@ export HAB_BLDR_URL="${ACCEPTANCE_HAB_BLDR_URL}"
 
 # Take advantage of the fact that we're just promoting and we can run 
 # 100% on linux
-install_latest_hab_binary "x86_64-linux"
+curlbash_hab "x86_64-linux"
 
 ########################################################################
 

--- a/.expeditor/scripts/remove_build_channel.sh
+++ b/.expeditor/scripts/remove_build_channel.sh
@@ -10,11 +10,11 @@ source .expeditor/scripts/shared.sh
 export HAB_AUTH_TOKEN="${ACCEPTANCE_HAB_AUTH_TOKEN}"
 export HAB_BLDR_URL="${ACCEPTANCE_HAB_BLDR_URL}"
 
-install_latest_hab_binary "$BUILD_PKG_TARGET"
+curlbash_hab "$BUILD_PKG_TARGET"
 
 channel="$(get_release_channel)"
 echo "--- Destroying release channel '${channel}'"
 
-${hab_binary} bldr channel destroy \
+hab bldr channel destroy \
     --origin=core \
     "${channel}"

--- a/.expeditor/scripts/setup_environment.sh
+++ b/.expeditor/scripts/setup_environment.sh
@@ -18,7 +18,7 @@ export HAB_AUTH_TOKEN="${ACCEPTANCE_HAB_AUTH_TOKEN}"
 export HAB_BLDR_URL="${ACCEPTANCE_HAB_BLDR_URL}"
 export HAB_BLDR_CHANNEL="${channel}"
 
-install_latest_stable_hab_binary "$BUILD_PKG_TARGET"
+curlbash_hab "$BUILD_PKG_TARGET"
 
 echo "--- Installing latest core/hab from ${channel}"
 hab pkg install --binlink --force --channel "${channel}" core/hab

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -25,18 +25,31 @@ get_latest_pkg_version_in_channel() {
     echo "${version}"
 }
 
+# Install the latest stable `hab` binary using our standard
+# "curl|bash" approach.
+#
+# This is the currently recommended way to get Habitat onto a system
+# that does not already have it.
+#
+# As usual, this will install `hab` at `/bin/hab`
+curlbash_hab() {
+    local pkg_target="${1:-$BUILD_PKG_TARGET}"
+    echo "--- :habicat: Bootstrap installation of the current stable hab binary for $pkg_target using curl|bash"
+    # TODO:
+    # really weird corner case on linux2 because the 0.82.0 versions of both
+    # are the same. let's just delete it
+    rm -rf /hab/pkgs/core/hab/0.82.0
+    curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -t "$pkg_target"
+}
+
 # Always install the latest hab binary appropriate for your linux platform
 #
 # Accepts a pkg target argument if you need to override it, otherwise
 # will default to the value of `BUILD_PKG_TARGET`
 install_latest_hab_binary() {
     local pkg_target="${1:-$BUILD_PKG_TARGET}"
-    echo "--- Installing latest hab binary for $pkg_target using curl|bash"
-    # TODO:
-    # really weird corner case on linux2 because the 0.82.0 versions of both
-    # are the same. let's just delete it
-    rm -rf /hab/pkgs/core/hab/0.82.0
-    curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -t "$pkg_target"
+    curlbash_hab "${pkg_target}"
+
     hab_binary="/bin/hab"
     # TODO: workaround for https://github.com/habitat-sh/habitat/issues/6771
     ${hab_binary} pkg install core/hab-studio


### PR DESCRIPTION
The original `install_latest_hab_binary` is doing more work than
needed; it both bootstraps `hab` onto a system, and then does extra work
to possibly install `hab` and `hab-studio` in the context of a release.

To help tease these concerns apart, we extract a `curlbash_hab`
function that just handles the bootstrapping logic.

Now, in the places where we really don't care what version of `hab`
we're using, we can just use `curlbash_hab`. Note that we also don't
need to use the `hab_binary` global variable that
`install_latest_hab_binary` set; since the "curlbash" method adds a
link to `/bin/hab`, we can just reference the binary by name directly.

This will allow us to expand our usage into additional pipelines,
without implicitly relying on logic that was only useful in the
context of the release pipeline.

Signed-off-by: Christopher Maier <cmaier@chef.io>