### PR TITLE
Copy SSL_CERT_FILE to studio internal and persist env var

### DIFF
--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -59,6 +59,7 @@ steps:
             - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN
+    timeout_in_minutes: 20
 
   - wait
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ dependencies = [
  "pbr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -36,6 +36,7 @@ pbr = "*"
 # and https://github.com/habitat-sh/habitat/issues/6852
 reqwest = "=0.9.17"
 retry = "*"
+same-file = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -25,6 +25,7 @@ pub enum Error {
     APIClient(api_client::Error),
     ArgumentError(&'static str),
     ButterflyError(String),
+    CacheSslCertError(String),
     CannotParseBinlinkBinaryName(PathBuf),
     CannotParseBinlinkTarget(PathBuf),
     CannotRemoveDockerStudio,
@@ -74,6 +75,7 @@ impl fmt::Display for Error {
             Error::APIClient(ref e) => e.to_string(),
             Error::ArgumentError(ref e) => e.to_string(),
             Error::ButterflyError(ref e) => e.to_string(),
+            Error::CacheSslCertError(ref e) => format!("Cannot cache SSL_CERT_FILE: {}", e),
             Error::CannotParseBinlinkBinaryName(ref p) => {
                 format!("Cannot parse binlink binary name from {}.", p.display())
             }
@@ -185,6 +187,7 @@ impl error::Error for Error {
             Error::APIClient(ref err) => err.description(),
             Error::ArgumentError(_) => "There was an error parsing an error or with it's value",
             Error::ButterflyError(_) => "Butterfly has had an error",
+            Error::CacheSslCertError(_) => "Cannot cache SSL_CERT_FILE",
             Error::CannotParseBinlinkBinaryName(_) => "Cannot parse binlink binary name",
             Error::CannotParseBinlinkTarget(_) => "Cannot parse binlink target path",
             Error::CannotRemoveFromChannel(_) => {

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -288,7 +288,6 @@ subcommand_enter() {
   shift "$((OPTIND - 1))"
 
   trap cleanup_studio EXIT
-
   new_studio
   enter_studio "$@"
 }
@@ -882,6 +881,12 @@ chroot_env() {
     env="$env no_proxy=$(echo "$no_proxy" | $bb sed 's/, /,/g')"
   fi
 
+  if [ -n "${SSL_CERT_FILE:-}" ] \
+  && [ -z "${NO_MOUNT}" ] \
+  && [ -z "${NO_CERT_PATH}" ]; then 
+    env="$env SSL_CERT_FILE=${HAB_CACHE_CERT_PATH}/$($bb basename "$SSL_CERT_FILE")"
+  fi
+
   env="$env $(load_secrets)"
 
   echo "$env"
@@ -940,6 +945,7 @@ report_env_vars() {
 cleanup_studio() {
   kill_launcher
   chown_artifacts
+  chown_certs
   unmount_filesystems
 }
 


### PR DESCRIPTION
Closes #6900 

This will copy an ssl certificate specified by the SSL_CERT_FILE env variable to the inside of the studio, and set the variable on the inside of the studio to the  internal cache.

@chefsalim  I think we'll want to pull the certificate copy back into `studio::enter` in the Rust code.  It will cut down on the duplication between shell/powershell and I _think_ it will need to live there anyways in order for the Docker studio to have the same functionality. 

I'm going to work on the powershell implementation and add some tests in the mean time. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>