### PR TITLE
Fix some deprecations; no functionality changes

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -295,7 +295,7 @@ steps:
         user: "buildkite-agent"
         group: "buildkite-agent"
         image: "chefes/buildkite"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 40
     retry:
       automatic:
         limit: 1
@@ -311,7 +311,7 @@ steps:
         user: "buildkite-agent"
         group: "buildkite-agent"
         image: "chefes/buildkite"
-    timeout_in_minutes: 10
+    timeout_in_minutes: 40
     soft_fail: true
 
   - label: "[unit] :linux: sup nitox_stream"

--- a/components/core/src/os/signals/unix.rs
+++ b/components/core/src/os/signals/unix.rs
@@ -5,10 +5,9 @@ use crate::os::process::{Signal,
 use std::{collections::VecDeque,
           sync::{atomic::Ordering,
                  Mutex,
-                 Once,
-                 ONCE_INIT}};
+                 Once}};
 
-static INIT: Once = ONCE_INIT;
+static INIT: Once = Once::new();
 
 lazy_static::lazy_static! {
     static ref CAUGHT_SIGNALS: Mutex<VecDeque<SignalCode>> = Mutex::new(VecDeque::new());

--- a/components/launcher/src/sys/unix/service.rs
+++ b/components/launcher/src/sys/unix/service.rs
@@ -90,7 +90,9 @@ pub fn run(msg: protocol::Spawn) -> Result<Service> {
         return Err(Error::GroupNotFound(String::from("")));
     };
 
-    cmd.before_exec(owned_pgid);
+    unsafe {
+        cmd.pre_exec(owned_pgid);
+    }
     cmd.stdin(Stdio::null())
        .stdout(Stdio::piped())
        .stderr(Stdio::piped())


### PR DESCRIPTION
These are very straightforward and shouldn't require a new launcher release, but it's nice to get rid of the warnings which will eventually become errors.