### PR TITLE
Add support for running e2e tests locally, for rapid iteration

### DIFF
--- a/END_TO_END_TESTING.md
+++ b/END_TO_END_TESTING.md
@@ -1,0 +1,21 @@
+# End-to-End Testing
+
+The [end-to-end scripts](./test/end-to-end) are run automatically in CI
+with each merge to master. They are intended to run on a bare system,
+and thus should not be run directly on a developer workstation, as
+false positives, false negatives, and unintended consequences will be
+the result.
+
+To mimic the CI environment of the tests, the
+[e2e_local.sh](./e2e_local.sh) script is provided. Developers can use
+this to iterate locally on an individual test scenario.
+
+```sh
+./e2e_local.sh test/end-to-end/${YOUR_TEST_FILE}
+```
+
+Ideally, test files will take take no arguments, but can respond to
+environment variables. The variables used for local testing are
+currently found in [e2e_env](./e2e_env).
+
+Also see the [end-to-end pipeline definition](./.expeditor/end_to_end.pipeline.yml) for additional background.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -11,6 +11,7 @@ implementation details.
 - [Building](../../BUILDING.md)
 - [UX Principles](../../UX_PRINCIPLES.md)
 - [Verification Testing](../../VERIFICATION_TESTING.md)
+- [End-to-End Testing](../../END_TO_END_TESTING.md)
 
 ## Design Documents
 

--- a/e2e_env
+++ b/e2e_env
@@ -1,0 +1,9 @@
+# Environment Variables for local end-to-end testing
+#
+# DO NOT ADD SECRETS TO THIS FILE!
+#
+HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
+BUILD_PKG_TARGET=x86_64-linux
+HAB_ORIGIN=core
+HAB_BLDR_CHANNEL=DEV
+HAB_INTERNAL_BLDR_CHANNEL=DEV

--- a/e2e_local.sh
+++ b/e2e_local.sh
@@ -26,7 +26,7 @@ docker run \
        --interactive \
        --tty \
        --privileged \
-       --env-file=$(pwd)/e2e_env \
-       --volume $(pwd):/workdir \
+       --env-file="$(pwd)/e2e_env" \
+       --volume="$(pwd):/workdir" \
        --workdir=/workdir \
        chefes/buildkite /bin/bash -e -c "${commands@E}"

--- a/e2e_local.sh
+++ b/e2e_local.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# These are the commands that will be sequentially run in the
+# container. The final one will be the test itself, which is supplied
+# as the first argument to this script
+#
+# Not every test requires `expect`, but it's not hurting anything to
+# install it for everything.
+#
+# Note that the `ci-studio-common.sh` file is baked into the image we
+# use.
+raw_commands=(". /opt/ci-studio-common/buildkite-agent-hooks/ci-studio-common.sh"
+              ".expeditor/scripts/setup_environment.sh DEV"
+              "hab pkg install --binlink --channel=stable core/expect"
+              "${*}")
+
+# Add a newline after every command, for feeding into the container.
+commands="${raw_commands[*]/%/\\n}"
+
+# The `${variable@E}` notation interprets the `\n` sequences as actual
+# newlines.
+docker run \
+       --rm \
+       --interactive \
+       --tty \
+       --privileged \
+       --env-file=$(pwd)/e2e_env \
+       --volume $(pwd):/workdir \
+       --workdir=/workdir \
+       chefes/buildkite /bin/bash -e -c "${commands@E}"


### PR DESCRIPTION
Adds an `e2e_local.sh` script that can be used to run an individual
end-to-end test script in an isolated Docker environment that mimics
what we use in CI.

Documentation is included, but the TL;DR is

```sh
./e2e_local.sh test/end-to-end/${YOUR_TEST_FILE}
```

Signed-off-by: Christopher Maier <cmaier@chef.io>