### PR TITLE
Remove spec file of failed services

### DIFF
--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -471,7 +471,6 @@ mod storage {
             rs.increment_update_counter();
             assert_eq!(rs.get_update_counter(), 1);
         }
-
     }
 }
 

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -166,6 +166,8 @@ impl Identifiable for PackageIdent {
     fn release(&self) -> Option<&str> { self.release.as_ref().map(String::as_str) }
 }
 
+// It does not make sense for `PackageIdent` to implement `Default`. This should be removed.
+// See https://github.com/habitat-sh/habitat/issues/6829
 impl Default for PackageIdent {
     fn default() -> PackageIdent { PackageIdent::new("", "", None, None) }
 }

--- a/components/sup/src/ctl_gateway/server.rs
+++ b/components/sup/src/ctl_gateway/server.rs
@@ -119,28 +119,30 @@ impl From<mpsc::SendError<CtlCommand>> for HandlerError {
 /// A wrapper around a [`ctl_gateway.CtlRequest`] and a closure for the main thread to execute.
 pub struct CtlCommand {
     pub req: CtlRequest,
-    // JW: This needs to be an `FnOnce<Box>` and not an `Fn<Box>` but right now there is no support
-    // for boxing an FnOnce in stable Rust. There is a new type called `FnBox` which exists only on
-    // nightly right now which accomplishes this but it won't stabilize because the Rust core team
-    // feels that they should just get `Box<FnOnce>` working. We'll need to clone the `CtlRequest`
-    // argument passed to this closure until `FnOnce<Box>` stabilizes.
-    //
-    // https://github.com/rust-lang/rust/issues/28796
-    fun: Box<dyn Fn(&ManagerState, &mut CtlRequest, ActionSender) -> NetResult<()> + Send>,
+    // We need to wrap this in an `Option` because we implement `Future` for `CtlCommand`. It will
+    // only be polled once, but there is no way to express this with `poll`'s signature.
+    #[allow(clippy::type_complexity)]
+    fun: Option<Box<dyn FnOnce(&ManagerState, &mut CtlRequest, ActionSender) -> NetResult<()>
+                        + Send>>,
 }
 
 impl CtlCommand {
     /// Create a new CtlCommand from the given CtlSender, transaction, and closure to execute.
     pub fn new<F>(tx: CtlSender, txn: Option<SrvTxn>, fun: F) -> Self
-        where F: Fn(&ManagerState, &mut CtlRequest, ActionSender) -> NetResult<()> + Send + 'static
+        where F: FnOnce(&ManagerState, &mut CtlRequest, ActionSender) -> NetResult<()>
+                  + Send
+                  + 'static
     {
-        CtlCommand { fun: Box::new(fun),
+        CtlCommand { fun: Some(Box::new(fun)),
                      req: CtlRequest::new(tx, txn), }
     }
 
     /// Run the contained closure with the given [`manager.ManagerState`].
     pub fn run(&mut self, state: &ManagerState, action_sender: ActionSender) -> NetResult<()> {
-        (self.fun)(state, &mut self.req, action_sender)
+        if let Some(fun) = self.fun.take() {
+            return fun(state, &mut self.req, action_sender);
+        }
+        Ok(())
     }
 }
 
@@ -303,7 +305,7 @@ impl SrvHandler {
                 Ok(CtlCommand::new(ctl_sender,
                                    msg.transaction(),
                                    move |state, req, _action_sender| {
-                                       commands::service_load(state, req, &m)
+                                       commands::service_load(state, req, m)
                                    }))
             }
             "SvcUnload" => {

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -275,10 +275,15 @@ impl From<habitat_api_client::Error> for Error {
     fn from(err: habitat_api_client::Error) -> Error { Error::APIClient(err) }
 }
 
-// TODO (CM): not sure if this works or not
 impl From<Error> for habitat_sup_protocol::net::NetErr {
     fn from(err: Error) -> habitat_sup_protocol::net::NetErr {
-        habitat_sup_protocol::net::err(habitat_sup_protocol::net::ErrCode::Internal, err)
+        match err {
+            Error::MissingRequiredBind(_) | Error::InvalidBinds(_) => {
+                habitat_sup_protocol::net::err(habitat_sup_protocol::net::ErrCode::InvalidPayload,
+                                               err)
+            }
+            _ => habitat_sup_protocol::net::err(habitat_sup_protocol::net::ErrCode::Internal, err),
+        }
     }
 }
 

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -739,7 +739,7 @@ impl Manager {
         runtime.spawn(ctl_handler);
 
         if let Some(svc_load) = svc {
-            commands::service_load(&self.state, &mut CtlRequest::default(), &svc_load)?;
+            commands::service_load(&self.state, &mut CtlRequest::default(), svc_load)?;
         }
 
         // This serves to start up any services that need starting

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1918,8 +1918,7 @@ mod test {
         /// Helper function for generating a basic spec from an
         /// identifier string
         fn new_spec(ident: &str) -> ServiceSpec {
-            ServiceSpec::with_ident(PackageIdent::from_str(ident).expect("couldn't parse ident \
-                                                                          str"))
+            ServiceSpec::new(PackageIdent::from_str(ident).expect("couldn't parse ident str"))
         }
 
         #[test]

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -930,7 +930,8 @@ impl Manager {
                     }
                     SupervisorAction::UnloadService { service_spec,
                                                       shutdown_input, } => {
-                        self.unload(&service_spec.ident, &shutdown_input, &mut runtime);
+                        self.try_remove_spec_file(&service_spec.ident);
+                        self.try_stop_service(&service_spec.ident, &shutdown_input, &mut runtime);
                     }
                 }
             }
@@ -1335,18 +1336,14 @@ impl Manager {
                                            stop_it)
     }
 
-    fn unload(&mut self,
-              ident: &PackageIdent,
-              shutdown_input: &ShutdownInput,
-              runtime: &mut Runtime) {
+    fn try_remove_spec_file(&self, ident: &PackageIdent) {
         let file = self.state.cfg.spec_path_for(ident);
         if let Err(err) = fs::remove_file(&file) {
-            warn!("Tried to unload '{}', but couldn't remove the file '{}': {:?}",
-                  ident,
+            warn!("Tried to remove spec file '{}' for '{}': {:?}",
                   file.display(),
+                  ident,
                   err);
         };
-        self.try_stop_service(ident, shutdown_input, runtime);
     }
 
     /// Wrap a future that starts, stops, or restarts a service with

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -647,6 +647,8 @@ impl Manager {
             }
             Err(err) => {
                 outputln!("Unable to start {}, {}", ident, err);
+                // Remove the spec file so it does not look like this service is loaded.
+                self.try_remove_spec_file(&ident);
                 return;
             }
         };

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -637,14 +637,14 @@ impl Manager {
     fn add_service_rsw_mlw(&mut self, spec: &ServiceSpec) {
         // JW TODO: This clone sucks, but our data structures are a bit messy here. What we really
         // want is the service to hold the spec and, on failure, return an error with the spec
-        // back to us. Since we consume and deconstruct the spec in `Service::new()` which
-        // `Service::load()` eventually delegates to we just can't have that. We should clean
+        // back to us. Since we consume and deconstruct the spec in `Service::new_impl()` which
+        // `Service::new()` eventually delegates to we just can't have that. We should clean
         // this up in the future.
-        let service = match Service::load(self.sys.clone(),
-                                          spec.clone(),
-                                          self.fs_cfg.clone(),
-                                          self.organization.as_ref().map(|org| &**org),
-                                          self.state.gateway_state.clone())
+        let service = match Service::new(self.sys.clone(),
+                                         spec.clone(),
+                                         self.fs_cfg.clone(),
+                                         self.organization.as_ref().map(|org| &**org),
+                                         self.state.gateway_state.clone())
         {
             Ok(service) => {
                 outputln!("Starting {} ({})", &spec.ident, service.pkg.ident);
@@ -1267,11 +1267,11 @@ impl Manager {
                 .iter()
                 .filter(|spec| !existing_idents.contains(&spec.ident))
                 .flat_map(|spec| {
-                    Service::load(self.sys.clone(),
-                                  spec.clone(),
-                                  self.fs_cfg.clone(),
-                                  self.organization.as_ref().map(|org| &**org),
-                                  self.state.gateway_state.clone()).into_iter()
+                    Service::new(self.sys.clone(),
+                                 spec.clone(),
+                                 self.fs_cfg.clone(),
+                                 self.organization.as_ref().map(|org| &**org),
+                                 self.state.gateway_state.clone()).into_iter()
                 })
                 .collect();
         let watched_service_proxies: Vec<ServiceProxy<'_>> =

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -4,8 +4,7 @@ use crate::{ctl_gateway::CtlRequest,
             error::Error,
             manager::{action::{ActionSender,
                                SupervisorAction},
-                      service::{spec::{IntoServiceSpec,
-                                       ServiceSpec},
+                      service::{spec::ServiceSpec,
                                 DesiredState,
                                 ProcessState},
                       ManagerState},
@@ -201,7 +200,7 @@ pub fn service_load(mgr: &ManagerState,
         ServiceSpec::default()
     };
 
-    opts.into_spec(&mut spec);
+    spec.merge_svc_load(opts);
 
     let package = util::pkg::satisfy_or_install(req, &source, &spec.bldr_url, &spec.channel)?;
     spec.validate(&package)?;

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -18,8 +18,7 @@ use habitat_common::{command::package::install::InstallSource,
 use habitat_core::{package::{Identifiable,
                              PackageIdent,
                              PackageTarget},
-                   service::ServiceGroup,
-                   ChannelIdent};
+                   service::ServiceGroup};
 use habitat_sup_protocol::{self as protocol,
                            net::{self,
                                  ErrCode,
@@ -185,60 +184,27 @@ pub fn service_load(mgr: &ManagerState,
                     opts: &protocol::ctl::SvcLoad)
                     -> NetResult<()> {
     let ident: PackageIdent = opts.ident.clone().ok_or_else(err_update_client)?.into();
-    let bldr_url = opts.bldr_url
-                       .clone()
-                       .unwrap_or_else(|| protocol::DEFAULT_BLDR_URL.to_string());
-    let bldr_channel = opts.bldr_channel
-                           .clone()
-                           .map(ChannelIdent::from)
-                           .unwrap_or_default();
-    let force = opts.force.unwrap_or(false);
     let source = InstallSource::Ident(ident.clone(), PackageTarget::active_target());
-    match mgr.cfg.spec_for_ident(source.as_ref()) {
-        None => {
-            let mut spec = ServiceSpec::default();
-            opts.into_spec(&mut spec);
-
-            // We don't have any record of this thing; let's set it up!
-            //
-            // If a package exists on disk that satisfies the
-            // desired package identifier, it will be used;
-            // otherwise, we'll install the latest suitable
-            // version from the specified Builder channel.
-            util::pkg::satisfy_or_install(req, &source, &bldr_url, &bldr_channel)?;
-
-            mgr.cfg.save_spec_for(&spec)?;
-            req.info(format!("The {} service was successfully loaded", spec.ident))?;
+    let mut spec = if let Some(spec) = mgr.cfg.spec_for_ident(source.as_ref()) {
+        // We've seen this service before. Thus `load` acts as a way to edit spec files from the
+        // command line. As a result, we check that you *really* meant to change an existing spec.
+        if !opts.force.unwrap_or(false) {
+            return Err(net::err(ErrCode::Conflict,
+                                format!("Service already loaded, unload '{}' \
+                                         and try again",
+                                        ident)));
         }
-        Some(mut spec) => {
-            // We've seen this service  before. Thus `load`
-            // basically acts as a way to edit spec files on the
-            // command line. As a result, we a) check that you
-            // *really* meant to change an existing spec, and b) DO
-            // NOT download a potentially new version of the package
-            // in question
+        spec
+    } else {
+        ServiceSpec::default()
+    };
 
-            if !force {
-                return Err(net::err(ErrCode::Conflict,
-                                    format!("Service already loaded, unload '{}' \
-                                             and try again",
-                                            ident)));
-            }
+    opts.into_spec(&mut spec);
 
-            opts.into_spec(&mut spec);
+    util::pkg::satisfy_or_install(req, &source, &spec.bldr_url, &spec.channel)?;
+    mgr.cfg.save_spec_for(&spec)?;
 
-            // Only install if we don't have something
-            // locally; otherwise you could potentially
-            // upgrade each time you load.
-            //
-            // Also make sure you're pulling from where you're
-            // supposed to be pulling from!
-            util::pkg::satisfy_or_install(req, &source, &spec.bldr_url, &spec.channel)?;
-
-            mgr.cfg.save_spec_for(&spec)?;
-            req.info(format!("The {} service was successfully loaded", spec.ident))?;
-        }
-    }
+    req.info(format!("The {} service was successfully loaded", spec.ident))?;
     req.reply_complete(net::ok());
     Ok(())
 }

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -201,7 +201,8 @@ pub fn service_load(mgr: &ManagerState,
 
     opts.into_spec(&mut spec);
 
-    util::pkg::satisfy_or_install(req, &source, &spec.bldr_url, &spec.channel)?;
+    let package = util::pkg::satisfy_or_install(req, &source, &spec.bldr_url, &spec.channel)?;
+    spec.validate(&package)?;
     mgr.cfg.save_spec_for(&spec)?;
 
     req.info(format!("The {} service was successfully loaded", spec.ident))?;

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -197,7 +197,7 @@ pub fn service_load(mgr: &ManagerState,
         }
         spec
     } else {
-        ServiceSpec::default()
+        ServiceSpec::new(PackageIdent::default())
     };
 
     spec.merge_svc_load(opts);

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -190,8 +190,10 @@ pub fn service_load(mgr: &ManagerState,
         // command line. As a result, we check that you *really* meant to change an existing spec.
         if !opts.force.unwrap_or(false) {
             return Err(net::err(ErrCode::Conflict,
-                                format!("Service already loaded, unload '{}' \
-                                         and try again",
+                                format!("Service already loaded. Unload '{}' \
+                                         and try again, or load with the \
+                                         --force flag to reload and restart the \
+                                         service.",
                                         ident)));
         }
         spec

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -181,7 +181,7 @@ pub fn service_file_put(mgr: &ManagerState,
 
 pub fn service_load(mgr: &ManagerState,
                     req: &mut CtlRequest,
-                    opts: &protocol::ctl::SvcLoad)
+                    opts: protocol::ctl::SvcLoad)
                     -> NetResult<()> {
     let ident: PackageIdent = opts.ident.clone().ok_or_else(err_update_client)?.into();
     let source = InstallSource::Ident(ident.clone(), PackageTarget::active_target());
@@ -196,7 +196,7 @@ pub fn service_load(mgr: &ManagerState,
                                          service.",
                                         ident)));
         }
-        spec.merge_svc_load(opts)
+        spec.merge_svc_load(opts)?
     } else {
         ServiceSpec::try_from(opts)?
     };

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -554,7 +554,7 @@ impl Service {
     }
 
     pub fn to_spec(&self) -> ServiceSpec {
-        let mut spec = ServiceSpec::with_ident(self.spec_ident.clone());
+        let mut spec = ServiceSpec::new(self.spec_ident.clone());
         spec.group = self.service_group.group().to_string();
         if let Some(appenv) = self.service_group.application_environment() {
             spec.application_environment = Some(appenv)
@@ -1219,7 +1219,7 @@ mod tests {
             panic!("This is being run on a platform that's not currently supported");
         };
 
-        let spec = ServiceSpec::with_ident(ident);
+        let spec = ServiceSpec::new(ident);
 
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
                                                             .join("fixtures")

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -229,13 +229,13 @@ pub struct Service {
 }
 
 impl Service {
-    fn new(sys: Arc<Sys>,
-           package: &PackageInstall,
-           spec: ServiceSpec,
-           manager_fs_cfg: Arc<FsCfg>,
-           organization: Option<&str>,
-           gateway_state: Arc<RwLock<GatewayState>>)
-           -> Result<Service> {
+    fn new_impl(sys: Arc<Sys>,
+                package: &PackageInstall,
+                spec: ServiceSpec,
+                manager_fs_cfg: Arc<FsCfg>,
+                organization: Option<&str>,
+                gateway_state: Arc<RwLock<GatewayState>>)
+                -> Result<Service> {
         spec.validate(&package)?;
         let all_pkg_binds = package.all_binds()?;
         let pkg = Pkg::from_install(&package)?;
@@ -295,21 +295,21 @@ impl Service {
                    .join("hooks")
     }
 
-    pub fn load(sys: Arc<Sys>,
-                spec: ServiceSpec,
-                manager_fs_cfg: Arc<FsCfg>,
-                organization: Option<&str>,
-                gateway_state: Arc<RwLock<GatewayState>>)
-                -> Result<Service> {
+    pub fn new(sys: Arc<Sys>,
+               spec: ServiceSpec,
+               manager_fs_cfg: Arc<FsCfg>,
+               organization: Option<&str>,
+               gateway_state: Arc<RwLock<GatewayState>>)
+               -> Result<Service> {
         // The package for a spec should already be installed.
         let fs_root_path = Path::new(&*FS_ROOT_PATH);
         let package = PackageInstall::load(&spec.ident, Some(fs_root_path))?;
-        Ok(Self::new(sys,
-                     &package,
-                     spec,
-                     manager_fs_cfg,
-                     organization,
-                     gateway_state)?)
+        Ok(Self::new_impl(sys,
+                          &package,
+                          spec,
+                          manager_fs_cfg,
+                          organization,
+                          gateway_state)?)
     }
 
     /// Create the service path for this package.
@@ -1233,8 +1233,9 @@ mod tests {
         let afs = Arc::new(fscfg);
 
         let gs = Arc::new(RwLock::new(GatewayState::default()));
-        Service::new(asys, &install, spec, afs, Some("haha"), gs).expect("I wanted a service to \
-                                                                          load, but it didn't")
+        Service::new_impl(asys, &install, spec, afs, Some("haha"), gs).expect("I wanted a service \
+                                                                               to load, but it \
+                                                                               didn't")
     }
 
     #[test]

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -25,7 +25,6 @@ use self::{context::RenderContext,
 pub use self::{health::HealthCheckResult,
                hooks::HealthCheckHook,
                spec::{DesiredState,
-                      IntoServiceSpec,
                       ServiceSpec}};
 use crate::{census::{CensusGroup,
                      CensusRing,

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -89,7 +89,7 @@ pub fn deserialize_application_environment<'de, D>(
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-#[serde(default = "ServiceSpec::default")]
+#[serde(default = "ServiceSpec::deserialization_base")]
 pub struct ServiceSpec {
     #[serde(with = "serde_string")]
     pub ident: PackageIdent,
@@ -129,7 +129,10 @@ impl ServiceSpec {
                shutdown_timeout: None }
     }
 
-    fn default() -> Self { Self::new(PackageIdent::default()) }
+    // This should only be used to provide a default value when deserializing. We intentially do not
+    // implement `Default` because a default value for `PackageIdent` does not make sense and should
+    // be removed.
+    fn deserialization_base() -> Self { Self::new(PackageIdent::default()) }
 
     fn to_toml_string(&self) -> Result<String> {
         if self.ident == PackageIdent::default() {
@@ -289,8 +292,7 @@ impl TryFrom<habitat_sup_protocol::ctl::SvcLoad> for ServiceSpec {
     fn try_from(svc_load: habitat_sup_protocol::ctl::SvcLoad) -> Result<Self> {
         // We use the default `PackageIdent` here but `merge_svc_load` checks that
         // `svc_load.ident` is set so we will return an error if there is no ident.
-        let spec = Self::new(PackageIdent::default());
-        spec.merge_svc_load(svc_load)
+        Self::new(PackageIdent::default()).merge_svc_load(svc_load)
     }
 }
 

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -162,9 +162,9 @@ pub struct ServiceSpec {
 
 impl ServiceSpec {
     pub fn default_for(ident: PackageIdent) -> Self {
-        let mut spec = Self::default();
-        spec.ident = ident;
-        spec
+        Self { ident,
+               bldr_url: DEFAULT_BLDR_URL.to_string(),
+               ..Default::default() }
     }
 
     fn to_toml_string(&self) -> Result<String> {

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -152,7 +152,11 @@ impl ServiceSpec {
         Ok(())
     }
 
-    pub fn file_name(&self) -> String { format!("{}.{}", &self.ident.name, SPEC_FILE_EXT) }
+    pub fn ident_file_name(ident: &PackageIdent) -> String {
+        format!("{}.{}", ident.name, SPEC_FILE_EXT)
+    }
+
+    pub fn file_name(&self) -> String { Self::ident_file_name(&self.ident) }
 
     /// Validates that all required package binds are present in service binds and all remaining
     /// service binds are optional package binds.


### PR DESCRIPTION
Resolves #4494

This is a third attempt at resolving this issue. I apologize to reviewers. The feedback on the previous two attempts, #6719 and #6730, have illuminated much better ways to address the problem. The new method is sufficiently different that I believe it warrants a new PR.

To recap there are two changes in behavior:

1. Disallow loading services whose spec cannot be validated. See this [commit]( https://github.com/habitat-sh/habitat/commit/5ea42dd407b9c55d1f717f97e9b7e0a3a34e1462).
2. Remove the spec file of a service that fails to be created. See this [commit](https://github.com/habitat-sh/habitat/commit/aeb12f33feb76bcbdbf7ae8fb82a95e565c7e196). **Important Questions** Does this seem reasonable? Are there workflows this breaks? I believe this only happens when a service is updated. There is no other way for a service to get in this state because the change in 1 prevents it. In other words, this change will automatically unload a service if a new version of the service causes its spec file to be invalid. For example, when binds are added to a service.

I am still trying to find a way to encapsulate these changes in our test suite, but I wanted to get this PR up for initial feedback. 