### PR TITLE
Fix end-to-end tests

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -31,7 +31,7 @@ steps:
 
   - label: "[:linux: hup-does-not-abandon-services]"
     command:
-      - .expeditor/scripts/setup_environment.sh DEV
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
       - hab pkg install --binlink --channel=stable core/expect
       - test/end-to-end/hup-does-not-abandon-services.exp
     expeditor:
@@ -43,7 +43,7 @@ steps:
 
   - label: "[:linux: hab-svc-load]"
     command:
-      - .expeditor/scripts/setup_environment.sh DEV
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
       - hab pkg install --binlink --channel=stable core/expect
       - test/end-to-end/hab-svc-load.exp
     expeditor:

--- a/e2e_local.sh
+++ b/e2e_local.sh
@@ -22,7 +22,7 @@ fi
 # Note that the `ci-studio-common.sh` file is baked into the image we
 # use.
 commands=(". /opt/ci-studio-common/buildkite-agent-hooks/ci-studio-common.sh"
-          ".expeditor/scripts/setup_environment.sh DEV"
+          ".expeditor/scripts/end_to_end/setup_environment.sh DEV"
           "hab pkg install --binlink --channel=stable core/expect"
           "${*}")
 

--- a/test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.sh
+++ b/test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.sh
@@ -22,7 +22,7 @@ fi
 
 TESTING_FS_ROOT=$(mktemp -d)
 export TESTING_FS_ROOT
-sup_log=$(mktemp)
+sup_log="sup.log"
 
 echo "Setting $TESTING_FS_ROOT to read-only to induce supervisor start failure"
 chmod -R a-w "$TESTING_FS_ROOT"

--- a/test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.sh
+++ b/test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.sh
@@ -24,6 +24,15 @@ TESTING_FS_ROOT=$(mktemp -d)
 export TESTING_FS_ROOT
 sup_log="sup.log"
 
+# Installing the launcher here because TESTING_FS_ROOT is an imperfect
+# abstraction that needs to be removed. It turns out that even if
+# TESTING_FS_ROOT is in place, we still look for the launcher in
+# `/hab` when we start up.
+#
+# Once we remove TESTING_FS_ROOT completely, we'll need to rethink how
+# this test works, since we can't really make `/` read-only
+hab pkg install core/hab-launcher
+
 echo "Setting $TESTING_FS_ROOT to read-only to induce supervisor start failure"
 chmod -R a-w "$TESTING_FS_ROOT"
 echo -n "Starting launcher with root $TESTING_FS_ROOT (logging to $sup_log)..."
@@ -33,7 +42,7 @@ launcher_pid=$!
 trap 'pgrep hab-launch &>/dev/null && pkill -9 hab-launch' INT TERM EXIT
 
 retries=0
-max_retries=5
+max_retries=50
 while ps -p "$launcher_pid" &>/dev/null; do
 	echo -n .
 	if [[ $((retries++)) -gt $max_retries ]]; then


### PR DESCRIPTION
Since these aren't quite wired up to be running all the time, they were broken because of some other refactorings.

Additionally, one of the tests was "passing" even though it wasn't actually successfully running the desired test. The workaround here gets things running again, even though it's not the best fix.