### PR TITLE
Fix "warning: unused variable: `curr_path`" on linux

### DIFF
--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -471,7 +471,6 @@ mod storage {
             rs.increment_update_counter();
             assert_eq!(rs.get_update_counter(), 1);
         }
-
     }
 }
 

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -292,7 +292,6 @@ mod test {
         let hypnoanalyze_link = "hypnoanalyze.exe";
         #[cfg(target_os = "windows")]
         let hypnoanalyze_link = "hypnoanalyze.bat";
-        let curr_path = ";%PATH%";
 
         start(&mut ui,
               &ident,
@@ -301,7 +300,7 @@ mod test {
               rootfs.path(),
               force).unwrap();
         #[cfg(windows)]
-        assert!(fs::read_to_string(rootfs_bin_dir.join(magicate_link)).unwrap().contains(&format!("PATH={}{}", rootfs_src_dir.to_string_lossy(), curr_path)));
+        assert!(fs::read_to_string(rootfs_bin_dir.join(magicate_link)).unwrap().contains(&format!("PATH={}{}", rootfs_src_dir.to_string_lossy(), ";%PATH%")));
         assert_eq!(rootfs_src_dir.join("magicate.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(magicate_link)).unwrap()
                                                                           .target);
@@ -313,7 +312,7 @@ mod test {
               rootfs.path(),
               force).unwrap();
         #[cfg(windows)]
-        assert!(fs::read_to_string(rootfs_bin_dir.join(hypnoanalyze_link)).unwrap().contains(&format!("PATH={}{}", rootfs_src_dir.to_string_lossy(), curr_path)));
+        assert!(fs::read_to_string(rootfs_bin_dir.join(hypnoanalyze_link)).unwrap().contains(&format!("PATH={}{}", rootfs_src_dir.to_string_lossy(), ";%PATH%")));
         assert_eq!(rootfs_src_dir.join("hypnoanalyze.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(hypnoanalyze_link)).unwrap()
                                                                               .target);


### PR DESCRIPTION
This variable was only used in two Windows-specific lines, so using the literal instead should silence this warning without affecting Windows.
