### PR TITLE
Fix cargo update scheduled task

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -91,5 +91,5 @@ subscriptions:
 
 schedules:
   - name: cargo_update
-    description: "Run 'cargo update' every Sunday at 2am"
-    cronline: "0 2 * * 0"
+    description: "Run 'cargo update' every Monday at 12PM UTC"
+    cronline: "0 12 * * 1"

--- a/.expeditor/scripts/cargo_update.sh
+++ b/.expeditor/scripts/cargo_update.sh
@@ -2,11 +2,6 @@
 
 set -euo pipefail 
  
-if ! "${BUILDKITE:-false}"; then 
-  echo "This script does not appear to be running in Buildkite. Exiting!" 
-  exit 1
-fi
-
 # shellcheck source=./support/ci/shared.sh 
 source ./support/ci/shared.sh 
 


### PR DESCRIPTION
The scheduled task should always be run from CI so we don't need the guard. 

Adjust the timing to account for UTC. This should now run shortly before the start of the work week (for the current members of the Habitat team) rather than Saturday evening.  