### PR TITLE
End to end tests: hab-svc-load and hup-does-not-abandon-services

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -33,8 +33,8 @@ steps:
   - label: "[:linux: hup-does-not-abandon-services]"
     command:
       - .expeditor/scripts/setup_environment.sh DEV
-      - hab pkg install --binlink core/expect/5.45.4/20190115014137
-      - expect test/end-to-end/hup-does-not-abandon-services.exp
+      - hab pkg install --binlink --channel=stable core/expect
+      - test/end-to-end/hup-does-not-abandon-services.exp
     expeditor:
       executor:
         docker:
@@ -45,8 +45,8 @@ steps:
   - label: "[:linux: hab-svc-load]"
     command:
       - .expeditor/scripts/setup_environment.sh DEV
-      - hab pkg install --binlink core/expect/5.45.4/20190115014137
-      - expect test/end-to-end/hab-svc-load.exp
+      - hab pkg install --binlink --channel=stable core/expect
+      - test/end-to-end/hab-svc-load.exp
     expeditor:
       executor:
         docker:

--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -42,6 +42,18 @@ steps:
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
 
+  - label: "[:linux: hab-svc-load]"
+    command:
+      - .expeditor/scripts/setup_environment.sh DEV
+      - hab pkg install --binlink core/expect/5.45.4/20190115014137
+      - expect test/end-to-end/hab-svc-load.exp
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+
   - label: "[:linux: test_launcher_checks_supervisor_version]"
     command:
       - .expeditor/scripts/setup_environment.sh DEV

--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -9,7 +9,7 @@ expeditor:
       timeout_in_minutes: 30
       env:
         HAB_ORIGIN: "core"
-        ACCEPTANCE_HAB_BLDR_URL: "https://bldr.acceptance.habitat.sh"
+        HAB_BLDR_URL: "https://bldr.acceptance.habitat.sh"
         HAB_BLDR_CHANNEL: "DEV"
         HAB_INTERNAL_BLDR_CHANNEL: "DEV"
 

--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -30,6 +30,18 @@ steps:
             - BUILD_PKG_TARGET=x86_64-linux
             - HAB_BLDR_URL=$ACCEPTANCE_HAB_BLDR_URL
 
+  - label: "[:linux: hup-does-not-abandon-services]"
+    command:
+      - .expeditor/scripts/setup_environment.sh DEV
+      - hab pkg install --binlink core/expect/5.45.4/20190115014137
+      - expect test/end-to-end/hup-does-not-abandon-services.exp
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+
   - label: "[:linux: test_launcher_checks_supervisor_version]"
     command:
       - .expeditor/scripts/setup_environment.sh DEV

--- a/.expeditor/scripts/setup_environment.sh
+++ b/.expeditor/scripts/setup_environment.sh
@@ -9,21 +9,16 @@ source .expeditor/scripts/shared.sh
 # e.g. `DEV`, `ACCEPTANCE` etc.
 channel=${1:?You must specify a channel value}
 
-# This currently overrides some functions from the pure buildkite
-# shared.sh file above. As we migrate, more things will be added to
-# this file.
-# source .expeditor/scripts/shared.sh
-
-export HAB_AUTH_TOKEN="${ACCEPTANCE_HAB_AUTH_TOKEN}"
-export HAB_BLDR_URL="${ACCEPTANCE_HAB_BLDR_URL}"
-export HAB_BLDR_CHANNEL="${channel}"
-
 declare -g hab_binary
 curlbash_hab "$BUILD_PKG_TARGET"
 
-echo "--- Installing latest core/hab from ${channel}"
-${hab_binary} pkg install --binlink --force --channel "${channel}" core/hab
-
-echo "--- $(hab --version)"
+echo "--- Installing latest core/hab from ${HAB_BLDR_URL}, ${channel} channel"
+hab pkg install core/hab \
+    --binlink \
+    --force \
+    --channel "${channel}" \
+    --url="${HAB_BLDR_URL}"
+echo "--- Using $(hab --version)"
 
 useradd --system --no-create-home hab
+

--- a/.expeditor/scripts/setup_environment.sh
+++ b/.expeditor/scripts/setup_environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -xeuo pipefail
 
 source .expeditor/scripts/shared.sh
 
@@ -25,3 +25,5 @@ echo "--- Installing latest core/hab from ${channel}"
 ${hab_binary} pkg install --binlink --force --channel "${channel}" core/hab
 
 echo "--- $(hab --version)"
+
+useradd --system --no-create-home hab

--- a/.expeditor/scripts/setup_environment.sh
+++ b/.expeditor/scripts/setup_environment.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -xeuo pipefail
+set -euo pipefail
 
 source .expeditor/scripts/shared.sh
 

--- a/test/end-to-end/hab-svc-load.exp
+++ b/test/end-to-end/hab-svc-load.exp
@@ -1,4 +1,4 @@
-#!/usr/bin/env expect
+#!/bin/expect
 
 # Run a Supervisor locally and verify that `hab svc load` works
 # See https://github.com/habitat-sh/habitat/issues/6852

--- a/test/end-to-end/hab-svc-load.exp
+++ b/test/end-to-end/hab-svc-load.exp
@@ -1,0 +1,73 @@
+#!/usr/bin/env expect
+
+# Run a Supervisor locally and verify that `hab svc load` works
+# See https://github.com/habitat-sh/habitat/issues/6852
+#
+# Run under sudo (for now, at least)
+#
+# TODO: This currently depends on a bit of state
+#
+# - Which launcher version is used
+# - Which sup version is used
+# - Having write access to the filesystem
+# - There are no other services running
+#
+# We might be able to concoct a Docker container that things could run
+# in, but we'd need to start the container with something other than
+# the Launcher as PID 1, because otherwise, there's no way to verify
+# that the services are actually cleaned up properly.
+
+# TODO: make this work on Windows
+
+# TODO: Find a real test assertion library for TCL
+proc assert {cond {msg "assertion failed"}} {
+    if {![uplevel 1 expr $cond]} {error $msg}
+}
+
+# Print out some helpful tracing messages in the test output.
+proc log {message} {
+    puts "LOG >>> $message"
+}
+
+# Cleanup after the test
+exit -onexit {
+    exec hab sup term
+    exec rm -Rf /hab/sup/default/specs/redis.spec
+    exec pkill redis-server ;# Just in case the test fails
+}
+
+# Begin the test!
+
+# Start up a Supervisor
+spawn hab sup run
+expect {
+    "Starting http-gateway on 0.0.0.0:9631" {
+        log "Supervisor started normally"
+    }
+    "Unable to start Habitat Supervisor because another instance is already running" {
+        error "Another Supervisor is running; leftover state?"
+    }
+    timeout {
+        error "Supervisor appears not to have started, correctly"
+    }
+}
+
+# Let the control gateway come up. :/
+# Alternatively, use `nc -wv localhost 9632`
+sleep 1
+
+# Load up Redis on that Supervisor
+spawn hab svc load core/redis
+expect {
+    "The core/redis service was successfully loaded" {}
+    "Service already loaded, unload 'core/redis' and try again" {
+        error "Service was already loaded; leftover state?"
+    }
+    timeout {
+        error "Timed out waiting for core/redis to load";
+    }
+}
+expect eof wait
+
+spawn hab sup term
+wait

--- a/test/end-to-end/hup-does-not-abandon-services.exp
+++ b/test/end-to-end/hup-does-not-abandon-services.exp
@@ -99,7 +99,7 @@ expect {
         error "Redis not ready to accept connections!"
     }
 }
-set redis_pid [exec pgrep redis-server]
+set redis_pid [exec cat /hab/svc/redis/PID]
 assert { [is_alive $redis_pid] } "Redis PID isn't alive!"
 
 set redis_parent [parent_pid $redis_pid]
@@ -130,15 +130,5 @@ expect {
 assert { [is_alive $redis_pid] } "Redis PID isn't alive!"
 assert { [is_alive $launcher_pid] } "Launcher PID isn't alive!"
 
-exec hab sup term
-expect {
-    eof {
-        wait
-    }
-    timeout {
-        error "Supervisor should have shut down!"
-    }
-}
-
-assert { [is_not_alive $launcher_pid] } "Launcher PID is still alive!"
-assert { [is_not_alive $redis_pid] } "Redis PID is still alive!"
+spawn hab sup term
+wait

--- a/test/end-to-end/hup-does-not-abandon-services.exp
+++ b/test/end-to-end/hup-does-not-abandon-services.exp
@@ -99,6 +99,11 @@ expect {
         error "Redis not ready to accept connections!"
     }
 }
+
+while { [file exists /hab/svc/redis/PID] != 1} {
+    log "waiting for /hab/svc/redis/PID to be created"
+    sleep 1
+}
 set redis_pid [exec cat /hab/svc/redis/PID]
 assert { [is_alive $redis_pid] } "Redis PID isn't alive!"
 

--- a/test/end-to-end/hup-does-not-abandon-services.exp
+++ b/test/end-to-end/hup-does-not-abandon-services.exp
@@ -1,4 +1,4 @@
-#!/usr/bin/env expect
+#!/bin/expect
 
 # Run a Supervisor locally and verify that HUPping the Supervisor does
 # not result in the Launcher losing track of services, manifested by


### PR DESCRIPTION
Add/fix these two tests for our end-to-end CI. This will merge back into https://github.com/habitat-sh/habitat/pull/6780.

See also https://github.com/habitat-sh/habitat/issues/6816