### PR TITLE
Normalize use of retry to use retry crate in a standard way

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -51,11 +51,11 @@ use crate::{api_client::{self,
                               PackageIdent,
                               PackageInstall,
                               PackageTarget},
-                    util::wait_for,
                     ChannelIdent}};
 use glob;
 use reqwest::StatusCode;
-use retry::retry;
+use retry::{delay,
+            retry};
 
 use crate::{error::{Error,
                     Result},
@@ -672,7 +672,7 @@ impl<'a> InstallTask<'a> {
                    ident);
         } else if self.is_offline() {
             return Err(Error::OfflineArtifactNotFound(ident.as_ref().clone()));
-        } else if retry(wait_for(RETRY_WAIT, RETRIES), fetch_artifact).is_err() {
+        } else if retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), fetch_artifact).is_err() {
             return Err(Error::DownloadFailed(format!("We tried {} times but \
                                                       could not download {}. \
                                                       Giving up.",

--- a/components/core/src/util.rs
+++ b/components/core/src/util.rs
@@ -6,8 +6,7 @@ pub mod sys;
 #[cfg(windows)]
 pub mod win_perm;
 
-use std::{mem,
-          time::Duration};
+use std::mem;
 
 /// Provide a way to convert numeric types safely to i64
 pub trait ToI64 {
@@ -45,10 +44,6 @@ impl ToI64 for u64 {
             self as i64
         }
     }
-}
-
-pub fn wait_for(delay: Duration, times: usize) -> impl IntoIterator<Item = Duration> {
-    vec![delay].into_iter().cycle().take(times)
 }
 
 #[cfg(test)]

--- a/components/hab/src/command/origin/key/download.rs
+++ b/components/hab/src/command/origin/key/download.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use crate::{api_client::{BoxedClient,
                          Client},
             common::{self,
@@ -8,15 +6,14 @@ use crate::{api_client::{BoxedClient,
                      ui::{Status,
                           UIWriter,
                           UI}},
-            hcore::crypto::SigKeyPair};
-
-use crate::{error::{Error,
+            error::{Error,
                     Result},
+            hcore::crypto::SigKeyPair,
             PRODUCT,
             VERSION};
-
 use retry::{delay,
             retry};
+use std::path::Path;
 
 #[allow(clippy::too_many_arguments)]
 pub fn start(ui: &mut UI,
@@ -174,23 +171,22 @@ fn download_key(ui: &mut UI,
                 token: Option<&str>,
                 cache: &Path)
                 -> Result<()> {
-    match SigKeyPair::get_public_key_path(&nwr, &cache) {
-        Ok(_) => ui.status(Status::Using, &format!("{} in {}", nwr, cache.display()))?,
-        Err(_) => {
-            let download_fn = || -> Result<()> {
-                ui.status(Status::Downloading, &nwr)?;
-                api_client.fetch_origin_key(name, rev, token, cache, ui.progress())?;
-                ui.status(Status::Cached, &format!("{} to {}", nwr, cache.display()))?;
-                Ok(())
-            };
+    if SigKeyPair::get_public_key_path(&nwr, &cache).is_ok() {
+        ui.status(Status::Using, &format!("{} in {}", nwr, cache.display()))?;
+        Ok(())
+    } else {
+        let download_fn = || -> Result<()> {
+            ui.status(Status::Downloading, &nwr)?;
+            api_client.fetch_origin_key(name, rev, token, cache, ui.progress())?;
+            ui.status(Status::Cached, &format!("{} to {}", nwr, cache.display()))?;
+            Ok(())
+        };
 
-            if retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), download_fn).is_err() {
-                return Err(Error::from(common::error::Error::DownloadFailed(format!(
-                    "We tried {} times but could not download {}/{} origin key. Giving up.",
-                    RETRIES, &name, &rev
-                ))));
-            }
-        }
+        retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), download_fn).map_err(|_| {
+            Error::from(common::error::Error::DownloadFailed(format!("We tried {} times but \
+                                                                      could not download {}/{} \
+                                                                      origin key. Giving up.",
+                                                                     RETRIES, &name, &rev)))
+        })
     }
-    Ok(())
 }

--- a/components/hab/src/command/origin/key/upload.rs
+++ b/components/hab/src/command/origin/key/upload.rs
@@ -46,12 +46,12 @@ pub fn start(ui: &mut UI,
             Ok(())
         };
 
-        if retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), upload_fn).is_err() {
-            return Err(Error::from(api_client::Error::UploadFailed(format!(
-                "We tried {} times but could not upload {}/{} public origin key. Giving up.",
-                RETRIES, &name, &rev
-            ))));
-        }
+        retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), upload_fn).map_err(|_| {
+            Error::from(api_client::Error::UploadFailed(format!("We tried {} times but could \
+                                                                 not upload {}/{} public origin \
+                                                                 key. Giving up.",
+                                                                RETRIES, &name, &rev)))
+        })?;
     }
 
     ui.end(format!("Upload of public origin key {} complete.", &name_with_rev))?;
@@ -77,12 +77,12 @@ pub fn start(ui: &mut UI,
             }
         };
 
-        if retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), upload_fn).is_err() {
-            return Err(Error::from(api_client::Error::UploadFailed(format!(
-                "We tried {} times but could not upload {}/{} secret origin key. Giving up.",
-                RETRIES, &name, &rev
-            ))));
-        }
+        retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), upload_fn).map_err(|_| {
+            Error::from(api_client::Error::UploadFailed(format!("We tried {} times but could \
+                                                                 not upload {}/{} secret origin \
+                                                                 key. Giving up.",
+                                                                RETRIES, &name, &rev)))
+        })?;
     }
     Ok(())
 }

--- a/components/hab/src/command/origin/key/upload.rs
+++ b/components/hab/src/command/origin/key/upload.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use super::get_name_with_rev;
 use crate::{api_client::{self,
                          Client},
             common::{command::package::install::{RETRIES,
@@ -7,18 +8,16 @@ use crate::{api_client::{self,
                      ui::{Status,
                           UIWriter,
                           UI}},
-            hcore::{crypto::{keys::parse_name_with_rev,
-                             PUBLIC_SIG_KEY_VERSION,
-                             SECRET_SIG_KEY_VERSION},
-                    util::wait_for}};
-use reqwest::StatusCode;
-use retry::retry;
-
-use super::get_name_with_rev;
-use crate::{error::{Error,
+            error::{Error,
                     Result},
+            hcore::crypto::{keys::parse_name_with_rev,
+                            PUBLIC_SIG_KEY_VERSION,
+                            SECRET_SIG_KEY_VERSION},
             PRODUCT,
             VERSION};
+use reqwest::StatusCode;
+use retry::{delay,
+            retry};
 
 pub fn start(ui: &mut UI,
              bldr_url: &str,
@@ -47,7 +46,7 @@ pub fn start(ui: &mut UI,
             Ok(())
         };
 
-        if retry(wait_for(RETRY_WAIT, RETRIES), upload_fn).is_err() {
+        if retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), upload_fn).is_err() {
             return Err(Error::from(api_client::Error::UploadFailed(format!(
                 "We tried {} times but could not upload {}/{} public origin key. Giving up.",
                 RETRIES, &name, &rev
@@ -78,7 +77,7 @@ pub fn start(ui: &mut UI,
             }
         };
 
-        if retry(wait_for(RETRY_WAIT, RETRIES), upload_fn).is_err() {
+        if retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), upload_fn).is_err() {
             return Err(Error::from(api_client::Error::UploadFailed(format!(
                 "We tried {} times but could not upload {}/{} secret origin key. Giving up.",
                 RETRIES, &name, &rev


### PR DESCRIPTION
Now that https://github.com/jimmycuadra/retry/pull/21 has merged, we no longer need our `wait_for` utility function. Additionally, convert some `retry` usages from:

```rust
    if retry(…).is_err() {
        return Err(e);
    }

    Ok(())
```
to the more concise and idiomatic:

```rust
    retry(…).map_err(|_| e)
```

Finally, the ad hoc retry implementation of `try_command_from_min_pkg` obscured the actual retry semantics. Convert it to using the `retry` crate and simplify the logic to make it clear that only the install command is retried, eliminating the need for separate `command_from_min_pkg` and `try_command_from_min_pkg` functions.