### PR TITLE
report last error after all failed pkg download attempts

### DIFF
--- a/.expeditor/scripts/shared.ps1
+++ b/.expeditor/scripts/shared.ps1
@@ -1,3 +1,17 @@
+function Get-RustfmtToolchain {
+  # It turns out that every nightly version of rustfmt has slight tweaks from the previous version.
+  # This means that if we're always using the latest version, then we're going to have enormous
+  # churn. Even PRs that don't touch rust code will likely fail CI, since master will have been
+  # formatted with a different version than is running in CI. Because of this, we're going to pin
+  # the version of nightly that's used to run rustfmt and bump it when we do a new release.
+  #
+  # Note that not every nightly version of rust includes rustfmt. Sometimes changes are made that
+  # break the way rustfmt uses rustc. Therefore, before updating the pin below, double check
+  # that the nightly version you're going to update it to includes rustfmt. You can do that
+  # using https://mexus.github.io/rustup-components-history/x86_64-unknown-linux-gnu.html
+  Get-Content "$PSScriptRoot\..\..\RUSTFMT_VERSION"
+}
+
 function Install-Habitat {
   if (get-command -Name hab -ErrorAction SilentlyContinue) {
       Write-Host "Using habitat version:`n$(hab --version)"

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -672,11 +672,12 @@ impl<'a> InstallTask<'a> {
                    ident);
         } else if self.is_offline() {
             return Err(Error::OfflineArtifactNotFound(ident.as_ref().clone()));
-        } else if retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), fetch_artifact).is_err() {
+        } else if let Err(err) = retry(delay::Fixed::from(RETRY_WAIT).take(RETRIES), fetch_artifact)
+        {
             return Err(Error::DownloadFailed(format!("We tried {} times but \
                                                       could not download {}. \
-                                                      Giving up.",
-                                                     RETRIES, ident)));
+                                                      Last error was: {}",
+                                                     RETRIES, ident, err)));
         }
 
         let mut artifact = PackageArchive::new(self.cached_artifact_path(ident));


### PR DESCRIPTION
When downloading packages we retry up to 5 times when there is any failure. However the true inner error is never reported back which can make debugging difficult. This bubbles up the error message of the last attempt.

For example, the current state of master has a bug that will fail on `chunked` transfer encoding because there is no `CONTENT_LENGTH` header. In such a case this PR would result in the final error output being:

```
XXX
XXX We tried 5 times but could not download core/visual-build-tools-2017/15/20190808171719. Last error was: Missing header
XXX                                                                                                                     
```

Signed-off-by: mwrock <matt@mattwrock.com>