### PR TITLE
Redo the locks inside the butterfly::server module.

### DIFF
--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -24,7 +24,6 @@ pub enum Error {
     HabitatCore(habitat_core::error::Error),
     IncarnationIO(PathBuf, io::Error),
     IncarnationParse(PathBuf, num::ParseIntError),
-    InvalidIncarnationSynchronization,
     InvalidRumorShareLimit,
     NonExistentRumor(String, String),
     ProtocolMismatch(&'static str),
@@ -73,10 +72,6 @@ impl fmt::Display for Error {
                         path.display(),
                         err)
             }
-            Error::InvalidIncarnationSynchronization => "Tried to synchronize own member \
-                                                         incarnation from non-existent \
-                                                         incarnation store"
-                                                                           .to_string(),
             Error::InvalidRumorShareLimit => {
                 "Rumor share limit should be a positive integer".to_string()
             }
@@ -125,9 +120,6 @@ impl error::Error for Error {
             Error::HabitatCore(_) => "Habitat core error",
             Error::IncarnationIO(..) => "Error reading or writing incarnation store file",
             Error::IncarnationParse(..) => "Error parsing value from incarnation store file",
-            Error::InvalidIncarnationSynchronization => {
-                "Tried to synchronize own member incarnation from non-existent incarnation store"
-            }
             Error::InvalidRumorShareLimit => "Invalid rumor share limit",
             Error::NonExistentRumor(..) => "Cannot write rumor to bytes because it does not exist",
             Error::ProtocolMismatch(_) => {

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
         server.member_list.add_initial_member_imlw(member);
     }
 
-    server.start_rsw_mlw(&server::timing::Timing::default())
+    server.start_rsw_mlw_smw(&server::timing::Timing::default())
           .expect("Cannot start server");
     loop {
         println!("{:#?}", server.member_list);

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -115,7 +115,7 @@ pub(crate) mod sync {
     impl<'a> MyselfReadGuard<'a> {
         fn new(lock: &'a Lock<MyselfInner>) -> Self { Self(lock.read()) }
 
-        pub fn as_member(&self) -> Member { self.0.as_member() }
+        pub fn to_member(&self) -> Member { self.0.as_member() }
 
         pub fn incarnation(&self) -> Incarnation { self.0.incarnation() }
     }
@@ -581,7 +581,7 @@ impl Server {
 
     pub fn set_member_persistent(&mut self) { self.member.lock_smw().set_persistent() }
 
-    pub fn member_as_member(&self) -> Member { self.member.lock_smr().as_member() }
+    pub fn member_as_member(&self) -> Member { self.member.lock_smr().to_member() }
 
     /// Insert a member to the `MemberList`, and update its `RumorKey` appropriately.
     ///

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -107,7 +107,7 @@ pub trait Suitability: Debug + Send + Sync {
 ///
 /// In particular, this localizes all incarnation increment and
 /// persistence logic.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Myself {
     member: Member,
     // TODO (CM): This is only optional because the current

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -484,8 +484,7 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `Server::block_list` (write)
     pub fn add_to_block_list_sblw(&self, member_id: String) {
-        let mut block_list = self.block_list.write();
-        block_list.insert(member_id);
+        self.block_list.write().insert(member_id);
     }
 
     /// Remove a given address from the block_list.
@@ -493,8 +492,7 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `Server::block_list` (write)
     pub fn remove_from_block_list_sblw(&self, member_id: &str) {
-        let mut block_list = self.block_list.write();
-        block_list.remove(member_id);
+        self.block_list.write().remove(member_id);
     }
 
     /// Check if a given member ID is on the block_list.
@@ -502,8 +500,7 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `Server::block_list` (read)
     fn is_member_blocked_sblr(&self, member_id: &str) -> bool {
-        let block_list = self.block_list.read();
-        block_list.contains(member_id)
+        self.block_list.read().contains(member_id)
     }
 
     /// Stop the outbound and inbound threads from processing work.

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -609,12 +609,10 @@ impl Server {
     /// * `Server::member` (write)
     pub fn set_departed_mlw_smw(&self) {
         if self.socket.is_some() {
-            {
-                self.myself.lock_smw().increment_incarnation();
-                // TODO (CM): It's not clear that this operation is actually needed.
-                self.myself.lock_smw().mark_departed();
-                self.member_list.set_departed_mlw(&self.member_id);
-            }
+            self.myself.lock_smw().increment_incarnation();
+            // TODO (CM): It's not clear that this operation is actually needed.
+            self.myself.lock_smw().mark_departed();
+            self.member_list.set_departed_mlw(&self.member_id);
             // We need to mark this as "hot" in order to propagate it.
             //
             // TODO (CM): This exact code is present numerous places;

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -652,13 +652,14 @@ impl Server {
     fn insert_member_from_rumor_mlw_smw(&self, member: Member, mut health: Health) {
         let rk: RumorKey = RumorKey::from(&member);
 
-        if member.id == self.member_id() && health != Health::Alive {
-            if member.incarnation >= self.member.lock_smr().incarnation() {
-                self.member
-                    .lock_smw()
-                    .refute_incarnation(member.incarnation);
-                health = Health::Alive;
-            }
+        if member.id == self.member_id()
+           && health != Health::Alive
+           && member.incarnation >= self.member.lock_smr().incarnation()
+        {
+            self.member
+                .lock_smw()
+                .refute_incarnation(member.incarnation);
+            health = Health::Alive;
         }
 
         let member_id = member.id.clone();

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -579,9 +579,7 @@ impl Server {
     /// Return the name of this server.
     pub fn name(&self) -> &str { &self.name }
 
-    pub fn set_member_persistent(&mut self) { self.myself.lock_smw().set_persistent() }
-
-    pub fn member_as_member(&self) -> Member { self.myself.lock_smr().to_member() }
+    pub fn myself(&self) -> &Myself { self.myself.as_ref() }
 
     /// Insert a member to the `MemberList`, and update its `RumorKey` appropriately.
     ///

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -96,7 +96,7 @@ pub fn run_loop(server: &Server, socket: &UdpSocket, tx_outbound: &AckSender) ->
                 trace!("SWIM Message: {:?}", msg);
                 match msg.kind {
                     SwimKind::Ping(ping) => {
-                        if server.is_member_blocked(&ping.from.id) {
+                        if server.is_member_blocked_sblr(&ping.from.id) {
                             debug!("Not processing message from {} - it is blocked",
                                    ping.from.id);
                             continue;
@@ -104,7 +104,7 @@ pub fn run_loop(server: &Server, socket: &UdpSocket, tx_outbound: &AckSender) ->
                         process_ping_mlw(server, socket, addr, ping);
                     }
                     SwimKind::Ack(ack) => {
-                        if server.is_member_blocked(&ack.from.id) && ack.forward_to.is_none() {
+                        if server.is_member_blocked_sblr(&ack.from.id) && ack.forward_to.is_none() {
                             debug!("Not processing message from {} - it is blocked",
                                    ack.from.id);
                             continue;
@@ -112,12 +112,12 @@ pub fn run_loop(server: &Server, socket: &UdpSocket, tx_outbound: &AckSender) ->
                         process_ack_mlw(server, socket, tx_outbound, addr, ack);
                     }
                     SwimKind::PingReq(pingreq) => {
-                        if server.is_member_blocked(&pingreq.from.id) {
+                        if server.is_member_blocked_sblr(&pingreq.from.id) {
                             debug!("Not processing message from {} - it is blocked",
                                    pingreq.from.id);
                             continue;
                         }
-                        process_pingreq_mlr(server, socket, addr, pingreq);
+                        process_pingreq_mlr_smr(server, socket, addr, pingreq);
                     }
                 }
             }
@@ -146,11 +146,15 @@ pub fn run_loop(server: &Server, socket: &UdpSocket, tx_outbound: &AckSender) ->
 ///
 /// # Locking (see locking.md)
 /// * `MemberList::entries` (read)
-fn process_pingreq_mlr(server: &Server, socket: &UdpSocket, addr: SocketAddr, mut msg: PingReq) {
+/// * `Server::member` (read)
+fn process_pingreq_mlr_smr(server: &Server,
+                           socket: &UdpSocket,
+                           addr: SocketAddr,
+                           mut msg: PingReq) {
     if let Some(target) = server.member_list.get_cloned_mlr(&msg.target.id) {
         msg.from.address = addr.ip().to_string();
         let ping_msg = Ping { membership: vec![],
-                              from:       server.member.read().unwrap().as_member(),
+                              from:       server.member.read().as_member(),
                               forward_to: Some(msg.from.clone()), };
         let swim = outbound::populate_membership_rumors_mlr(server, &target, ping_msg);
         // Set the route-back address to the one we received the
@@ -202,7 +206,7 @@ fn process_ack_mlw(server: &Server,
     match tx_outbound.send((addr, msg)) {
         Ok(()) => {
             for membership in memberships {
-                server.insert_member_from_rumor_mlw(membership.member, membership.health);
+                server.insert_member_from_rumor_mlw_smw(membership.member, membership.health);
             }
         }
         Err(e) => panic!("Outbound thread has died - this shouldn't happen: #{:?}", e),
@@ -212,7 +216,7 @@ fn process_ack_mlw(server: &Server,
 /// # Locking (see locking.md)
 /// * `MemberList::entries` (write)
 fn process_ping_mlw(server: &Server, socket: &UdpSocket, addr: SocketAddr, mut msg: Ping) {
-    outbound::ack_mlr(server, socket, &msg.from, addr, msg.forward_to);
+    outbound::ack_mlr_smr(server, socket, &msg.from, addr, msg.forward_to);
     // Populate the member for this sender with its remote address
     msg.from.address = addr.ip().to_string();
     trace!("Ping from {}@{}", msg.from.id, addr);
@@ -222,6 +226,6 @@ fn process_ping_mlw(server: &Server, socket: &UdpSocket, addr: SocketAddr, mut m
         server.insert_member_mlw(msg.from, Health::Alive);
     }
     for membership in msg.membership {
-        server.insert_member_from_rumor_mlw(membership.member, membership.health);
+        server.insert_member_from_rumor_mlw_smw(membership.member, membership.health);
     }
 }

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -154,7 +154,7 @@ fn process_pingreq_mlr_smr(server: &Server,
     if let Some(target) = server.member_list.get_cloned_mlr(&msg.target.id) {
         msg.from.address = addr.ip().to_string();
         let ping_msg = Ping { membership: vec![],
-                              from:       server.member.read().as_member(),
+                              from:       server.member.lock_smr().as_member(),
                               forward_to: Some(msg.from.clone()), };
         let swim = outbound::populate_membership_rumors_mlr(server, &target, ping_msg);
         // Set the route-back address to the one we received the

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -154,7 +154,7 @@ fn process_pingreq_mlr_smr(server: &Server,
     if let Some(target) = server.member_list.get_cloned_mlr(&msg.target.id) {
         msg.from.address = addr.ip().to_string();
         let ping_msg = Ping { membership: vec![],
-                              from:       server.member.lock_smr().to_member(),
+                              from:       server.myself.lock_smr().to_member(),
                               forward_to: Some(msg.from.clone()), };
         let swim = outbound::populate_membership_rumors_mlr(server, &target, ping_msg);
         // Set the route-back address to the one we received the

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -154,7 +154,7 @@ fn process_pingreq_mlr_smr(server: &Server,
     if let Some(target) = server.member_list.get_cloned_mlr(&msg.target.id) {
         msg.from.address = addr.ip().to_string();
         let ping_msg = Ping { membership: vec![],
-                              from:       server.member.lock_smr().as_member(),
+                              from:       server.member.lock_smr().to_member(),
                               forward_to: Some(msg.from.clone()), };
         let swim = outbound::populate_membership_rumors_mlr(server, &target, ping_msg);
         // Set the route-back address to the one we received the

--- a/components/butterfly/src/server/incarnation_store.rs
+++ b/components/butterfly/src/server/incarnation_store.rs
@@ -1,17 +1,16 @@
 //! Provide the means to persist a Supervisor's own incarnation
 //! number across restarts.
 
-use std::{fs::File,
-          io::Read,
-          path::{Path,
-                 PathBuf}};
-
 use crate::{error::{Error,
                     Result},
             member::Incarnation};
 use habitat_core::fs::atomic_write;
-use std::{io,
-          num};
+use std::{fs::File,
+          io::{self,
+               Read},
+          num,
+          path::{Path,
+                 PathBuf}};
 
 /// Provide storage of an incarnation number that can persist across
 /// Supervisor restarts.

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -185,7 +185,7 @@ fn probe_mlw_smr(server: &Server,
     }
 
     let pingreq_message = PingReq { membership: vec![],
-                                    from:       server.member.read().as_member(),
+                                    from:       server.member.lock_smr().as_member(),
                                     target:     member.clone(), };
     let swim = populate_membership_rumors_mlr(server, &member, pingreq_message);
 
@@ -370,7 +370,7 @@ pub fn ping_mlr_smr(server: &Server,
                     addr: SocketAddr,
                     forward_to: Option<&Member>) {
     let ping_msg = Ping { membership: vec![],
-                          from:       server.member.read().as_member(),
+                          from:       server.member.lock_smr().as_member(),
                           forward_to: forward_to.cloned(), /* TODO: see if we can eliminate this
                                                             * clone */ };
     let swim = populate_membership_rumors_mlr(server, target, ping_msg);
@@ -474,7 +474,7 @@ pub fn ack_mlr_smr(server: &Server,
                    addr: SocketAddr,
                    forward_to: Option<Member>) {
     let ack_msg = Ack { membership: vec![],
-                        from:       server.member.read().as_member(),
+                        from:       server.member.lock_smr().as_member(),
                         forward_to: forward_to.map(Member::from), };
     let member_id = ack_msg.from.id.clone();
     let swim = populate_membership_rumors_mlr(server, target, ack_msg);

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -96,11 +96,11 @@ fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timin
                     have_members = true;
                 } else {
                     server.member_list.with_initial_members_imlr(|member| {
-                                          ping_mlr(&server,
-                                                   &socket,
-                                                   &member,
-                                                   member.swim_socket_address(),
-                                                   None);
+                                          ping_mlr_smr(&server,
+                                                       &socket,
+                                                       &member,
+                                                       member.swim_socket_address(),
+                                                       None);
                                       });
                 }
             }
@@ -124,7 +124,7 @@ fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timin
                 // until this timer expires.
                 let next_protocol_period = timing.next_protocol_period();
 
-                probe_mlw(&server, &socket, &rx_inbound, &timing, member);
+                probe_mlw_smr(&server, &socket, &rx_inbound, &timing, member);
 
                 if SteadyTime::now() <= next_protocol_period {
                     let wait_time = (next_protocol_period - SteadyTime::now()).num_milliseconds();
@@ -163,11 +163,12 @@ fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timin
 ///
 /// # Locking (see locking.md)
 /// * `MemberList::entries` (write)
-fn probe_mlw(server: &Server,
-             socket: &UdpSocket,
-             rx_inbound: &AckReceiver,
-             timing: &Timing,
-             member: Member) {
+/// * `Server::member` (read)
+fn probe_mlw_smr(server: &Server,
+                 socket: &UdpSocket,
+                 rx_inbound: &AckReceiver,
+                 timing: &Timing,
+                 member: Member) {
     let pa_timer = SWIM_PROBE_DURATION.with_label_values(&["ping/ack"])
                                       .start_timer();
     let mut pr_timer: Option<HistogramTimer> = None;
@@ -175,7 +176,7 @@ fn probe_mlw(server: &Server,
 
     // Ping the member, and wait for the ack.
     SWIM_PROBES_SENT.with_label_values(&["ping"]).inc();
-    ping_mlr(server, socket, &member, addr, None);
+    ping_mlr_smr(server, socket, &member, addr, None);
 
     if recv_ack_mlw(server, rx_inbound, timing, &member, addr, AckFrom::Ping) {
         SWIM_PROBES_SENT.with_label_values(&["ack"]).inc();
@@ -184,7 +185,7 @@ fn probe_mlw(server: &Server,
     }
 
     let pingreq_message = PingReq { membership: vec![],
-                                    from:       server.member.read().unwrap().as_member(),
+                                    from:       server.member.read().as_member(),
                                     target:     member.clone(), };
     let swim = populate_membership_rumors_mlr(server, &member, pingreq_message);
 
@@ -362,13 +363,14 @@ fn pingreq(server: &Server, // TODO: eliminate this arg
 ///
 /// # Locking (see locking.md)
 /// * `MemberList::entries` (read)
-pub fn ping_mlr(server: &Server,
-                socket: &UdpSocket,
-                target: &Member,
-                addr: SocketAddr,
-                forward_to: Option<&Member>) {
+/// * `Server::member` (read)
+pub fn ping_mlr_smr(server: &Server,
+                    socket: &UdpSocket,
+                    target: &Member,
+                    addr: SocketAddr,
+                    forward_to: Option<&Member>) {
     let ping_msg = Ping { membership: vec![],
-                          from:       server.member.read().unwrap().as_member(),
+                          from:       server.member.read().as_member(),
                           forward_to: forward_to.cloned(), /* TODO: see if we can eliminate this
                                                             * clone */ };
     let swim = populate_membership_rumors_mlr(server, target, ping_msg);
@@ -465,13 +467,14 @@ pub fn forward_ack(server: &Server, socket: &UdpSocket, addr: SocketAddr, msg: A
 ///
 /// # Locking (see locking.md)
 /// * `MemberList::entries` (read)
-pub fn ack_mlr(server: &Server,
-               socket: &UdpSocket,
-               target: &Member,
-               addr: SocketAddr,
-               forward_to: Option<Member>) {
+/// * `Server::member` (read)
+pub fn ack_mlr_smr(server: &Server,
+                   socket: &UdpSocket,
+                   target: &Member,
+                   addr: SocketAddr,
+                   forward_to: Option<Member>) {
     let ack_msg = Ack { membership: vec![],
-                        from:       server.member.read().unwrap().as_member(),
+                        from:       server.member.read().as_member(),
                         forward_to: forward_to.map(Member::from), };
     let member_id = ack_msg.from.id.clone();
     let swim = populate_membership_rumors_mlr(server, target, ack_msg);

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -185,7 +185,7 @@ fn probe_mlw_smr(server: &Server,
     }
 
     let pingreq_message = PingReq { membership: vec![],
-                                    from:       server.member.lock_smr().as_member(),
+                                    from:       server.member.lock_smr().to_member(),
                                     target:     member.clone(), };
     let swim = populate_membership_rumors_mlr(server, &member, pingreq_message);
 
@@ -370,7 +370,7 @@ pub fn ping_mlr_smr(server: &Server,
                     addr: SocketAddr,
                     forward_to: Option<&Member>) {
     let ping_msg = Ping { membership: vec![],
-                          from:       server.member.lock_smr().as_member(),
+                          from:       server.member.lock_smr().to_member(),
                           forward_to: forward_to.cloned(), /* TODO: see if we can eliminate this
                                                             * clone */ };
     let swim = populate_membership_rumors_mlr(server, target, ping_msg);
@@ -474,7 +474,7 @@ pub fn ack_mlr_smr(server: &Server,
                    addr: SocketAddr,
                    forward_to: Option<Member>) {
     let ack_msg = Ack { membership: vec![],
-                        from:       server.member.lock_smr().as_member(),
+                        from:       server.member.lock_smr().to_member(),
                         forward_to: forward_to.map(Member::from), };
     let member_id = ack_msg.from.id.clone();
     let swim = populate_membership_rumors_mlr(server, target, ack_msg);

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -185,7 +185,7 @@ fn probe_mlw_smr(server: &Server,
     }
 
     let pingreq_message = PingReq { membership: vec![],
-                                    from:       server.member.lock_smr().to_member(),
+                                    from:       server.myself.lock_smr().to_member(),
                                     target:     member.clone(), };
     let swim = populate_membership_rumors_mlr(server, &member, pingreq_message);
 
@@ -370,7 +370,7 @@ pub fn ping_mlr_smr(server: &Server,
                     addr: SocketAddr,
                     forward_to: Option<&Member>) {
     let ping_msg = Ping { membership: vec![],
-                          from:       server.member.lock_smr().to_member(),
+                          from:       server.myself.lock_smr().to_member(),
                           forward_to: forward_to.cloned(), /* TODO: see if we can eliminate this
                                                             * clone */ };
     let swim = populate_membership_rumors_mlr(server, target, ping_msg);
@@ -474,7 +474,7 @@ pub fn ack_mlr_smr(server: &Server,
                    addr: SocketAddr,
                    forward_to: Option<Member>) {
     let ack_msg = Ack { membership: vec![],
-                        from:       server.member.lock_smr().to_member(),
+                        from:       server.myself.lock_smr().to_member(),
                         forward_to: forward_to.map(Member::from), };
     let member_id = ack_msg.from.id.clone();
     let swim = populate_membership_rumors_mlr(server, target, ack_msg);

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -97,7 +97,7 @@ fn run_loop(server: &Server) -> ! {
             }
         };
 
-        let blocked = server.is_member_blocked(&proto.from_id);
+        let blocked = server.is_member_blocked_sblr(&proto.from_id);
         let blocked_label = if blocked { "true" } else { "false" };
         let label_values = &[&proto.r#type.to_string(), "success", blocked_label];
 
@@ -114,7 +114,7 @@ fn run_loop(server: &Server) -> ! {
 
         match proto.kind {
             RumorKind::Membership(membership) => {
-                server.insert_member_from_rumor_mlw(membership.member, membership.health);
+                server.insert_member_from_rumor_mlw_smw(membership.member, membership.health);
             }
             RumorKind::Service(service) => server.insert_service_rsw_mlw(*service),
             RumorKind::ServiceConfig(service_config) => {

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -70,7 +70,7 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
             };
             let next_gossip = timing.gossip_timeout();
             for member in check_list.drain(0..drain_length) {
-                if server.is_member_blocked(&member.id) {
+                if server.is_member_blocked_sblr(&member.id) {
                     debug!("Not sending rumors to {} - it is blocked", member.id);
 
                     continue;

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -70,7 +70,7 @@ pub fn start_server_smw(name: &str, ring_key: Option<SymKey>, suitability: u64) 
 /// # Locking (see locking.md)
 /// * `Server::member` (read)
 pub fn member_from_server_smr(server: &Server) -> Member {
-    let mut member = server.member_as_member();
+    let mut member = server.myself().lock_smr().to_member();
     // AAAAAAARGH... we currently have to do this because otherwise we
     // have no notion of where we're coming from... in "real life",
     // other Supervisors would discover this from the networking stack

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -60,16 +60,13 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
                                  Some(String::from(name)),
                                  None,
                                  Box::new(NSuitability(suitability))).unwrap();
-    server.start_rsw_mlw(&Timing::default())
+    server.start_rsw_mlw_smw(&Timing::default())
           .expect("Cannot start server");
     server
 }
 
 pub fn member_from_server(server: &Server) -> Member {
-    let mut member = server.member
-                           .read()
-                           .expect("Member lock is poisoned")
-                           .as_member();
+    let mut member = server.member.read().as_member();
     // AAAAAAARGH... we currently have to do this because otherwise we
     // have no notion of where we're coming from... in "real life",
     // other Supervisors would discover this from the networking stack
@@ -148,7 +145,7 @@ impl SwimNet {
         let to = self.members
                      .get(to_entry)
                      .expect("Asked for a network member who is out of bounds");
-        from.add_to_block_list(String::from(to.member_id()));
+        from.add_to_block_list_sblw(String::from(to.member_id()));
     }
 
     pub fn unblock(&self, from_entry: usize, to_entry: usize) {
@@ -158,7 +155,7 @@ impl SwimNet {
         let to = self.members
                      .get(to_entry)
                      .expect("Asked for a network member who is out of bounds");
-        from.remove_from_block_list(to.member_id());
+        from.remove_from_block_list_sblw(to.member_id());
     }
 
     /// # Locking (see locking.md)

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -38,7 +38,9 @@ impl Suitability for NSuitability {
     fn get(&self, _service_group: &str) -> u64 { self.0 }
 }
 
-pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> Server {
+/// # Locking (see locking.md)
+/// * `Server::member` (write)
+pub fn start_server_smw(name: &str, ring_key: Option<SymKey>, suitability: u64) -> Server {
     let swim_port;
     let gossip_port;
     {
@@ -65,7 +67,9 @@ pub fn start_server(name: &str, ring_key: Option<SymKey>, suitability: u64) -> S
     server
 }
 
-pub fn member_from_server(server: &Server) -> Member {
+/// # Locking (see locking.md)
+/// * `Server::member` (read)
+pub fn member_from_server_smr(server: &Server) -> Member {
     let mut member = server.member.read().as_member();
     // AAAAAAARGH... we currently have to do this because otherwise we
     // have no notion of where we're coming from... in "real life",
@@ -98,7 +102,7 @@ impl SwimNet {
         SwimNet { members: suitabilities.into_iter()
                                         .enumerate()
                                         .map(|(x, suitability)| {
-                                            start_server(&format!("{}", x), None, suitability)
+                                            start_server_smw(&format!("{}", x), None, suitability)
                                         })
                                         .collect(), }
     }
@@ -112,25 +116,30 @@ impl SwimNet {
         let mut members = Vec::with_capacity(count);
         for x in 0..count {
             let rk = ring_key.clone();
-            members.push(start_server(&format!("{}", x), Some(rk), 0));
+            members.push(start_server_smw(&format!("{}", x), Some(rk), 0));
         }
         SwimNet { members }
     }
 
-    pub fn connect(&mut self, from_entry: usize, to_entry: usize) {
-        let to = member_from_server(&self.members[to_entry]);
+    /// # Locking (see locking.md)
+    /// * `Server::member` (read)
+    pub fn connect_smr(&mut self, from_entry: usize, to_entry: usize) {
+        let to = member_from_server_smr(&self.members[to_entry]);
         self.members[from_entry].insert_member_mlw(to, Health::Alive);
     }
 
-    // Fully mesh the network
-    pub fn mesh(&mut self) {
+    /// Fully mesh the network
+    ///
+    /// # Locking (see locking.md)
+    /// * `Server::member` (read)
+    pub fn mesh_mlw_smr(&mut self) {
         for pos in 0..self.members.len() {
             let mut to_mesh: Vec<Member> = Vec::new();
             for x_pos in 0..self.members.len() {
                 if pos == x_pos {
                     continue;
                 }
-                to_mesh.push(member_from_server(&self.members[x_pos]))
+                to_mesh.push(member_from_server_smr(&self.members[x_pos]))
             }
             for server_b in to_mesh.into_iter() {
                 self.members[pos].insert_member_mlw(server_b, Health::Alive);

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -70,7 +70,7 @@ pub fn start_server_smw(name: &str, ring_key: Option<SymKey>, suitability: u64) 
 /// # Locking (see locking.md)
 /// * `Server::member` (read)
 pub fn member_from_server_smr(server: &Server) -> Member {
-    let mut member = server.member.read().as_member();
+    let mut member = server.member_as_member();
     // AAAAAAARGH... we currently have to do this because otherwise we
     // have no notion of where we're coming from... in "real life",
     // other Supervisors would discover this from the networking stack

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -7,7 +7,7 @@ fn symmetric_encryption_of_wire_payloads() {
     let ring_key = SymKey::generate_pair_for_ring("wolverine").expect("Failed to generate an in \
                                                                        memory symkey");
     let mut net = btest::SwimNet::new_ring_encryption(2, &ring_key);
-    net.connect(0, 1);
+    net.connect_smr(0, 1);
     assert_wait_for_health_of_mlr!(net, [0..2, 0..2], Health::Alive);
     net.add_service(0, "core/beast/1.2.3/20161208121212");
     net.wait_for_gossip_rounds(2);

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -86,8 +86,8 @@ fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
 #[test]
 fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
     let mut net = btest::SwimNet::new(6);
-    net[0].set_member_persistent();
-    net[4].set_member_persistent();
+    net[0].myself().lock_smw().set_persistent();
+    net[4].myself().lock_smw().set_persistent();
     net.connect_smr(0, 1);
     net.connect_smr(1, 2);
     net.connect_smr(2, 3);

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -86,14 +86,8 @@ fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
 #[test]
 fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
     let mut net = btest::SwimNet::new(6);
-    net[0].member
-          .write()
-          .expect("Member lock is poisoned")
-          .set_persistent();
-    net[4].member
-          .write()
-          .expect("Member lock is poisoned")
-          .set_persistent();
+    net[0].member.write().set_persistent();
+    net[4].member.write().set_persistent();
     net.connect(0, 1);
     net.connect(1, 2);
     net.connect(2, 3);
@@ -115,7 +109,7 @@ fn six_members_unmeshed_allows_graceful_departure() {
     net.connect(3, 4);
     net.connect(4, 5);
     assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
-    net[0].set_departed_mlw();
+    net[0].set_departed_mlw_smw();
     net[0].pause();
     assert_wait_for_health_of_mlr!(net, 0, Health::Departed);
 }

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -86,8 +86,8 @@ fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
 #[test]
 fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
     let mut net = btest::SwimNet::new(6);
-    net[0].member.write().set_persistent();
-    net[4].member.write().set_persistent();
+    net[0].set_member_persistent();
+    net[4].set_member_persistent();
     net.connect_smr(0, 1);
     net.connect_smr(1, 2);
     net.connect_smr(2, 3);

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -10,7 +10,7 @@ use habitat_butterfly::{self,
 #[test]
 fn two_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(2);
-    net.mesh();
+    net.mesh_mlw_smr();
     assert_wait_for_health_of_mlr!(net, 0, 1, Health::Alive);
     assert_wait_for_health_of_mlr!(net, 1, 0, Health::Alive);
     net[0].pause();
@@ -21,7 +21,7 @@ fn two_members_meshed_confirm_one_member() {
 #[test]
 fn six_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(6);
-    net.mesh();
+    net.mesh_mlw_smr();
     net[0].pause();
     assert_wait_for_health_of_mlr!(net, 0, Health::Confirmed);
 }
@@ -29,7 +29,7 @@ fn six_members_meshed_confirm_one_member() {
 #[test]
 fn six_members_meshed_partition_one_node_from_another_node_remains_alive() {
     let mut net = btest::SwimNet::new(6);
-    net.mesh();
+    net.mesh_mlw_smr();
     net.block(0, 1);
     net.wait_for_rounds(2);
     assert_wait_for_health_of_mlr!(net, 1, Health::Alive);
@@ -38,7 +38,7 @@ fn six_members_meshed_partition_one_node_from_another_node_remains_alive() {
 #[test]
 fn six_members_meshed_partition_half_of_nodes_from_each_other_both_sides_confirmed() {
     let mut net = btest::SwimNet::new(6);
-    net.mesh();
+    net.mesh_mlw_smr();
     assert_wait_for_health_of_mlr!(net, 0, Health::Alive);
     net.partition(0..3, 3..6);
     assert_wait_for_health_of_mlr!(net, [0..3, 3..6], Health::Confirmed);
@@ -47,22 +47,22 @@ fn six_members_meshed_partition_half_of_nodes_from_each_other_both_sides_confirm
 #[test]
 fn six_members_unmeshed_become_fully_meshed_via_gossip() {
     let mut net = btest::SwimNet::new(6);
-    net.connect(0, 1);
-    net.connect(1, 2);
-    net.connect(2, 3);
-    net.connect(3, 4);
-    net.connect(4, 5);
+    net.connect_smr(0, 1);
+    net.connect_smr(1, 2);
+    net.connect_smr(2, 3);
+    net.connect_smr(3, 4);
+    net.connect_smr(4, 5);
     assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
 }
 
 #[test]
 fn six_members_unmeshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(6);
-    net.connect(0, 1);
-    net.connect(1, 2);
-    net.connect(2, 3);
-    net.connect(3, 4);
-    net.connect(4, 5);
+    net.connect_smr(0, 1);
+    net.connect_smr(1, 2);
+    net.connect_smr(2, 3);
+    net.connect_smr(3, 4);
+    net.connect_smr(4, 5);
     assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
     net[0].pause();
     assert_wait_for_health_of_mlr!(net, 0, Health::Confirmed);
@@ -71,11 +71,11 @@ fn six_members_unmeshed_confirm_one_member() {
 #[test]
 fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
     let mut net = btest::SwimNet::new(6);
-    net.connect(0, 1);
-    net.connect(1, 2);
-    net.connect(2, 3);
-    net.connect(3, 4);
-    net.connect(4, 5);
+    net.connect_smr(0, 1);
+    net.connect_smr(1, 2);
+    net.connect_smr(2, 3);
+    net.connect_smr(3, 4);
+    net.connect_smr(4, 5);
     assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
     net.partition(0..3, 3..6);
     assert_wait_for_health_of_mlr!(net, [0..3, 3..6], Health::Confirmed);
@@ -88,11 +88,11 @@ fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
     let mut net = btest::SwimNet::new(6);
     net[0].member.write().set_persistent();
     net[4].member.write().set_persistent();
-    net.connect(0, 1);
-    net.connect(1, 2);
-    net.connect(2, 3);
-    net.connect(3, 4);
-    net.connect(4, 5);
+    net.connect_smr(0, 1);
+    net.connect_smr(1, 2);
+    net.connect_smr(2, 3);
+    net.connect_smr(3, 4);
+    net.connect_smr(4, 5);
     assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
     net.partition(0..3, 3..6);
     assert_wait_for_health_of_mlr!(net, [0..3, 3..6], Health::Confirmed);
@@ -103,11 +103,11 @@ fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
 #[test]
 fn six_members_unmeshed_allows_graceful_departure() {
     let mut net = btest::SwimNet::new(6);
-    net.connect(0, 1);
-    net.connect(1, 2);
-    net.connect(2, 3);
-    net.connect(3, 4);
-    net.connect(4, 5);
+    net.connect_smr(0, 1);
+    net.connect_smr(1, 2);
+    net.connect_smr(2, 3);
+    net.connect_smr(3, 4);
+    net.connect_smr(4, 5);
     assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
     net[0].set_departed_mlw_smw();
     net[0].pause();
@@ -117,7 +117,7 @@ fn six_members_unmeshed_allows_graceful_departure() {
 #[test]
 fn ten_members_meshed_confirm_one_member() {
     let mut net = btest::SwimNet::new(10);
-    net.mesh();
+    net.mesh_mlw_smr();
     net[0].pause();
     assert_wait_for_health_of_mlr!(net, 0, Health::Confirmed);
 }

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -5,7 +5,7 @@ use habitat_butterfly::{client::Client,
 #[test]
 fn two_members_share_departures() {
     let mut net = btest::SwimNet::new(2);
-    net.mesh();
+    net.mesh_mlw_smr();
     net.add_departure(0);
     net.wait_for_gossip_rounds(1);
     assert!(net[1].departure_store
@@ -16,7 +16,7 @@ fn two_members_share_departures() {
 #[test]
 fn departure_via_client() {
     let mut net = btest::SwimNet::new(3);
-    net.mesh();
+    net.mesh_mlw_smr();
 
     net.wait_for_gossip_rounds(1);
     let mut client =

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -93,8 +93,8 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 #[allow(clippy::cognitive_complexity)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
-    net[0].member.write().set_persistent();
-    net[4].member.write().set_persistent();
+    net[0].set_member_persistent();
+    net[4].set_member_persistent();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -93,14 +93,8 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 #[allow(clippy::cognitive_complexity)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
-    net[0].member
-          .write()
-          .expect("Member lock is poisoned")
-          .set_persistent();
-    net[4].member
-          .write()
-          .expect("Member lock is poisoned")
-          .set_persistent();
+    net[0].member.write().set_persistent();
+    net[4].member.write().set_persistent();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -93,8 +93,8 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 #[allow(clippy::cognitive_complexity)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
-    net[0].set_member_persistent();
-    net[4].set_member_persistent();
+    net[0].myself().lock_smw().set_persistent();
+    net[4].myself().lock_smw().set_persistent();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -8,7 +8,7 @@ use habitat_common::FeatureFlag;
 #[test]
 fn three_members_run_election() {
     let mut net = btest::SwimNet::new(3);
-    net.mesh();
+    net.mesh_mlw_smr();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");
@@ -24,7 +24,7 @@ fn three_members_run_election() {
 #[test]
 fn three_members_run_election_from_one_starting_rumor() {
     let mut net = btest::SwimNet::new(3);
-    net.mesh();
+    net.mesh_mlw_smr();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");
@@ -36,7 +36,7 @@ fn three_members_run_election_from_one_starting_rumor() {
 #[test]
 fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let mut net = btest::SwimNet::new(5);
-    net.mesh();
+    net.mesh_mlw_smr();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
     net.add_service(2, "core/witcher/1.2.3/20161208121212");
@@ -101,10 +101,10 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     net.add_service(3, "core/witcher/1.2.3/20161208121212");
     net.add_service(4, "core/witcher/1.2.3/20161208121212");
     net.add_election(0, "witcher");
-    net.connect(0, 1);
-    net.connect(1, 2);
-    net.connect(2, 3);
-    net.connect(3, 4);
+    net.connect_smr(0, 1);
+    net.connect_smr(1, 2);
+    net.connect_smr(2, 3);
+    net.connect_smr(3, 4);
     assert_wait_for_health_of_mlr!(net, [0..5, 0..5], Health::Alive);
     assert_wait_for_election_status!(net, [0..5], "witcher.prod", ElectionStatus::Finished);
     assert_wait_for_equal_election!(net, [0..5, 0..5], "witcher.prod");

--- a/components/butterfly/tests/rumor/service.rs
+++ b/components/butterfly/tests/rumor/service.rs
@@ -3,7 +3,7 @@ use crate::btest;
 #[test]
 fn two_members_share_services() {
     let mut net = btest::SwimNet::new(2);
-    net.mesh();
+    net.mesh_mlw_smr();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.wait_for_rounds(2);
     assert!(net[1].service_store

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -7,7 +7,7 @@ use habitat_core::service::ServiceGroup;
 #[test]
 fn two_members_share_service_config() {
     let mut net = btest::SwimNet::new(2);
-    net.mesh();
+    net.mesh_mlw_smr();
     net.add_service_config(0, "witcher", "tcp-backlog = 128");
     net.wait_for_gossip_rounds(1);
     assert!(net[1].service_config_store
@@ -19,7 +19,7 @@ fn two_members_share_service_config() {
 #[test]
 fn service_config_via_client() {
     let mut net = btest::SwimNet::new(2);
-    net.mesh();
+    net.mesh_mlw_smr();
 
     net.wait_for_gossip_rounds(1);
     let mut client =

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -5,7 +5,7 @@ use habitat_core::service::ServiceGroup;
 #[test]
 fn two_members_share_service_files() {
     let mut net = btest::SwimNet::new(2);
-    net.mesh();
+    net.mesh_mlw_smr();
     net.add_service_file(0,
                          "witcher",
                          "yeppers",
@@ -20,7 +20,7 @@ fn two_members_share_service_files() {
 #[test]
 fn service_file_via_client() {
     let mut net = btest::SwimNet::new(2);
-    net.mesh();
+    net.mesh_mlw_smr();
 
     net.wait_for_gossip_rounds(1);
     let mut client =

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -203,12 +203,16 @@ pub mod sync {
     /// internally use either a RwLock or a Mutex in order to make it easier to expose erroneous
     /// recursive locking in tests while still using an RwLock in production to avoid deadlocking
     /// as much as possible.
-    #[derive(Debug, Default)]
-    pub struct Lock<T: Default> {
+    #[derive(Debug)]
+    pub struct Lock<T> {
         inner: InnerLock<T>,
     }
 
-    impl<T: Default> Lock<T> {
+    impl<T: Default> Default for Lock<T> {
+        fn default() -> Self { Self { inner: InnerLock::new(T::default()), } }
+    }
+
+    impl<T> Lock<T> {
         pub fn new(val: T) -> Self {
             #[cfg(feature = "lock_as_mutex")]
             println!("Lock::new is using Mutex to help find recursive locking");

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -445,7 +445,7 @@ impl PackageInstall {
     }
 
     fn root_paths(&self, paths: &mut Vec<PathBuf>) -> Result<String> {
-        for path in &mut paths.into_iter() {
+        for path in &mut paths.iter_mut() {
             *path = fs::fs_rooted_path(&path, &self.fs_root_path);
         }
         env::join_paths(paths)?.into_string()

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
     logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
-    let result = start_rsr_imlw_mlw_gsw(flags);
+    let result = start_rsr_imlw_mlw_gsw_smw(flags);
     let exit_code = match result {
         Ok(_) => 0,
         Err(ref err) => {
@@ -115,7 +115,8 @@ fn boot() -> Option<LauncherCli> {
 /// * `MemberList::initial_members` (write)
 /// * `MemberList::entries` (write)
 /// * `GatewayState::inner` (write)
-fn start_rsr_imlw_mlw_gsw(feature_flags: FeatureFlag) -> Result<()> {
+/// * `Server::member` (write)
+fn start_rsr_imlw_mlw_gsw_smw(feature_flags: FeatureFlag) -> Result<()> {
     if feature_flags.contains(FeatureFlag::TEST_BOOT_FAIL) {
         outputln!("Simulating boot failure");
         return Err(Error::TestBootFail);
@@ -145,7 +146,7 @@ fn start_rsr_imlw_mlw_gsw(feature_flags: FeatureFlag) -> Result<()> {
         ("bash", Some(_)) => sub_bash(),
         ("run", Some(m)) => {
             let launcher = launcher.ok_or(Error::NoLauncher)?;
-            sub_run_rsr_imlw_mlw_gsw(m, launcher, feature_flags)
+            sub_run_rsr_imlw_mlw_gsw_smw(m, launcher, feature_flags)
         }
         ("sh", Some(_)) => sub_sh(),
         ("term", Some(_)) => sub_term(),
@@ -160,10 +161,11 @@ fn sub_bash() -> Result<()> { command::shell::bash() }
 /// * `MemberList::initial_members` (write)
 /// * `MemberList::entries` (write)
 /// * `GatewayState::inner` (write)
-fn sub_run_rsr_imlw_mlw_gsw(m: &ArgMatches,
-                            launcher: LauncherCli,
-                            feature_flags: FeatureFlag)
-                            -> Result<()> {
+/// * `Server::member` (write)
+fn sub_run_rsr_imlw_mlw_gsw_smw(m: &ArgMatches,
+                                launcher: LauncherCli,
+                                feature_flags: FeatureFlag)
+                                -> Result<()> {
     set_supervisor_logging_options(m);
 
     let cfg = mgrcfg_from_sup_run_matches(m, feature_flags)?;
@@ -200,7 +202,8 @@ fn sub_run_rsr_imlw_mlw_gsw(m: &ArgMatches,
     } else {
         None
     };
-    manager.run_rsw_imlw_mlw_gsw(svc)
+
+    manager.run_rsw_imlw_mlw_gsw_smw(svc)
 }
 
 fn sub_sh() -> Result<()> { command::shell::sh() }

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -807,7 +807,7 @@ impl Manager {
 
         outputln!("Starting gossip-listener on {}",
                   self.butterfly.gossip_addr());
-        self.butterfly.start_rsw_mlw(&Timing::default())?;
+        self.butterfly.start_rsw_mlw_smw(&Timing::default())?;
         debug!("gossip-listener started");
         self.persist_state_rsr_mlr_gsw();
         let http_listen_addr = self.sys.http_listen();
@@ -1093,7 +1093,7 @@ impl Manager {
             }
             ShutdownMode::Normal | ShutdownMode::Departed => {
                 outputln!("Gracefully departing from butterfly network.");
-                self.butterfly.set_departed_mlw();
+                self.butterfly.set_departed_mlw_smw();
 
                 let mut svcs = self.state
                                    .services

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -769,10 +769,11 @@ impl Manager {
     /// * `MemberList::initial_members` (write)
     /// * `MemberList::entries` (write)
     /// * `GatewayState::inner` (write)
+    /// * `Server::member` (write)
     #[allow(clippy::cognitive_complexity)]
-    pub fn run_rsw_imlw_mlw_gsw(mut self,
-                                svc: Option<habitat_sup_protocol::ctl::SvcLoad>)
-                                -> Result<()> {
+    pub fn run_rsw_imlw_mlw_gsw_smw(mut self,
+                                    svc: Option<habitat_sup_protocol::ctl::SvcLoad>)
+                                    -> Result<()> {
         let main_hist = RUN_LOOP_DURATION.with_label_values(&["sup"]);
         let service_hist = RUN_LOOP_DURATION.with_label_values(&["service"]);
         let mut next_cpu_measurement = SteadyTime::now();

--- a/docs/dev/design_documents/locking.md
+++ b/docs/dev/design_documents/locking.md
@@ -36,6 +36,8 @@ must be acquired in the conventional order and released in the reverse order:
 1. `MemberList::initial_members` (`iml`)
 1. `MemberList::entries` (`ml`)
 1. `GatewayState::inner` (`gs`)
+1. `Server::member` (`sm`)
+1. `Server::block_list` (`sbl`)
 
 Any function which is documented to acquire a lock should not be called with
 any lock that occurs later in the lock order held. For example, since


### PR DESCRIPTION
* Convert RwLock to habitat_common::sync::Lock
* Convert function signatures to match
* Document new lock names in locking.md
* Adjust doc comments on functions

This is in service of https://github.com/habitat-sh/habitat/issues/6435

![](https://media.giphy.com/media/2GoOdhX9GYp7a/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>