### PR TITLE
Copy SSL certs into Windows studio

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -1,4 +1,5 @@
-use crate::{command::studio::enter::ARTIFACT_PATH_ENVVAR,
+use crate::{command::studio::enter::{ARTIFACT_PATH_ENVVAR,
+                                     CERT_PATH_ENVVAR},
             common::ui::UI,
             error::{Error,
                     Result},
@@ -6,7 +7,8 @@ use crate::{command::studio::enter::ARTIFACT_PATH_ENVVAR,
                     env as henv,
                     fs::{cache_key_path,
                          CACHE_ARTIFACT_PATH,
-                         CACHE_KEY_PATH},
+                         CACHE_KEY_PATH,
+                         CACHE_SSL_PATH},
                     os::process,
                     package::target,
                     util::docker},
@@ -68,8 +70,13 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
                                    mnt_prefix,
                                    CACHE_KEY_PATH),];
     if let Ok(cache_artifact_path) = henv::var(ARTIFACT_PATH_ENVVAR) {
+        // Don't use Path::join here as "\" can cause problems in Docker mounts
         volumes.push(format!("{}:{}/{}",
                              cache_artifact_path, mnt_prefix, CACHE_ARTIFACT_PATH));
+    }
+    if let Ok(cache_ssl_path) = henv::var(CERT_PATH_ENVVAR) {
+        // Don't use Path::join here as "\" can cause problems in Docker mounts
+        volumes.push(format!("{}:{}/{}", cache_ssl_path, mnt_prefix, CACHE_SSL_PATH));
     }
     if !using_windows_containers
        && (Path::new(DOCKER_SOCKET).exists() || cfg!(target_os = "windows"))

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -254,6 +254,16 @@ function New-Studio {
     $env:HAB_CACHE_KEY_PATH = Join-Path $env:FS_ROOT "hab\cache\keys"
   }
 
+  $env:HAB_CACHE_SSL_PATH = Join-Path $env:FS_ROOT "hab\cache\ssl"
+  if (!(Test-Path $env:HAB_CACHE_SSL_PATH)) {
+    mkdir $env:HAB_CACHE_SSL_PATH | Out-Null
+  }
+
+  $sslCacheSourcePath = Join-Path $env:SystemDrive "hab\cache\ssl"
+  if (Test-Path $sslCacheSourcePath) {
+    Write-HabInfo "Populating SSL certificate cache at $env:HAB_CACHE_SSL_PATH"
+    Copy-Item -Path $sslCacheSourcePath\* -Destination $env:HAB_CACHE_SSL_PATH
+  }
 
   Set-Secrets
 


### PR DESCRIPTION
This change copies over SSL certs from a hab cert cache from outside the studio when creating a new Windows studio. This allows certs to be seamlessly propagated into the Studio.

Signed-off-by: Salim Alam <seasalim>


![](https://media1.giphy.com/media/3oEjHYdoXUnkbUN8QM/200w.gif?cid=5a38a5a20d2989b0a93c0df623e4b55e2808cf7cc0ed3691&rid=200w.gif)
