### PR TITLE
Remove PID file error message

### DIFF
--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -275,10 +275,7 @@ fn read_pid<T>(pid_file: T) -> Option<Pid>
                 }
             }
         }
-        Err(ref err) if err.kind() == std::io::ErrorKind::NotFound => {
-            error!("PID file not found: {}", p.display());
-            None
-        }
+        Err(ref err) if err.kind() == std::io::ErrorKind::NotFound => None,
         Err(_) => {
             error!("Error reading PID file: {}", p.display());
             None


### PR DESCRIPTION
Remove the error message when a PID file is not found. We use `read_pid` to check if a service is running. If it is not running the PID file will not be found. This always happens at startup and is not a true error.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>