### PR TITLE
Error when sys.ip cannot be determined

### DIFF
--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -101,8 +101,6 @@ pub enum Error {
     InvalidPathString(ffi::OsString),
     /// Occurs when making lower level IO calls.
     IO(io::Error),
-    /// Occurs when this hosts outbound IP address cannot be determined
-    IpLookupFailed(io::Error),
     /// Errors when joining paths :)
     JoinPathsError(env::JoinPathsError),
     // When LogonUserW does not have the correct logon type
@@ -119,7 +117,7 @@ pub enum Error {
     /// When an IO error while accessing a MetaFile.
     MetaFileIO(io::Error),
     /// Occurs when we can't find an outbound IP address
-    NoOutboundAddr,
+    NoOutboundIpAddr(io::Error),
     /// Occurs when a call to OpenDesktopW fails
     OpenDesktopFailed(String),
     /// Occurs when a suitable installed package cannot be found.
@@ -299,9 +297,6 @@ impl fmt::Display for Error {
                 format!("Could not generate String from path: {:?}", s)
             }
             Error::IO(ref err) => format!("{}", err),
-            Error::IpLookupFailed(ref err) => {
-                format!("Failed to discover this hosts outbound IP address: {}", err)
-            }
             Error::JoinPathsError(ref err) => format!("{}", err),
             Error::LogonTypeNotGranted => {
                 "hab_svc_user user must possess the 'SE_SERVICE_LOGON_NAME' account right to be \
@@ -317,8 +312,8 @@ impl fmt::Display for Error {
             }
             Error::MetaFileNotFound(ref e) => format!("Couldn't read MetaFile: {}, not found", e),
             Error::MetaFileIO(ref e) => format!("IO error while accessing MetaFile: {:?}", e),
-            Error::NoOutboundAddr => {
-                "Failed to discover this hosts outbound IP address".to_string()
+            Error::NoOutboundIpAddr(ref e) => {
+                format!("Failed to discover this host's outbound IP address: {}", e)
             }
             Error::OpenDesktopFailed(ref e) => e.to_string(),
             Error::PackageNotFound(ref pkg) => {

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -101,6 +101,8 @@ pub enum Error {
     InvalidPathString(ffi::OsString),
     /// Occurs when making lower level IO calls.
     IO(io::Error),
+    /// Occurs when this hosts outbound IP address cannot be determined
+    IpLookupFailed(io::Error),
     /// Errors when joining paths :)
     JoinPathsError(env::JoinPathsError),
     // When LogonUserW does not have the correct logon type
@@ -297,6 +299,9 @@ impl fmt::Display for Error {
                 format!("Could not generate String from path: {:?}", s)
             }
             Error::IO(ref err) => format!("{}", err),
+            Error::IpLookupFailed(ref err) => {
+                format!("Failed to discover this hosts outbound IP address: {}", err)
+            }
             Error::JoinPathsError(ref err) => format!("{}", err),
             Error::LogonTypeNotGranted => {
                 "hab_svc_user user must possess the 'SE_SERVICE_LOGON_NAME' account right to be \

--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -2,14 +2,32 @@ use crate::error::{Error,
                    Result};
 pub use crate::os::system::{uname,
                             Uname};
-use std::net::{IpAddr,
-               UdpSocket};
+use std::{io,
+          net::{IpAddr,
+                Ipv4Addr,
+                ToSocketAddrs,
+                UdpSocket}};
 
-static GOOGLE_DNS: &str = "8.8.8.8:53";
+const UNSPECIFIED_SOCKET_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
+const GOOGLE_DNS: &str = "8.8.8.8:53";
 
-pub fn ip() -> Result<IpAddr> {
-    let socket = UdpSocket::bind("0.0.0.0:0").map_err(Error::IpLookupFailed)?;
-    socket.connect(GOOGLE_DNS).map_err(Error::IpLookupFailed)?;
-    let addr = socket.local_addr().map_err(Error::IpLookupFailed)?;
+pub fn ip() -> Result<IpAddr> { ip_impl(GOOGLE_DNS).map_err(Error::IpLookupFailed) }
+
+fn ip_impl(connect_addr: impl ToSocketAddrs) -> io::Result<IpAddr> {
+    let socket = UdpSocket::bind(UNSPECIFIED_SOCKET_ADDR)?;
+    socket.connect(connect_addr)?;
+    let addr = socket.local_addr()?;
     Ok(addr.ip())
+}
+
+#[cfg(test)]
+mod test {
+    use super::{ip,
+                ip_impl};
+
+    #[test]
+    fn ip_lookup() {
+        assert!(ip_impl("an invalid socket addr").is_err());
+        assert!(ip().is_ok());
+    }
 }

--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -11,7 +11,7 @@ use std::{io,
 const UNSPECIFIED_SOCKET_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
 const GOOGLE_DNS: &str = "8.8.8.8:53";
 
-pub fn ip() -> Result<IpAddr> { ip_impl(GOOGLE_DNS).map_err(Error::IpLookupFailed) }
+pub fn ip() -> Result<IpAddr> { ip_impl(GOOGLE_DNS).map_err(Error::NoOutboundIpAddr) }
 
 fn ip_impl(connect_addr: impl ToSocketAddrs) -> io::Result<IpAddr> {
     let socket = UdpSocket::bind(UNSPECIFIED_SOCKET_ADDR)?;

--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -1,4 +1,5 @@
-use crate::error::Result;
+use crate::error::{Error,
+                   Result};
 pub use crate::os::system::{uname,
                             Uname};
 use std::net::{IpAddr,
@@ -7,8 +8,8 @@ use std::net::{IpAddr,
 static GOOGLE_DNS: &str = "8.8.8.8:53";
 
 pub fn ip() -> Result<IpAddr> {
-    let socket = UdpSocket::bind("0.0.0.0:0")?;
-    socket.connect(GOOGLE_DNS)?;
-    let addr = socket.local_addr()?;
+    let socket = UdpSocket::bind("0.0.0.0:0").map_err(Error::IpLookupFailed)?;
+    socket.connect(GOOGLE_DNS).map_err(Error::IpLookupFailed)?;
+    let addr = socket.local_addr().map_err(Error::IpLookupFailed)?;
     Ok(addr.ip())
 }

--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -20,6 +20,17 @@ crate::env_config_socketaddr!(OutboundIpAddrLookupSocketAddr,
                               8,
                               53);
 
+/// The technique used to determine the outgoing IP address is documented [here][1].
+///
+/// "A connected UDP socket can also be used to determine the outgoing interface
+/// that will be used to a particular destination. This is because of a side effect of the connect
+/// function when applied to a UDP socket: The kernel chooses the local IP address (assuming the
+/// process has not already called bind to explicitly assign this). This local IP address is chosen
+/// by searching the routing table for the destination IP address, and then using the primary IP
+/// address for the resulting interface." From "Unix Network Programming v1.3" chapter 8
+/// section 14.
+///
+/// [1]: http://www.masterraghu.com/subjects/np/introduction/unix_network_programming_v1.3/ch08lev1sec14.html
 pub fn ip() -> Result<IpAddr> {
     let connect_addr = SocketAddr::from(OutboundIpAddrLookupSocketAddr::configured_value());
     ip_impl(connect_addr).map_err(Error::NoOutboundIpAddr)

--- a/components/core/src/util/sys.rs
+++ b/components/core/src/util/sys.rs
@@ -5,13 +5,25 @@ pub use crate::os::system::{uname,
 use std::{io,
           net::{IpAddr,
                 Ipv4Addr,
+                SocketAddr,
                 ToSocketAddrs,
                 UdpSocket}};
 
 const UNSPECIFIED_SOCKET_ADDR: (Ipv4Addr, u16) = (Ipv4Addr::UNSPECIFIED, 0);
-const GOOGLE_DNS: &str = "8.8.8.8:53";
 
-pub fn ip() -> Result<IpAddr> { ip_impl(GOOGLE_DNS).map_err(Error::NoOutboundIpAddr) }
+crate::env_config_socketaddr!(OutboundIpAddrLookupSocketAddr,
+                              HAB_OUTBOUND_IP_ADDR_LOOKUP_SOCKET_ADDR,
+                              // Use Google DNS as the default
+                              8,
+                              8,
+                              8,
+                              8,
+                              53);
+
+pub fn ip() -> Result<IpAddr> {
+    let connect_addr = SocketAddr::from(OutboundIpAddrLookupSocketAddr::configured_value());
+    ip_impl(connect_addr).map_err(Error::NoOutboundIpAddr)
+}
 
 fn ip_impl(connect_addr: impl ToSocketAddrs) -> io::Result<IpAddr> {
     let socket = UdpSocket::bind(UNSPECIFIED_SOCKET_ADDR)?;
@@ -22,12 +34,18 @@ fn ip_impl(connect_addr: impl ToSocketAddrs) -> io::Result<IpAddr> {
 
 #[cfg(test)]
 mod test {
-    use super::{ip,
-                ip_impl};
+    use super::*;
 
     #[test]
     fn ip_lookup() {
         assert!(ip_impl("an invalid socket addr").is_err());
         assert!(ip().is_ok());
+
+        // We would prefer to use the `locked_env_var` macro here but currently, the `habitat_core`
+        // crate does not depend on `habitat_common`. If this becomes an issue, some refactoring
+        // will be needed.
+        std::env::set_var(OutboundIpAddrLookupSocketAddr::ENVVAR, "127.0.0.1:80");
+        // localhost should route back to localhost
+        assert_eq!(ip().unwrap(), Ipv4Addr::LOCALHOST);
     }
 }

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -64,7 +64,6 @@ pub enum Error {
     InvalidTopology(String),
     InvalidUpdateStrategy(String),
     Io(io::Error),
-    IPFailed,
     Launcher(habitat_launcher_client::Error),
     MissingRequiredBind(Vec<String>),
     MissingRequiredIdent,
@@ -175,7 +174,6 @@ impl fmt::Display for Error {
             Error::InvalidTopology(ref t) => format!("Invalid topology: {}", t),
             Error::InvalidUpdateStrategy(ref s) => format!("Invalid update strategy: {}", s),
             Error::Io(ref err) => err.to_string(),
-            Error::IPFailed => "Failed to discover this hosts outbound IP address".to_string(),
             Error::Launcher(ref err) => err.to_string(),
             Error::MissingRequiredBind(ref e) => {
                 format!("Missing required bind(s), {}", e.join(", "))

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -528,7 +528,7 @@ impl Manager {
         let mut sys = Sys::new(cfg.gossip_permanent,
                                cfg.gossip_listen,
                                cfg.ctl_listen,
-                               cfg.http_listen);
+                               cfg.http_listen)?;
         let member = Self::load_member(&mut sys, &fs_cfg)?;
         let services = Arc::new(RwLock::new(HashMap::new()));
 

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -1224,7 +1224,7 @@ mod tests {
         let sys = Sys::new(false,
                            GossipListenAddr::default(),
                            listen_ctl_addr,
-                           HttpListenAddr::default());
+                           HttpListenAddr::default()).expect("to create Sys");
 
         let ident = if cfg!(target_os = "linux") {
             PackageIdent::new("core", "tree", Some("1.7.0"), Some("20180609045201"))

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -689,7 +689,7 @@ mod tests {
         let sys = Sys::new(true,
                            GossipListenAddr::default(),
                            ListenCtlAddr::default(),
-                           HttpListenAddr::default());
+                           HttpListenAddr::default()).expect("to create Sys");
 
         let pg_id = PackageIdent::new("testing",
                                       &service_group.service(),

--- a/components/sup/src/manager/sys.rs
+++ b/components/sup/src/manager/sys.rs
@@ -1,4 +1,5 @@
-use crate::VERSION;
+use crate::{error::Result,
+            VERSION};
 use habitat_butterfly::rumor::service::SysInfo;
 use habitat_common::{outputln,
                      types::{GossipListenAddr,
@@ -6,7 +7,6 @@ use habitat_common::{outputln,
                              ListenCtlAddr}};
 use habitat_core;
 use std::{net::{IpAddr,
-                Ipv4Addr,
                 SocketAddr},
           str};
 
@@ -32,15 +32,8 @@ impl Sys {
                gossip: GossipListenAddr,
                ctl: ListenCtlAddr,
                http: HttpListenAddr)
-               -> Sys {
-        let ip = habitat_core::util::sys::ip().unwrap_or_else(|e| {
-                                                  let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
-                                                  outputln!("IP Address lookup failed; using \
-                                                             fallback of {} ({})",
-                                                            ip,
-                                                            e);
-                                                  ip
-                                              });
+               -> Result<Self> {
+        let ip = habitat_core::util::sys::ip()?;
         let host = habitat_core::os::net::hostname().unwrap_or_else(|e| {
                                                         let host = String::from("localhost");
                                                         outputln!("Hostname lookup failed; using \
@@ -49,17 +42,17 @@ impl Sys {
                                                                   e);
                                                         host
                                                     });
-        Sys { version: VERSION.to_string(),
-              member_id: "unloaded".to_string(),
-              ip,
-              hostname: host,
-              gossip_ip: gossip.ip(),
-              gossip_port: gossip.port(),
-              ctl_gateway_ip: ctl.ip(),
-              ctl_gateway_port: ctl.port(),
-              http_gateway_ip: http.ip(),
-              http_gateway_port: http.port(),
-              permanent }
+        Ok(Self { version: VERSION.to_string(),
+                  member_id: "unloaded".to_string(),
+                  ip,
+                  hostname: host,
+                  gossip_ip: gossip.ip(),
+                  gossip_port: gossip.port(),
+                  ctl_gateway_ip: ctl.ip(),
+                  ctl_gateway_port: ctl.port(),
+                  http_gateway_ip: http.ip(),
+                  http_gateway_port: http.port(),
+                  permanent })
     }
 
     pub fn as_sys_info(&self) -> SysInfo {


### PR DESCRIPTION
Resolves #6913

This PR depends on #6949 so the first [commit](https://github.com/habitat-sh/habitat/pull/6953/commits/89a259cfc4d9113c16ca8c81650549ea94125509) can be ignored

If you try and start the supervisor without connectivity to `8.8.8.8`, the supervisor immediately exits with:
```text
hab-sup(MR): core/hab-sup (core/hab-sup/0.85.0)
Failed to discover this hosts outbound IP address: Network is unreachable (os error 101)
[2019-09-11T18:31:56Z ERROR hab_launch] Launcher exiting with code 86
```

Not sure the best way to add automated testing for this. Any suggestions?