### PR TITLE
Remove unused locks and consolidate test helpers.

### DIFF
--- a/components/common/src/templating/test_helpers.rs
+++ b/components/common/src/templating/test_helpers.rs
@@ -1,11 +1,10 @@
+use crate::json;
+use serde_json;
 use std::{fs::File,
           io::{Read,
                Write},
           path::{Path,
                  PathBuf}};
-
-use crate::json;
-use serde_json;
 use valico::json_schema;
 
 pub fn create_with_content<P>(path: P, content: &str)

--- a/components/hab/src/command/bldr/job/promote.rs
+++ b/components/hab/src/command/bldr/job/promote.rs
@@ -142,13 +142,6 @@ pub fn start(ui: &mut UI,
 
 #[cfg(test)]
 mod test {
-    use std::{io::{self,
-                   Cursor,
-                   Write},
-              sync::{Arc,
-                     RwLock}};
-    use termcolor::ColorChoice;
-
     use super::get_ident_list;
     use crate::{api_client::{Project,
                              SchedulerResponse},
@@ -169,49 +162,9 @@ mod test {
         vec![project1, project2]
     }
 
-    fn ui() -> (UI, OutputBuffer, OutputBuffer) {
-        let stdout_buf = OutputBuffer::new();
-        let stderr_buf = OutputBuffer::new();
-
-        let ui = UI::with_streams(Box::new(io::empty()),
-                                  || Box::new(stdout_buf.clone()),
-                                  || Box::new(stderr_buf.clone()),
-                                  ColorChoice::Never,
-                                  false);
-
-        (ui, stdout_buf, stderr_buf)
-    }
-
-    #[derive(Clone)]
-    pub struct OutputBuffer {
-        pub cursor: Arc<RwLock<Cursor<Vec<u8>>>>,
-    }
-
-    impl OutputBuffer {
-        fn new() -> Self {
-            OutputBuffer { cursor: Arc::new(RwLock::new(Cursor::new(Vec::new()))), }
-        }
-    }
-
-    impl Write for OutputBuffer {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.cursor
-                .write()
-                .expect("Cursor lock is poisoned")
-                .write(buf)
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            self.cursor
-                .write()
-                .expect("Cursor lock is poisoned")
-                .flush()
-        }
-    }
-
     #[test]
     fn test_get_ident_list() {
-        let (mut ui, _stdout, _stderr) = ui();
+        let mut ui = UI::with_sinks();
         let group_status = SchedulerResponse { id:           "12345678".to_string(),
                                                state:        "Finished".to_string(),
                                                projects:     sample_project_list(),


### PR DESCRIPTION
The OutputBuffer construct that was used to test certain functions
involving the UI struct was entirely unnecessary, given `UI::with_sinks`.

This is in service of completing https://github.com/habitat-sh/habitat/issues/6435

![](https://media.giphy.com/media/ltPSrOE0p2tRS/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>