### PR TITLE
mention earlier there's a debug option for PS plans

### DIFF
--- a/www/source/partials/docs/_dev-pkgs-troubleshooting.html.md.erb
+++ b/www/source/partials/docs/_dev-pkgs-troubleshooting.html.md.erb
@@ -1,10 +1,10 @@
 # <a name="debug-builds" id="debug-builds" data-magellan-target="debug-builds">Troubleshooting Builds</a>
 
-While working on plans, you may wish to stop the build and inspect the environment at any point during a build phase (e.g. download, build, unpack, etc.). In Bash based plans, Chef Habitat provides an `attach` function for use in your plan.sh that functions like a debugging breakpoint and provides an easy <acronym title="Read, Evaluation, Print Loop">REPL</acronym> at that point.
+While working on plans, you may wish to stop the build and inspect the environment at any point during a build phase (e.g. download, build, unpack, etc.). In Bash-based plans, Chef Habitat provides an `attach` function for use in your plan.sh that functions like a debugging breakpoint and provides an easy <acronym title="Read, Evaluation, Print Loop">REPL</acronym> at that point. For PowerShell-based plans, you can use the PowerShell built-in `Set-PSBreakpoint` cmdlet prior to running your build.
+
+### Bash Plans: `attach`
 
 To use `attach`, insert it into your plan at the point where you would like to use it, e.g.
-
-> Note: `attach` is only available in `plan.sh` files and not in Powershell based plans.
 
 ```bash
  do_build() {
@@ -74,7 +74,7 @@ Aliases
 
   Type `quit` when you are done with the debugger, and the remainder of the build will continue. If you wish to abort the build entirely, type `quit-program`.
 
-### Using `Set-PSBreakpoint` in Powershell plans
+### PowerShell Plans: `Set-PSBreakpoint`
 
 While there is no `attach` function exposed in a `plan.ps1` file, one can use the native Powershell cmdlet `Set-PSBreakpoint` to access virtually the same functionality. Instead of adding `attach` to your `Invoke-Build` function, enter the following from inside your studio shell:
 


### PR DESCRIPTION
I'd been tripped up for weeks on the note saying there is no "attach" command for PowerShell plans. I stopped reading there and totally missed the section below it about "Set-PSBreakPoint". Here's an documentation offering that might clue future readers into the existence of a debugging option for PowerShell by mentioning both in the section's intro paragraph and naming the sub-sections according to the plan-type.