### PR TITLE
handle chunked encoding responses that lack content length header

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -172,25 +172,22 @@ impl BuilderAPIClient {
         resp.ok_if(StatusCode::OK)?;
 
         fs::create_dir_all(&dst_path)?;
-
         let file_name = resp.get_header(X_FILENAME)?;
         let dst_file_path = dst_path.join(file_name);
         let w = AtomicWriter::new(&dst_file_path)?;
         w.with_writer(|mut f| {
-             match progress {
-                 Some(mut progress) => {
-                     let size = resp.get_header(CONTENT_LENGTH)?
-                                    .parse()
-                                    .map_err(Error::ParseIntError)?;
-
+             // There will be no CONTENT_LENGTH header if an on prem
+             // builder is using chunked transfer encoding
+             match (progress, resp.get_header(CONTENT_LENGTH)) {
+                 (Some(mut progress), Ok(header)) => {
+                     let size = header.parse().map_err(Error::ParseIntError)?;
                      progress.size(size);
                      let mut writer = BroadcastWriter::new(&mut f, progress);
                      io::copy(&mut resp, &mut writer).map_err(Error::IO)
                  }
-                 None => io::copy(&mut resp, &mut f).map_err(Error::IO),
+                 _ => io::copy(&mut resp, &mut f).map_err(Error::IO),
              }
          })?;
-
         Ok(dst_file_path)
     }
 


### PR DESCRIPTION
This is a bug introduced in the migration to reqwest but has nothing to do with that crate but is instead related to some refactoring of the line that gets the `content_length` header. We used to fall back to `0` if there was no header but now it will throw the `no header` error.

It will not be uncommon for on prem builders to use chunked transfer encoding which lacks a `content_length` header. This should ignore the lack of that header.

I validated this by "hacking" the package URL with `http://anglesharp.azurewebsites.net/Chunked` which sends content in chunks.

Signed-off-by: mwrock <matt@mattwrock.com>