### PR TITLE
Audit `habitat_sup::manager::ManagerServices` locking

### DIFF
--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -4,6 +4,7 @@ use habitat_butterfly::{member,
                                  Suitability}};
 use std::{env,
           net::SocketAddr,
+          sync::Arc,
           thread,
           time::Duration};
 
@@ -38,7 +39,7 @@ fn main() {
                                          None,
                                          None,
                                          None,
-                                         Box::new(ZeroSuitability)).unwrap();
+                                         Arc::new(ZeroSuitability)).unwrap();
     println!("Server ID: {}", server.member_id());
 
     let targets: Vec<String> = args.collect();

--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -11,7 +11,7 @@ use std::{env,
 #[derive(Debug)]
 struct ZeroSuitability;
 impl Suitability for ZeroSuitability {
-    fn get(&self, _service_group: &str) -> u64 { 0 }
+    fn suitability_for_msr(&self, _service_group: &str) -> u64 { 0 }
 }
 
 fn main() {
@@ -52,7 +52,7 @@ fn main() {
         server.member_list.add_initial_member_imlw(member);
     }
 
-    server.start_rsw_mlw_smw_rhw(&server::timing::Timing::default())
+    server.start_rsw_mlw_smw_rhw_msr(&server::timing::Timing::default())
           .expect("Cannot start server");
     loop {
         println!("{:#?}", server.member_list);

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -121,7 +121,8 @@ impl DatFileReader {
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (write)
     /// * `RumorHeat::inner` (write)
-    pub fn read_into_rsw_mlw_rhw(&mut self, server: &Server) -> Result<()> {
+    /// * `ManagerServices::inner` (read)
+    pub fn read_into_rsw_mlw_rhw_msr(&mut self, server: &Server) -> Result<()> {
         for Membership { member, health } in self.read_members()? {
             server.insert_member_mlw_rhw(member, health);
         }
@@ -139,7 +140,7 @@ impl DatFileReader {
         }
 
         for election in self.read_rumors::<Election>()? {
-            server.insert_election_rsw_mlr_rhw(election);
+            server.insert_election_rsw_mlr_rhw_msr(election);
         }
 
         for update_election in self.read_rumors::<ElectionUpdate>()? {

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -100,7 +100,7 @@ type AckReceiver = mpsc::Receiver<(SocketAddr, Ack)>;
 type AckSender = mpsc::Sender<(SocketAddr, Ack)>;
 
 pub trait Suitability: Debug + Send + Sync {
-    fn get(&self, service_group: &str) -> u64;
+    fn suitability_for_msr(&self, service_group: &str) -> u64;
 }
 
 pub(crate) mod sync {
@@ -448,13 +448,14 @@ impl Server {
     /// * `MemberList::entries` (write)
     /// * `Server::member` (write)
     /// * `RumorHeat::inner` (write)
+    /// * `ManagerServices::inner` (read)
     ///
     /// # Errors
     ///
     /// * Returns `Error::CannotBind` if the socket cannot be bound
     /// * Returns `Error::SocketSetReadTimeout` if the socket read timeout cannot be set
     /// * Returns `Error::SocketSetWriteTimeout` if the socket write timeout cannot be set
-    pub fn start_rsw_mlw_smw_rhw(&mut self, timing: &timing::Timing) -> Result<()> {
+    pub fn start_rsw_mlw_smw_rhw_msr(&mut self, timing: &timing::Timing) -> Result<()> {
         debug!("entering habitat_butterfly::server::Server::start");
         let (tx_outbound, rx_inbound) = channel();
         if let Some(ref path) = self.data_path {
@@ -472,7 +473,7 @@ impl Server {
                                                                    &self.update_store,
                                                                    &self.departure_store)?;
 
-            match reader.read_into_rsw_mlw_rhw(&self) {
+            match reader.read_into_rsw_mlw_rhw_msr(&self) {
                 Ok(_) => {
                     debug!("Successfully ingested rumors from {}",
                            reader.path().display())
@@ -865,8 +866,9 @@ impl Server {
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (read)
     /// * `RumorHeat::inner` (write)
-    pub fn start_election_rsw_mlr_rhw(&self, service_group: &str, term: u64) {
-        let suitability = self.suitability_lookup.get(&service_group);
+    /// * `ManagerServices::inner` (read)
+    pub fn start_election_rsw_mlr_rhw_msr(&self, service_group: &str, term: u64) {
+        let suitability = self.suitability_lookup.suitability_for_msr(&service_group);
         let has_quorum = self.check_quorum_mlr(service_group);
         let e = Election::new(self.member_id(),
                               service_group,
@@ -998,7 +1000,8 @@ impl Server {
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (read)
     /// * `RumorHeat::inner` (write)
-    pub fn restart_elections_rsw_mlr_rhw(&self, feature_flags: FeatureFlag) {
+    /// * `ManagerServices::inner` (read)
+    pub fn restart_elections_rsw_mlr_rhw_msr(&self, feature_flags: FeatureFlag) {
         let elections_to_restart =
             self.elections_to_restart_rsr_mlr(&self.election_store, feature_flags);
 
@@ -1014,7 +1017,7 @@ impl Server {
             warn!("Starting a new election for {} {}", service_group, term);
             self.election_store
                 .remove_rsw(&service_group, Election::const_id());
-            self.start_election_rsw_mlr_rhw(&service_group, term);
+            self.start_election_rsw_mlr_rhw_msr(&service_group, term);
         }
 
         for (service_group, old_term) in update_elections_to_restart {
@@ -1034,7 +1037,8 @@ impl Server {
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (read)
     /// * `RumorHeat::inner` (write)
-    pub fn insert_election_rsw_mlr_rhw(&self, mut election: Election) {
+    /// * `ManagerServices::inner` (read)
+    pub fn insert_election_rsw_mlr_rhw_msr(&self, mut election: Election) {
         debug!("insert_election: {:?}", election);
         let rk = RumorKey::from(&election);
 
@@ -1058,7 +1062,7 @@ impl Server {
                     debug!("removing old rumor and starting new election");
                     self.election_store
                         .remove_rsw(election.key(), election.id());
-                    self.start_election_rsw_mlr_rhw(&election.service_group, election.term);
+                    self.start_election_rsw_mlr_rhw_msr(&election.service_group, election.term);
                 }
                 // If we are the member that this election is voting for, then check to see if the
                 // election is over! If it is, mark this election as final before you process it.
@@ -1108,7 +1112,7 @@ impl Server {
                                               .lock()
                                               .expect("Election timers lock poisoned");
                 existing_timers.insert(election.service_group.clone(), ElectionTimer(timer));
-                self.start_election_rsw_mlr_rhw(&election.service_group, election.term);
+                self.start_election_rsw_mlr_rhw_msr(&election.service_group, election.term);
             }
 
             if !election.is_finished() {
@@ -1662,7 +1666,7 @@ mod tests {
         #[derive(Debug)]
         struct ZeroSuitability;
         impl Suitability for ZeroSuitability {
-            fn get(&self, _service_group: &str) -> u64 { 0 }
+            fn suitability_for_msr(&self, _service_group: &str) -> u64 { 0 }
         }
 
         fn start_server() -> Server {
@@ -1733,14 +1737,14 @@ mod tests {
         fn new_with_corrupt_rumor_file() {
             let tmpdir = TempDir::new().unwrap();
             let mut server = start_with_corrupt_rumor_file(&tmpdir);
-            server.start_rsw_mlw_smw_rhw(&Timing::default())
+            server.start_rsw_mlw_smw_rhw_msr(&Timing::default())
                   .expect("Server failed to start");
         }
 
         #[test]
         fn start_listener() {
             let mut server = start_server();
-            server.start_rsw_mlw_smw_rhw(&Timing::default())
+            server.start_rsw_mlw_smw_rhw_msr(&Timing::default())
                   .expect("Server failed to start");
         }
     }

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -124,7 +124,7 @@ fn run_loop(server: &Server) -> ! {
                 server.insert_service_file_rsw_rhw(service_file);
             }
             RumorKind::Election(election) => {
-                server.insert_election_rsw_mlr_rhw(election);
+                server.insert_election_rsw_mlr_rhw_msr(election);
             }
             RumorKind::ElectionUpdate(election) => {
                 server.insert_update_election_rsw_mlr_rhw(election);

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -23,7 +23,8 @@ use std::{net::{IpAddr,
                 DerefMut,
                 Range},
           str::FromStr,
-          sync::Mutex,
+          sync::{Arc,
+                 Mutex},
           thread,
           time::Duration};
 use time::SteadyTime;
@@ -62,7 +63,7 @@ pub fn start_server_smw_rhw(name: &str, ring_key: Option<SymKey>, suitability: u
                                  ring_key,
                                  Some(String::from(name)),
                                  None,
-                                 Box::new(NSuitability(suitability))).unwrap();
+                                 Arc::new(NSuitability(suitability))).unwrap();
     server.start_rsw_mlw_smw_rhw(&Timing::default())
           .expect("Cannot start server");
     server

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -36,7 +36,7 @@ lazy_static::lazy_static! {
 #[derive(Debug)]
 struct NSuitability(u64);
 impl Suitability for NSuitability {
-    fn get(&self, _service_group: &str) -> u64 { self.0 }
+    fn suitability_for_msr(&self, _service_group: &str) -> u64 { self.0 }
 }
 
 /// # Locking (see locking.md)
@@ -64,7 +64,7 @@ pub fn start_server_smw_rhw(name: &str, ring_key: Option<SymKey>, suitability: u
                                  Some(String::from(name)),
                                  None,
                                  Arc::new(NSuitability(suitability))).unwrap();
-    server.start_rsw_mlw_smw_rhw(&Timing::default())
+    server.start_rsw_mlw_smw_rhw_msr(&Timing::default())
           .expect("Cannot start server");
     server
 }
@@ -461,8 +461,9 @@ impl SwimNet {
     }
 
     pub fn add_election(&mut self, member: usize, service: &str) {
-        self[member].start_election_rsw_mlr_rhw(&ServiceGroup::new(None, service, "prod", None).unwrap(),
-                                        0);
+        self[member].start_election_rsw_mlr_rhw_msr(&ServiceGroup::new(None, service, "prod",
+                                                                       None).unwrap(),
+                                                    0);
     }
 }
 

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -63,9 +63,9 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let paused_id = net[paused].member_id();
     assert_wait_for_health_of_mlr!(net, paused, Health::Confirmed);
     if paused == 0 {
-        net[1].restart_elections_rsw_mlr_rhw(FeatureFlag::empty());
+        net[1].restart_elections_rsw_mlr_rhw_msr(FeatureFlag::empty());
     } else {
-        net[0].restart_elections_rsw_mlr_rhw(FeatureFlag::empty());
+        net[0].restart_elections_rsw_mlr_rhw_msr(FeatureFlag::empty());
     }
 
     for i in 0..5 {
@@ -129,8 +129,8 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let new_leader_id;
     net.partition(0..2, 2..5);
     assert_wait_for_health_of_mlr!(net, [0..2, 2..5], Health::Confirmed);
-    net[0].restart_elections_rsw_mlr_rhw(FeatureFlag::empty());
-    net[4].restart_elections_rsw_mlr_rhw(FeatureFlag::empty());
+    net[0].restart_elections_rsw_mlr_rhw_msr(FeatureFlag::empty());
+    net[4].restart_elections_rsw_mlr_rhw_msr(FeatureFlag::empty());
     assert_wait_for_election_status!(net, 0, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 1, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 2, "witcher.prod", ElectionStatus::Finished);

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -583,7 +583,7 @@ mod tests {
                         None,
                         None,
                         None,
-                        Box::new(ZeroSuitability)).unwrap()
+                        std::sync::Arc::new(ZeroSuitability)).unwrap()
         }
 
         let server = start_server();

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -555,7 +555,7 @@ mod tests {
         #[derive(Debug)]
         struct ZeroSuitability;
         impl Suitability for ZeroSuitability {
-            fn get(&self, _service_group: &str) -> u64 { 0 }
+            fn suitability_for_msr(&self, _service_group: &str) -> u64 { 0 }
         }
 
         fn start_server() -> Server {

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
     logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
-    let result = start_rsr_imlw_mlw_gsw_smw_rhw(flags);
+    let result = start_rsr_imlw_mlw_gsw_smw_rhw_msw(flags);
     let exit_code = match result {
         Ok(_) => 0,
         Err(ref err) => {
@@ -117,7 +117,8 @@ fn boot() -> Option<LauncherCli> {
 /// * `GatewayState::inner` (write)
 /// * `Server::member` (write)
 /// * `RumorHeat::inner` (write)
-fn start_rsr_imlw_mlw_gsw_smw_rhw(feature_flags: FeatureFlag) -> Result<()> {
+/// * `ManagerServices::inner` (write)
+fn start_rsr_imlw_mlw_gsw_smw_rhw_msw(feature_flags: FeatureFlag) -> Result<()> {
     if feature_flags.contains(FeatureFlag::TEST_BOOT_FAIL) {
         outputln!("Simulating boot failure");
         return Err(Error::TestBootFail);
@@ -147,7 +148,7 @@ fn start_rsr_imlw_mlw_gsw_smw_rhw(feature_flags: FeatureFlag) -> Result<()> {
         ("bash", Some(_)) => sub_bash(),
         ("run", Some(m)) => {
             let launcher = launcher.ok_or(Error::NoLauncher)?;
-            sub_run_rsr_imlw_mlw_gsw_smw_rhw(m, launcher, feature_flags)
+            sub_run_rsr_imlw_mlw_gsw_smw_rhw_msw(m, launcher, feature_flags)
         }
         ("sh", Some(_)) => sub_sh(),
         ("term", Some(_)) => sub_term(),
@@ -164,10 +165,11 @@ fn sub_bash() -> Result<()> { command::shell::bash() }
 /// * `GatewayState::inner` (write)
 /// * `Server::member` (write)
 /// * `RumorHeat::inner` (write)
-fn sub_run_rsr_imlw_mlw_gsw_smw_rhw(m: &ArgMatches,
-                                    launcher: LauncherCli,
-                                    feature_flags: FeatureFlag)
-                                    -> Result<()> {
+/// * `ManagerServices::inner` (write)
+fn sub_run_rsr_imlw_mlw_gsw_smw_rhw_msw(m: &ArgMatches,
+                                        launcher: LauncherCli,
+                                        feature_flags: FeatureFlag)
+                                        -> Result<()> {
     set_supervisor_logging_options(m);
 
     let cfg = mgrcfg_from_sup_run_matches(m, feature_flags)?;
@@ -205,7 +207,7 @@ fn sub_run_rsr_imlw_mlw_gsw_smw_rhw(m: &ArgMatches,
         None
     };
 
-    manager.run_rsw_imlw_mlw_gsw_smw_rhw(svc)
+    manager.run_rsw_imlw_mlw_gsw_smw_rhw_msw(svc)
 }
 
 fn sub_sh() -> Result<()> { command::shell::sh() }

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1393,6 +1393,7 @@ impl Manager {
 
     /// # Locking (see locking.md)
     /// * `GatewayState::inner` (write)
+    /// * `ManagerServices::inner` (write)
     fn stop_service_gsw_msw(&mut self, ident: &PackageIdent, shutdown_input: &ShutdownInput) {
         if let Some(service) = self.remove_service_from_state_msw(&ident) {
             let future = self.stop_service_future_gsw(service, Some(shutdown_input));

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -340,9 +340,9 @@ impl ReconciliationFlag {
 /// state gets shared with all the CtlGateway handlers.
 pub struct ManagerState {
     /// The configuration used to instantiate this Manager instance
-    pub cfg: ManagerConfig,
-    pub services: Arc<RwLock<HashMap<PackageIdent, Service>>>,
-    pub gateway_state: Arc<sync::GatewayState>,
+    cfg: ManagerConfig,
+    services: Arc<RwLock<HashMap<PackageIdent, Service>>>,
+    gateway_state: Arc<sync::GatewayState>,
 }
 
 pub(crate) mod sync {

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -37,16 +37,13 @@ pub fn service_cfg(mgr: &ManagerState,
                    req: &mut CtlRequest,
                    opts: protocol::ctl::SvcGetDefaultCfg)
                    -> NetResult<()> {
+    // TODO: annotate
     let ident: PackageIdent = opts.ident.ok_or_else(err_update_client)?.into();
     let mut msg = protocol::types::ServiceCfg { format:
                                                     Some(protocol::types::service_cfg::Format::Toml
                                                          as i32),
                                                 default: None, };
-    for service in mgr.services
-                      .read()
-                      .expect("Services lock is poisoned")
-                      .values()
-    {
+    for service in mgr.services.lock_msr().services() {
         if service.pkg.ident.satisfies(&ident) {
             if let Some(ref cfg) = service.cfg.default {
                 msg.default =

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -33,11 +33,12 @@ use toml;
 
 static LOGKEY: &str = "CMD";
 
-pub fn service_cfg(mgr: &ManagerState,
-                   req: &mut CtlRequest,
-                   opts: protocol::ctl::SvcGetDefaultCfg)
-                   -> NetResult<()> {
-    // TODO: annotate
+/// # Locking (see locking.md)
+/// * `ManagerServices::inner` (read)
+pub fn service_cfg_msr(mgr: &ManagerState,
+                       req: &mut CtlRequest,
+                       opts: protocol::ctl::SvcGetDefaultCfg)
+                       -> NetResult<()> {
     let ident: PackageIdent = opts.ident.ok_or_else(err_update_client)?.into();
     let mut msg = protocol::types::ServiceCfg { format:
                                                     Some(protocol::types::service_cfg::Format::Toml

--- a/docs/dev/design_documents/locking.md
+++ b/docs/dev/design_documents/locking.md
@@ -32,6 +32,7 @@ to make this clear the function for inserting a service is named
 Whenever a thread needs to hold multiple locks concurrently, they
 must be acquired in the conventional order and released in the reverse order:
 
+1. `ManagerServices::inner` (`ms`)
 1. `RumorStore::list` (`rs`)
 1. `MemberList::initial_members` (`iml`)
 1. `MemberList::entries` (`ml`)


### PR DESCRIPTION
Currently based on `audit-sup-manager-locking`; will rebase to `master` once that merges. Skip [the first commit](https://github.com/habitat-sh/habitat/commit/346ca9104c5a152292e3f015a816ae73ad15bb6a) for now when reviewing this.

Added `T-DO-NOT-MERGE` label since we're currently in a merge freeze

See https://github.com/habitat-sh/habitat/issues/6435