### PR TITLE
Add environment to windows binstubs

### DIFF
--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
     ArgumentError(&'static str),
     ButterflyError(String),
     CannotParseBinlinkBinaryName(PathBuf),
-    CannotParseBinlinkSource(PathBuf),
+    CannotParseBinlinkTarget(PathBuf),
     CannotRemoveDockerStudio,
     CannotRemoveFromChannel((String, String)),
     CannotRemovePackage(hcore::package::PackageIdent, usize),
@@ -77,8 +77,8 @@ impl fmt::Display for Error {
             Error::CannotParseBinlinkBinaryName(ref p) => {
                 format!("Cannot parse binlink binary name from {}.", p.display())
             }
-            Error::CannotParseBinlinkSource(ref p) => {
-                format!("Cannot parse binlink source path from {}.", p.display())
+            Error::CannotParseBinlinkTarget(ref p) => {
+                format!("Cannot parse binlink target path from {}.", p.display())
             }
             Error::CannotRemoveDockerStudio => {
                 "Docker Studios are not persistent and cannot be removed".to_string()
@@ -186,7 +186,7 @@ impl error::Error for Error {
             Error::ArgumentError(_) => "There was an error parsing an error or with it's value",
             Error::ButterflyError(_) => "Butterfly has had an error",
             Error::CannotParseBinlinkBinaryName(_) => "Cannot parse binlink binary name",
-            Error::CannotParseBinlinkSource(_) => "Cannot parse binlink source path",
+            Error::CannotParseBinlinkTarget(_) => "Cannot parse binlink target path",
             Error::CannotRemoveFromChannel(_) => {
                 "Package cannot be removed from the specified channel"
             }

--- a/components/hab/src/lib.rs
+++ b/components/hab/src/lib.rs
@@ -16,6 +16,7 @@ extern crate log;
 extern crate serde_derive;
 
 extern crate serde_json;
+extern crate toml;
 
 #[cfg(windows)]
 extern crate widestring;

--- a/components/hab/static/template_binstub.bat
+++ b/components/hab/static/template_binstub.bat
@@ -1,0 +1,4 @@
+@echo off
+REM target='{target}'
+{env}
+"{target}" %*


### PR DESCRIPTION
This takes what was reverted in #6796 and adds back just the Windows pieces.

There was some light refactoring that does affect both platforms but this only contains material behavior changes for Windows. Namely it adds the environment to the binstub.