### PR TITLE
removes feature request from issue template in favor of the one in ha…

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,0 @@
----
-name: Feature Request
-about: Suggest new functionality for Habitat
-labels: C-feature
-
----
-


### PR DESCRIPTION
…bitat-sh/.github

I recently created a central [.github repo](https://github.com/habitat-sh/.github) for the Habitat org's community health files. For more information on community health files (and using a .github repository in the GitHub organization), check out [GitHub's documentation](https://help.github.com/en/articles/creating-a-default-community-health-file-for-your-organization).

I've removed the feature-request template in this PR so that the [habitat-sh/.github/ISSUE_TEMPLATES/feature-request.md](https://github.com/habitat-sh/.github/blob/master/.github/ISSUE_TEMPLATE/feature-request.md) will be used instead (it will auto-populate to this repo once the existing feature request issue template is removed).

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>