### PR TITLE
Pin to reqwest 0.9.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1283,7 +1283,7 @@ dependencies = [
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1341,7 +1341,7 @@ dependencies = [
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-transcode 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1404,7 +1404,7 @@ dependencies = [
  "habitat_core 0.0.0",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.19"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3044,7 +3044,6 @@ dependencies = [
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4547,7 +4546,7 @@ dependencies = [
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0777154c2c3eb54f5c480db01de845652d941e47191277cc673634c3853939"
+"checksum reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "e57803405f8ea0eb041c1567dac36127e0c8caa1251c843cb03d43fd767b3d50"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ac83b31b3831aa4b07608db4170f6555ab12942197037c38570dc4c5ba5028"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"

--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -15,7 +15,9 @@ log = "*"
 pbr = "*"
 rand = "*"
 regex = "*"
-reqwest = "*"
+# Locked on this version of reqwest until we can go fully async: see
+# https://github.com/seanmonstar/reqwest/commit/5096e12fa21ffdf62ce953c7514e772959d1e4e1
+reqwest = "=0.9.17"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -31,7 +31,9 @@ parking_lot = "*"
 pbr = "*"
 petgraph = "*"
 regex = "*"
-reqwest = "*"
+# Locked on this version of reqwest until we can go fully async: see
+# https://github.com/seanmonstar/reqwest/commit/5096e12fa21ffdf62ce953c7514e772959d1e4e1
+reqwest = "=0.9.17"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -31,7 +31,9 @@ lazy_static = "*"
 libc = "*"
 log = "*"
 pbr = "*"
-reqwest = "*"
+# Locked on this version of reqwest until we can go fully async: see
+# https://github.com/seanmonstar/reqwest/commit/5096e12fa21ffdf62ce953c7514e772959d1e4e1
+reqwest = "=0.9.17"
 retry = "*"
 serde = "*"
 serde_derive = "*"

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -10,7 +10,9 @@ workspace = "../../"
 base64 = "*"
 log = "*"
 httparse = "*"
-reqwest = "*"
+# Locked on this version of reqwest until we can go fully async: see
+# https://github.com/seanmonstar/reqwest/commit/5096e12fa21ffdf62ce953c7514e772959d1e4e1
+reqwest = "=0.9.17"
 # Unlock with url here and in bulider-api-client
 env_proxy = "=0.3.1"
 serde = "*"


### PR DESCRIPTION
A change was added to the 0.9.18 release of reqwest that throws an
error if a blocking client is used in an asynchronous context (see
https://github.com/seanmonstar/reqwest/commit/5096e12fa21ffdf62ce953c7514e772959d1e4e1).

While this is technically correct, we need to augment our HTTP client
usage to be able to switch to an asynchronous mode of operation in the
Supervisor. Otherwise, we won't be able to, say, run `hab svc load`
and install a package, because that's performed asynchronously.

Pinning to the last good version of reqwest will allow us to proceed
until we can do the bigger fix.