### PR TITLE
Release Habitat for macOS 10.13

### DIFF
--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -126,8 +126,8 @@ steps:
     agents:
       queue: default-macos-privileged
     plugins:
-      - chef/anka#v0.5.2:
-          vm-name: macos-base-10.12
+      - chef/anka#v0.5.3:
+          vm-name: macos-base-10.13
           inherit-environment-vars: true
           wait-network: true
     timeout_in_minutes: 30

--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -60,7 +60,7 @@ steps:
     expeditor:
       executor:
         macos:
-          os-version: "10.12"
+          os-version: "10.13"
           inherit-environment-vars: true
 
   - wait


### PR DESCRIPTION
Release engineering has deprecated macOS 10.12, so 10.13 is now the
oldest macOS release we build for.

Signed-off-by: Christopher Maier <cmaier@chef.io>