### PR TITLE
Add e2e tests to validate SSL_CERT_FILE behavior in studio

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -138,3 +138,66 @@ steps:
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
             - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
+  
+  - label: "[:linux: test_studio_with_ssl_cert_file_envvar_set]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+            - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
+ 
+  - label: "[:linux: :docker: test_studio_with_ssl_cert_file_envvar_set]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.sh
+    env:
+      BUILD_PKG_TARGET: x86_64-linux
+      HAB_BLDR_URL: https://bldr.acceptance.habitat.sh
+      STUDIO_DOCKER_TEST: true
+    expeditor:
+      executor:
+        linux:
+          single-use: true
+          privileged: true
+  
+  - label: "[:linux: test_studio_when_ssl_cert_file_is_invalid_cert]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_studio_when_ssl_cert_file_is_invalid_cert.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+            - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
+  
+  - label: "[:linux: test_studio_when_ssl_cert_file_is_nonexistant_file]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_studio_when_ssl_cert_file_is_nonexistant_file.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+            - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
+  
+  - label: "[:linux: test_studio_when_ssl_cert_file_is_directory]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_studio_when_ssl_cert_file_is_directory.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+            - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
+  

--- a/.expeditor/scripts/end_to_end/setup_environment.sh
+++ b/.expeditor/scripts/end_to_end/setup_environment.sh
@@ -13,12 +13,12 @@ declare -g hab_binary
 curlbash_hab "$BUILD_PKG_TARGET"
 
 echo "--- Installing latest core/hab from ${HAB_BLDR_URL}, ${channel} channel"
-hab pkg install core/hab \
+sudo -E hab pkg install core/hab \
     --binlink \
     --force \
     --channel "${channel}" \
     --url="${HAB_BLDR_URL}"
 echo "--- Using $(hab --version)"
 
-useradd --system --no-create-home hab
+sudo useradd --system --no-create-home hab
 

--- a/.expeditor/scripts/end_to_end/shared_end_to_end.sh
+++ b/.expeditor/scripts/end_to_end/shared_end_to_end.sh
@@ -6,3 +6,11 @@ source .expeditor/scripts/shared.sh
 
 ### Placeholder for shared functions used by the end to end pipeline.
 
+studio_run() {
+  local studio_flags=""
+  if [[ -n "${DOCKER_STUDIO_TEST:-}" ]]; then 
+    studio_flags="-D"
+  fi
+
+  hab studio run "$studio_flags" "$@"
+}

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -11,7 +11,14 @@ curlbash_hab() {
     # TODO:
     # really weird corner case on linux2 because the 0.82.0 versions of both
     # are the same. let's just delete it
-    rm -rf /hab/pkgs/core/hab/0.82.0
+    # 
+    # This command is potentially executed on different queues, under different users
+    # with varying levels of permissions.  Attempt to sudo-remove it first, for the linux-privileged 
+    # use case, and if that fails, try to remove it directly for the docker use case. 
+    if [ -d /hab/pkgs/core/hab/0.82.0 ]; then 
+      sudo rm -rf /hab/pkgs/core/hab/0.82.0 || \
+           rm -rf /hab/pkgs/core/hab/0.82.0
+    fi 
     curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash -s -- -t "$pkg_target"
     case "${pkg_target}" in
         x86_64-linux | x86_64-linux-kernel2)

--- a/test/end-to-end/test_studio_when_ssl_cert_file_is_directory.sh
+++ b/test/end-to-end/test_studio_when_ssl_cert_file_is_directory.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Test that when SSL_CERT_FILE points to a directory, 
+# that directory is not cached and communications with 
+# Builder still function in the studio
+
+set -euo pipefail
+
+source .expeditor/scripts/end_to_end/shared_end_to_end.sh
+
+echo "--- Generating a signing key"
+hab origin key generate "$HAB_ORIGIN"
+
+echo "--- Test Builder communications with SSL_CERT_FILE set to a directory"
+tempdir="$(mktemp --tmpdir --directory e2e-ssl-XXXXXX)"
+
+export SSL_CERT_FILE="${tempdir}"
+
+hab studio rm
+studio_run echo "SSL_CERT_FILE: \$SSL_CERT_FILE"
+studio_run test ! -f \$SSL_CERT_FILE
+studio_run hab pkg search core/vim
+

--- a/test/end-to-end/test_studio_when_ssl_cert_file_is_invalid_cert.sh
+++ b/test/end-to-end/test_studio_when_ssl_cert_file_is_invalid_cert.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Test that when SSL_CERT_FILE is an invalid certificate
+# communications with builder still function in the studio
+
+set -euo pipefail
+
+source .expeditor/scripts/end_to_end/shared_end_to_end.sh
+
+echo "--- Generating a signing key"
+hab origin key generate "$HAB_ORIGIN"
+
+echo "--- Generating invalid ssl certificate"
+tempdir="$(mktemp --tmpdir --directory e2e-ssl-XXXXXX)"
+e2e_certname="invalid-cert.pem"
+echo "I AM NOT A CERTIFICATE" > "$tempdir/$e2e_certname"
+
+export SSL_CERT_FILE="${tempdir}/${e2e_certname}"
+
+echo "--- Test Builder communications with invalid SSL_CERT_FILE"
+hab studio rm
+studio_run echo "SSL_CERT_FILE: \$SSL_CERT_FILE"
+studio_run hab pkg search core/vim
+

--- a/test/end-to-end/test_studio_when_ssl_cert_file_is_nonexistant_file.sh
+++ b/test/end-to-end/test_studio_when_ssl_cert_file_is_nonexistant_file.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Test that when SSL_CERT_FILE is set to a non-existant file
+# communications with Builder still function in the studio
+
+set -euo pipefail
+
+source .expeditor/scripts/end_to_end/shared_end_to_end.sh
+ 
+echo "--- Generating a signing key"
+hab origin key generate "$HAB_ORIGIN"
+
+echo "--- Generating self-signed ssl certificate"
+tempdir="$(mktemp --tmpdir --directory e2e-ssl-XXXXXX)"
+
+export SSL_CERT_FILE="${tempdir}/this-file-doesnt-exist"
+
+echo "--- Test Builder communications with invalid SSL_CERT_FILE"
+hab studio rm
+studio_run echo "SSL_CERT_FILE: \$SSL_CERT_FILE"  
+studio_run test ! -f \$SSL_CERT_FILE
+studio_run hab pkg search core/vim
+

--- a/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.sh
+++ b/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Test that SSL_CERT_FILE is persisted into the studio, set to 
+# the correct internal path and that we can communicate with Builder
+
+set -euo pipefail
+
+source .expeditor/scripts/end_to_end/shared_end_to_end.sh
+
+echo "--- Generating a signing key"
+hab origin key generate "$HAB_ORIGIN"
+
+echo "--- Generating self-signed ssl certificate"
+tempdir="$(mktemp --tmpdir --directory e2e-ssl-XXXXXX)"
+e2e_certname="e2e-ssl.pem"
+openssl req -newkey rsa:2048 -batch -nodes -keyout key.pem -x509 -days 365 -out "${tempdir}/${e2e_certname}"
+
+export SSL_CERT_FILE="${tempdir}/${e2e_certname}"
+
+echo "--- SSL_CERT_FILE is correctly set inside the studio: ${SSL_CERT_FILE})"
+# If this test fails with `test: ==: unary operator expected`
+# that likely indicates that $SSL_CERT_FILE was not passed into 
+# the studio and is unset.
+studio_run test "\$SSL_CERT_FILE" == "/hab/cache/ssl/${e2e_certname}"
+
+echo "--- SSL_CERT_FILE is copied into the studio"
+studio_run test -f "/hab/cache/ssl/${e2e_certname}"
+
+echo "--- Test Builder communications with self-signed cert"
+studio_run hab pkg search core/vim
+


### PR DESCRIPTION
This tests the following scenarios for the Linux chroot studio and Linux Docker studio when `SSL_CERT_FILE` is set:

- [x] chroot: valid SSL_CERT_FILE
- [x] chroot: invalid SSL_CERT_FILE
- [x] chroot: SSL_CERT_FILE is a directory
- [x] chroot: SSL_CERT_FILE points to non-existent file
- [x] Docker: valid SSL_CERT_FILE

### Running the tests:

#### Linux: 
./e2e_local.sh test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.sh
./e2e_local.sh test/end-to-end/test_studio_when_ssl_cert_file_is_invalid_cert.sh 
 
-----
Windows tests are blocked by #6954 

~Windows native studio~
~Windows docker studio~
~Windows docker studio w/ Linux containers~

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>