### PR TITLE
Convert RwLocks in the rumor::heat module to habitat_common::sync::Lock

### DIFF
--- a/components/butterfly/src/main.rs
+++ b/components/butterfly/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
         server.member_list.add_initial_member_imlw(member);
     }
 
-    server.start_rsw_mlw_smw(&server::timing::Timing::default())
+    server.start_rsw_mlw_smw_rhw(&server::timing::Timing::default())
           .expect("Cannot start server");
     loop {
         println!("{:#?}", server.member_list);

--- a/components/butterfly/src/rumor/dat_file.rs
+++ b/components/butterfly/src/rumor/dat_file.rs
@@ -120,33 +120,34 @@ impl DatFileReader {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (write)
-    pub fn read_into_rsw_mlw(&mut self, server: &Server) -> Result<()> {
+    /// * `RumorHeat::inner` (write)
+    pub fn read_into_rsw_mlw_rhw(&mut self, server: &Server) -> Result<()> {
         for Membership { member, health } in self.read_members()? {
-            server.insert_member_mlw(member, health);
+            server.insert_member_mlw_rhw(member, health);
         }
 
         for service in self.read_rumors::<Service>()? {
-            server.insert_service_rsw_mlw(service);
+            server.insert_service_rsw_mlw_rhw(service);
         }
 
         for service_config in self.read_rumors::<ServiceConfig>()? {
-            server.insert_service_config_rsw(service_config);
+            server.insert_service_config_rsw_rhw(service_config);
         }
 
         for service_file in self.read_rumors::<ServiceFile>()? {
-            server.insert_service_file_rsw(service_file);
+            server.insert_service_file_rsw_rhw(service_file);
         }
 
         for election in self.read_rumors::<Election>()? {
-            server.insert_election_rsw_mlr(election);
+            server.insert_election_rsw_mlr_rhw(election);
         }
 
         for update_election in self.read_rumors::<ElectionUpdate>()? {
-            server.insert_update_election_rsw_mlr(update_election);
+            server.insert_update_election_rsw_mlr_rhw(update_election);
         }
 
         for departure in self.read_rumors::<Departure>()? {
-            server.insert_departure_rsw_mlw(departure);
+            server.insert_departure_rsw_mlw_rhw(departure);
         }
 
         Ok(())

--- a/components/butterfly/src/rumor/heat.rs
+++ b/components/butterfly/src/rumor/heat.rs
@@ -46,7 +46,7 @@ habitat_core::env_config_int!(/// The number of times that a rumor will be share
 /// When a rumor changes, we can effectively reset things by starting
 /// the rumor mill up again. This will zero out all counters for every
 /// member, starting the sharing cycle over again.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct RumorHeat(Arc<Lock<HashMap<RumorKey, HashMap<String, usize>>>>);
 
 impl RumorHeat {
@@ -59,9 +59,7 @@ impl RumorHeat {
     /// # Locking (see locking.md)
     /// * `RumorHeat::inner` (write)
     pub fn start_hot_rumor_rhw<T: Into<RumorKey>>(&self, rumor: T) {
-        let rk: RumorKey = rumor.into();
-        let mut rumors = self.0.write();
-        rumors.insert(rk, HashMap::new());
+        self.0.write().insert(rumor.into(), Default::default());
     }
 
     /// Return a list of currently "hot" rumors for the specified
@@ -166,10 +164,6 @@ impl RumorHeat {
         }
         debug!("Purged {} heat count entries for {:?}", count, id);
     }
-}
-
-impl Default for RumorHeat {
-    fn default() -> RumorHeat { RumorHeat(Arc::new(Lock::new(HashMap::new()))) }
 }
 
 #[cfg(test)]

--- a/components/butterfly/src/rumor/heat.rs
+++ b/components/butterfly/src/rumor/heat.rs
@@ -79,14 +79,6 @@ pub(crate) mod sync {
             // We don't need the heat anymore, just return the rumors.
             rumor_heat.into_iter().map(|(k, _)| k).collect()
         }
-
-        // /// Return the number of elements in our internal map
-        // pub fn len(&self) -> usize { self.0.len() }
-
-        // /// Return the heat for a specific rumor
-        // pub fn heat(&self, rumor_key: &RumorKey, id: &str) -> Option<usize> {
-        //     self.0.get(rumor_key).and_then(|k| k.get(id).cloned())
-        // }
     }
 
     pub struct RumorHeatWriteGuard<'a>(WriteGuard<'a, RumorHeatInner>);

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -447,6 +447,7 @@ impl Server {
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (write)
     /// * `Server::member` (write)
+    /// * `RumorHeat::inner` (write)
     ///
     /// # Errors
     ///

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -453,7 +453,7 @@ impl Server {
     /// * Returns `Error::CannotBind` if the socket cannot be bound
     /// * Returns `Error::SocketSetReadTimeout` if the socket read timeout cannot be set
     /// * Returns `Error::SocketSetWriteTimeout` if the socket write timeout cannot be set
-    pub fn start_rsw_mlw_smw(&mut self, timing: &timing::Timing) -> Result<()> {
+    pub fn start_rsw_mlw_smw_rhw(&mut self, timing: &timing::Timing) -> Result<()> {
         debug!("entering habitat_butterfly::server::Server::start");
         let (tx_outbound, rx_inbound) = channel();
         if let Some(ref path) = self.data_path {
@@ -471,7 +471,7 @@ impl Server {
                                                                    &self.update_store,
                                                                    &self.departure_store)?;
 
-            match reader.read_into_rsw_mlw(&self) {
+            match reader.read_into_rsw_mlw_rhw(&self) {
                 Ok(_) => {
                     debug!("Successfully ingested rumors from {}",
                            reader.path().display())
@@ -585,7 +585,8 @@ impl Server {
     ///
     /// # Locking (see locking.md)
     /// * `MemberList::entries` (write)
-    pub fn insert_member_mlw(&self, member: Member, health: Health) {
+    /// * `RumorHeat::inner` (write)
+    pub fn insert_member_mlw_rhw(&self, member: Member, health: Health) {
         let rk: RumorKey = RumorKey::from(&member);
         let member_id = member.id.clone();
         if self.member_list.insert_mlw(member, health) {
@@ -595,9 +596,10 @@ impl Server {
             // has departed; that's why we subsequently start a "hot"
             // rumor.
             if health == Health::Departed {
-                self.rumor_heat.purge(&member_id);
+                self.rumor_heat.purge_rhw(&member_id);
             }
-            self.rumor_heat.start_hot_rumor(rk);
+
+            self.rumor_heat.start_hot_rumor_rhw(rk);
         }
     }
 
@@ -607,7 +609,8 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `MemberList::entries` (write)
     /// * `Server::member` (write)
-    pub fn set_departed_mlw_smw(&self) {
+    /// * `RumorHeat::inner` (write)
+    pub fn set_departed_mlw_smw_rhw(&self) {
         if self.socket.is_some() {
             self.myself.lock_smw().increment_incarnation();
             // TODO (CM): It's not clear that this operation is actually needed.
@@ -621,7 +624,7 @@ impl Server {
             // NOT calling RumorHeat::purge here because we'll be
             // shutting down soon anyway.
             self.rumor_heat
-                .start_hot_rumor(RumorKey::new(RumorType::Member, &*self.member_id, ""));
+                .start_hot_rumor_rhw(RumorKey::new(RumorType::Member, &*self.member_id, ""));
 
             let check_list = self.member_list.check_list_mlr(&self.member_id);
 
@@ -634,7 +637,7 @@ impl Server {
             for member in check_list.iter().take(SELF_DEPARTURE_RUMOR_FANOUT) {
                 let addr = member.swim_socket_address();
                 // Safe because we checked above
-                outbound::ack_mlr_smr(&self, self.socket.as_ref().unwrap(), member, addr, None);
+                outbound::ack_mlr_smr_rhw(&self, self.socket.as_ref().unwrap(), member, addr, None);
             }
         } else {
             debug!("No socket present; server was never started, so nothing to depart");
@@ -646,7 +649,8 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `MemberList::entries` (write)
     /// * `Server::member` (write)
-    fn insert_member_from_rumor_mlw_smw(&self, member: Member, mut health: Health) {
+    /// * `RumorHeat::inner` (write)
+    fn insert_member_from_rumor_mlw_smw_rhw(&self, member: Member, mut health: Health) {
         let rk: RumorKey = RumorKey::from(&member);
 
         if member.id == self.member_id()
@@ -663,9 +667,9 @@ impl Server {
 
         if self.member_list.insert_mlw(member, health) {
             if member_id != self.member_id() && health == Health::Departed {
-                self.rumor_heat.purge(&member_id);
+                self.rumor_heat.purge_rhw(&member_id);
             }
-            self.rumor_heat.start_hot_rumor(rk);
+            self.rumor_heat.start_hot_rumor_rhw(rk);
         }
     }
 
@@ -684,7 +688,8 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (write)
-    pub fn insert_service_rsw_mlw(&self, service: Service) {
+    /// * `RumorHeat::inner` (write)
+    pub fn insert_service_rsw_mlw_rhw(&self, service: Service) {
         Self::insert_service_impl(service,
                                   &self.service_store,
                                   &self.member_list,
@@ -723,13 +728,14 @@ impl Server {
                                  .min()
                 {
                     member_list.set_departed_mlw(&member_id_to_depart);
-                    rumor_heat.purge(&member_id_to_depart);
-                    rumor_heat.start_hot_rumor(RumorKey::new(RumorType::Member,
-                                                             &*member_id_to_depart,
-                                                             ""));
+                    rumor_heat.purge_rhw(&member_id_to_depart);
+                    rumor_heat.start_hot_rumor_rhw(RumorKey::new(RumorType::Member,
+                                                                 &*member_id_to_depart,
+                                                                 ""));
                 }
             }
-            rumor_heat.start_hot_rumor(rk);
+
+            rumor_heat.start_hot_rumor_rhw(rk);
         }
     }
 
@@ -737,10 +743,11 @@ impl Server {
     ///
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
-    pub fn insert_service_config_rsw(&self, service_config: ServiceConfig) {
+    /// * `RumorHeat::inner` (write)
+    pub fn insert_service_config_rsw_rhw(&self, service_config: ServiceConfig) {
         let rk = RumorKey::from(&service_config);
         if self.service_config_store.insert_rsw(service_config) {
-            self.rumor_heat.start_hot_rumor(rk);
+            self.rumor_heat.start_hot_rumor_rhw(rk);
         }
     }
 
@@ -748,10 +755,11 @@ impl Server {
     ///
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
-    pub fn insert_service_file_rsw(&self, service_file: ServiceFile) {
+    /// * `RumorHeat::inner` (write)
+    pub fn insert_service_file_rsw_rhw(&self, service_file: ServiceFile) {
         let rk = RumorKey::from(&service_file);
         if self.service_file_store.insert_rsw(service_file) {
-            self.rumor_heat.start_hot_rumor(rk);
+            self.rumor_heat.start_hot_rumor_rhw(rk);
         }
     }
 
@@ -760,7 +768,8 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (write)
-    pub fn insert_departure_rsw_mlw(&self, departure: Departure) {
+    /// * `RumorHeat::inner` (write)
+    pub fn insert_departure_rsw_mlw_rhw(&self, departure: Departure) {
         let rk = RumorKey::from(&departure);
         if *self.member_id == departure.member_id {
             self.departed
@@ -768,12 +777,12 @@ impl Server {
         }
 
         self.member_list.set_departed_mlw(&departure.member_id);
-        self.rumor_heat.purge(&departure.member_id);
+        self.rumor_heat.purge_rhw(&departure.member_id);
         self.rumor_heat
-            .start_hot_rumor(RumorKey::new(RumorType::Member, &departure.member_id, ""));
+            .start_hot_rumor_rhw(RumorKey::new(RumorType::Member, &departure.member_id, ""));
 
         if self.departure_store.insert_rsw(departure) {
-            self.rumor_heat.start_hot_rumor(rk);
+            self.rumor_heat.start_hot_rumor_rhw(rk);
         }
     }
 
@@ -851,7 +860,8 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (read)
-    pub fn start_election_rsw_mlr(&self, service_group: &str, term: u64) {
+    /// * `RumorHeat::inner` (write)
+    pub fn start_election_rsw_mlr_rhw(&self, service_group: &str, term: u64) {
         let suitability = self.suitability_lookup.get(&service_group);
         let has_quorum = self.check_quorum_mlr(service_group);
         let e = Election::new(self.member_id(),
@@ -863,14 +873,18 @@ impl Server {
             warn!("start_election check_quorum failed: {:?}", e);
         }
         debug!("start_election: {:?}", e);
-        self.rumor_heat.start_hot_rumor(RumorKey::from(&e));
+        self.rumor_heat.start_hot_rumor_rhw(RumorKey::from(&e));
         self.election_store.insert_rsw(e);
     }
 
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (read)
-    pub fn start_update_election_rsw_mlr(&self, service_group: &str, suitability: u64, term: u64) {
+    /// * `RumorHeat::inner` (write)
+    pub fn start_update_election_rsw_mlr_rhw(&self,
+                                             service_group: &str,
+                                             suitability: u64,
+                                             term: u64) {
         let has_quorum = self.check_quorum_mlr(service_group);
         let e = ElectionUpdate::new(self.member_id(),
                                     service_group,
@@ -881,7 +895,7 @@ impl Server {
             warn!("start_election check_quorum failed: {:?}", e);
         }
         debug!("start_update_election: {:?}", e);
-        self.rumor_heat.start_hot_rumor(RumorKey::from(&e));
+        self.rumor_heat.start_hot_rumor_rhw(RumorKey::from(&e));
         self.update_store.insert_rsw(e);
     }
 
@@ -975,7 +989,8 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (read)
-    pub fn restart_elections_rsw_mlr(&self, feature_flags: FeatureFlag) {
+    /// * `RumorHeat::inner` (write)
+    pub fn restart_elections_rsw_mlr_rhw(&self, feature_flags: FeatureFlag) {
         let elections_to_restart =
             self.elections_to_restart_rsr_mlr(&self.election_store, feature_flags);
 
@@ -991,7 +1006,7 @@ impl Server {
             warn!("Starting a new election for {} {}", service_group, term);
             self.election_store
                 .remove_rsw(&service_group, Election::const_id());
-            self.start_election_rsw_mlr(&service_group, term);
+            self.start_election_rsw_mlr_rhw(&service_group, term);
         }
 
         for (service_group, old_term) in update_elections_to_restart {
@@ -999,7 +1014,7 @@ impl Server {
             warn!("Starting a new election for {} {}", service_group, term);
             self.update_store
                 .remove_rsw(&service_group, ElectionUpdate::const_id());
-            self.start_update_election_rsw_mlr(&service_group, 0, term);
+            self.start_update_election_rsw_mlr_rhw(&service_group, 0, term);
         }
     }
 
@@ -1010,7 +1025,8 @@ impl Server {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (read)
-    pub fn insert_election_rsw_mlr(&self, mut election: Election) {
+    /// * `RumorHeat::inner` (write)
+    pub fn insert_election_rsw_mlr_rhw(&self, mut election: Election) {
         debug!("insert_election: {:?}", election);
         let rk = RumorKey::from(&election);
 
@@ -1034,7 +1050,7 @@ impl Server {
                     debug!("removing old rumor and starting new election");
                     self.election_store
                         .remove_rsw(election.key(), election.id());
-                    self.start_election_rsw_mlr(&election.service_group, election.term);
+                    self.start_election_rsw_mlr_rhw(&election.service_group, election.term);
                 }
                 // If we are the member that this election is voting for, then check to see if the
                 // election is over! If it is, mark this election as final before you process it.
@@ -1084,8 +1100,9 @@ impl Server {
                                               .lock()
                                               .expect("Election timers lock poisoned");
                 existing_timers.insert(election.service_group.clone(), ElectionTimer(timer));
-                self.start_election_rsw_mlr(&election.service_group, election.term);
+                self.start_election_rsw_mlr_rhw(&election.service_group, election.term);
             }
+
             if !election.is_finished() {
                 let has_quorum = self.check_quorum_mlr(election.key());
                 if has_quorum {
@@ -1095,15 +1112,17 @@ impl Server {
                 }
             }
         }
+
         if self.election_store.insert_rsw(election) {
-            self.rumor_heat.start_hot_rumor(rk);
+            self.rumor_heat.start_hot_rumor_rhw(rk);
         }
     }
 
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (read)
-    pub fn insert_update_election_rsw_mlr(&self, mut election: ElectionUpdate) {
+    /// * `RumorHeat::inner` (write)
+    pub fn insert_update_election_rsw_mlr_rhw(&self, mut election: ElectionUpdate) {
         debug!("insert_update_election: {:?}", election);
         let rk = RumorKey::from(&election);
 
@@ -1126,7 +1145,9 @@ impl Server {
                 if new_term {
                     debug!("removing old rumor and starting new election");
                     self.update_store.remove_rsw(election.key(), election.id());
-                    self.start_update_election_rsw_mlr(&election.service_group, 0, election.term);
+                    self.start_update_election_rsw_mlr_rhw(&election.service_group,
+                                                           0,
+                                                           election.term);
                 }
                 // If we are the member that this election is voting for, then check to see if the
                 // election is over! If it is, mark this election as final before you process it.
@@ -1155,8 +1176,9 @@ impl Server {
             } else {
                 // Otherwise, we need to create a new election object for ourselves prior to
                 // merging.
-                self.start_update_election_rsw_mlr(&election.service_group, 0, election.term);
+                self.start_update_election_rsw_mlr_rhw(&election.service_group, 0, election.term);
             }
+
             if !election.is_finished() {
                 let has_quorum = self.check_quorum_mlr(election.key());
                 if has_quorum {
@@ -1166,8 +1188,9 @@ impl Server {
                 }
             }
         }
+
         if self.update_store.insert_rsw(election) {
-            self.rumor_heat.start_hot_rumor(rk);
+            self.rumor_heat.start_hot_rumor_rhw(rk);
         }
     }
 
@@ -1701,14 +1724,14 @@ mod tests {
         fn new_with_corrupt_rumor_file() {
             let tmpdir = TempDir::new().unwrap();
             let mut server = start_with_corrupt_rumor_file(&tmpdir);
-            server.start_rsw_mlw_smw(&Timing::default())
+            server.start_rsw_mlw_smw_rhw(&Timing::default())
                   .expect("Server failed to start");
         }
 
         #[test]
         fn start_listener() {
             let mut server = start_server();
-            server.start_rsw_mlw_smw(&Timing::default())
+            server.start_rsw_mlw_smw_rhw(&Timing::default())
                   .expect("Server failed to start");
         }
     }

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -28,7 +28,7 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
 
         for id in newly_confirmed_members {
             server.rumor_heat
-                  .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
+                  .start_hot_rumor_rhw(RumorKey::new(RumorType::Member, &id, ""));
         }
 
         let newly_departed_members =
@@ -36,9 +36,9 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                   .members_expired_to_departed_mlw(timing.departure_timeout_duration());
 
         for id in newly_departed_members {
-            server.rumor_heat.purge(&id);
+            server.rumor_heat.purge_rhw(&id);
             server.rumor_heat
-                  .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
+                  .start_hot_rumor_rhw(RumorKey::new(RumorType::Member, &id, ""));
         }
 
         thread::sleep(Duration::from_millis(LOOP_DELAY_MS));

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -28,7 +28,8 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
 
         for id in newly_confirmed_members {
             server.rumor_heat
-                  .start_hot_rumor_rhw(RumorKey::new(RumorType::Member, &id, ""));
+                  .lock_rhw()
+                  .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
         }
 
         let newly_departed_members =
@@ -36,9 +37,10 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                   .members_expired_to_departed_mlw(timing.departure_timeout_duration());
 
         for id in newly_departed_members {
-            server.rumor_heat.purge_rhw(&id);
+            server.rumor_heat.lock_rhw().purge(&id);
             server.rumor_heat
-                  .start_hot_rumor_rhw(RumorKey::new(RumorType::Member, &id, ""));
+                  .lock_rhw()
+                  .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
         }
 
         thread::sleep(Duration::from_millis(LOOP_DELAY_MS));

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -295,7 +295,8 @@ pub fn populate_membership_rumors_mlr_rhw(server: &Server,
     // the 5 coolest (but still warm!) Member rumors.
     let rumors: Vec<RumorKey> = server
         .rumor_heat
-        .currently_hot_rumors_rhr(&target.id)
+        .lock_rhr()
+        .currently_hot_rumors(&target.id)
         .into_iter()
         .filter(|ref r| r.kind == RumorType::Member)
         .take(5) // TODO (CM): magic number!
@@ -310,7 +311,9 @@ pub fn populate_membership_rumors_mlr_rhw(server: &Server,
     // confirmed dead; the odds are, they won't receive them. Lets spam them a little harder with
     // rumors.
     if !server.member_list.persistent_and_confirmed_mlr(target) {
-        server.rumor_heat.cool_rumors_rhw(&target.id, &rumors);
+        server.rumor_heat
+              .lock_rhw()
+              .cool_rumors(&target.id, &rumors);
     }
 
     swim

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -114,23 +114,23 @@ fn run_loop(server: &Server) -> ! {
 
         match proto.kind {
             RumorKind::Membership(membership) => {
-                server.insert_member_from_rumor_mlw_smw(membership.member, membership.health);
+                server.insert_member_from_rumor_mlw_smw_rhw(membership.member, membership.health);
             }
-            RumorKind::Service(service) => server.insert_service_rsw_mlw(*service),
+            RumorKind::Service(service) => server.insert_service_rsw_mlw_rhw(*service),
             RumorKind::ServiceConfig(service_config) => {
-                server.insert_service_config_rsw(service_config);
+                server.insert_service_config_rsw_rhw(service_config);
             }
             RumorKind::ServiceFile(service_file) => {
-                server.insert_service_file_rsw(service_file);
+                server.insert_service_file_rsw_rhw(service_file);
             }
             RumorKind::Election(election) => {
-                server.insert_election_rsw_mlr(election);
+                server.insert_election_rsw_mlr_rhw(election);
             }
             RumorKind::ElectionUpdate(election) => {
-                server.insert_update_election_rsw_mlr(election);
+                server.insert_update_election_rsw_mlr_rhw(election);
             }
             RumorKind::Departure(departure) => {
-                server.insert_departure_rsw_mlw(departure);
+                server.insert_departure_rsw_mlw_rhw(departure);
             }
         }
     }

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -81,14 +81,14 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                 if server.member_list.pingable_mlr(&member)
                    && !server.member_list.persistent_and_confirmed_mlr(&member)
                 {
-                    let rumors = server.rumor_heat.currently_hot_rumors(&member.id);
+                    let rumors = server.rumor_heat.currently_hot_rumors_rhr(&member.id);
                     if !rumors.is_empty() {
                         let sc = server.clone();
                         let guard = match thread::Builder::new().name(String::from("push-worker"))
                                                                 .spawn(move || {
-                                                                    send_rumors_rsr_mlr(&sc,
-                                                                                        &member,
-                                                                                        &rumors)
+                                                                    send_rumors_rsr_mlr_rhw(&sc,
+                                                                                            &member,
+                                                                                            &rumors)
                                                                 }) {
                             Ok(guard) => guard,
                             Err(e) => {
@@ -129,12 +129,13 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
 /// # Locking (see locking.md)
 /// * `RumorStore::list` (read)
 /// * `MemberList::entries` (read)
+/// * `RumorHeat::inner` (write)
 // If we ever need to modify this function, it would be an excellent opportunity to
 // simplify the redundant aspects and remove this allow(clippy::cognitive_complexity),
 // but changing it in the absence of other necessity seems like too much risk for the
 // expected reward.
 #[allow(clippy::cognitive_complexity)]
-fn send_rumors_rsr_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
+fn send_rumors_rsr_mlr_rhw(server: &Server, member: &Member, rumors: &[RumorKey]) {
     let socket = (**ZMQ_CONTEXT).as_mut()
                                 .socket(zmq::PUSH)
                                 .expect("Failure to create the ZMQ push socket");
@@ -306,7 +307,8 @@ fn send_rumors_rsr_mlr(server: &Server, member: &Member, rumors: &[RumorKey]) {
             }
         }
     }
-    server.rumor_heat.cool_rumors(&member.id, &rumors);
+
+    server.rumor_heat.cool_rumors_rhw(&member.id, &rumors);
 }
 
 /// Given a rumorkey, creates a protobuf rumor for sharing.

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -81,7 +81,9 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                 if server.member_list.pingable_mlr(&member)
                    && !server.member_list.persistent_and_confirmed_mlr(&member)
                 {
-                    let rumors = server.rumor_heat.currently_hot_rumors_rhr(&member.id);
+                    let rumors = server.rumor_heat
+                                       .lock_rhr()
+                                       .currently_hot_rumors(&member.id);
                     if !rumors.is_empty() {
                         let sc = server.clone();
                         let guard = match thread::Builder::new().name(String::from("push-worker"))
@@ -308,7 +310,9 @@ fn send_rumors_rsr_mlr_rhw(server: &Server, member: &Member, rumors: &[RumorKey]
         }
     }
 
-    server.rumor_heat.cool_rumors_rhw(&member.id, &rumors);
+    server.rumor_heat
+          .lock_rhw()
+          .cool_rumors(&member.id, &rumors);
 }
 
 /// Given a rumorkey, creates a protobuf rumor for sharing.

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -6,7 +6,7 @@ use habitat_core::crypto::keys::sym_key::SymKey;
 fn symmetric_encryption_of_wire_payloads() {
     let ring_key = SymKey::generate_pair_for_ring("wolverine").expect("Failed to generate an in \
                                                                        memory symkey");
-    let mut net = btest::SwimNet::new_ring_encryption(2, &ring_key);
+    let mut net = btest::SwimNet::new_ring_encryption_rhw(2, &ring_key);
     net.connect_smr(0, 1);
     assert_wait_for_health_of_mlr!(net, [0..2, 0..2], Health::Alive);
     net.add_service(0, "core/beast/1.2.3/20161208121212");

--- a/components/butterfly/tests/integration.rs
+++ b/components/butterfly/tests/integration.rs
@@ -9,7 +9,7 @@ use habitat_butterfly::{self,
 
 #[test]
 fn two_members_meshed_confirm_one_member() {
-    let mut net = btest::SwimNet::new(2);
+    let mut net = btest::SwimNet::new_rhw(2);
     net.mesh_mlw_smr();
     assert_wait_for_health_of_mlr!(net, 0, 1, Health::Alive);
     assert_wait_for_health_of_mlr!(net, 1, 0, Health::Alive);
@@ -20,7 +20,7 @@ fn two_members_meshed_confirm_one_member() {
 
 #[test]
 fn six_members_meshed_confirm_one_member() {
-    let mut net = btest::SwimNet::new(6);
+    let mut net = btest::SwimNet::new_rhw(6);
     net.mesh_mlw_smr();
     net[0].pause();
     assert_wait_for_health_of_mlr!(net, 0, Health::Confirmed);
@@ -28,7 +28,7 @@ fn six_members_meshed_confirm_one_member() {
 
 #[test]
 fn six_members_meshed_partition_one_node_from_another_node_remains_alive() {
-    let mut net = btest::SwimNet::new(6);
+    let mut net = btest::SwimNet::new_rhw(6);
     net.mesh_mlw_smr();
     net.block(0, 1);
     net.wait_for_rounds(2);
@@ -37,7 +37,7 @@ fn six_members_meshed_partition_one_node_from_another_node_remains_alive() {
 
 #[test]
 fn six_members_meshed_partition_half_of_nodes_from_each_other_both_sides_confirmed() {
-    let mut net = btest::SwimNet::new(6);
+    let mut net = btest::SwimNet::new_rhw(6);
     net.mesh_mlw_smr();
     assert_wait_for_health_of_mlr!(net, 0, Health::Alive);
     net.partition(0..3, 3..6);
@@ -46,7 +46,7 @@ fn six_members_meshed_partition_half_of_nodes_from_each_other_both_sides_confirm
 
 #[test]
 fn six_members_unmeshed_become_fully_meshed_via_gossip() {
-    let mut net = btest::SwimNet::new(6);
+    let mut net = btest::SwimNet::new_rhw(6);
     net.connect_smr(0, 1);
     net.connect_smr(1, 2);
     net.connect_smr(2, 3);
@@ -57,7 +57,7 @@ fn six_members_unmeshed_become_fully_meshed_via_gossip() {
 
 #[test]
 fn six_members_unmeshed_confirm_one_member() {
-    let mut net = btest::SwimNet::new(6);
+    let mut net = btest::SwimNet::new_rhw(6);
     net.connect_smr(0, 1);
     net.connect_smr(1, 2);
     net.connect_smr(2, 3);
@@ -70,7 +70,7 @@ fn six_members_unmeshed_confirm_one_member() {
 
 #[test]
 fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
-    let mut net = btest::SwimNet::new(6);
+    let mut net = btest::SwimNet::new_rhw(6);
     net.connect_smr(0, 1);
     net.connect_smr(1, 2);
     net.connect_smr(2, 3);
@@ -85,7 +85,7 @@ fn six_members_unmeshed_partition_and_rejoin_no_persistent_peers() {
 
 #[test]
 fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
-    let mut net = btest::SwimNet::new(6);
+    let mut net = btest::SwimNet::new_rhw(6);
     net[0].myself().lock_smw().set_persistent();
     net[4].myself().lock_smw().set_persistent();
     net.connect_smr(0, 1);
@@ -102,21 +102,21 @@ fn six_members_unmeshed_partition_and_rejoin_persistent_peers() {
 
 #[test]
 fn six_members_unmeshed_allows_graceful_departure() {
-    let mut net = btest::SwimNet::new(6);
+    let mut net = btest::SwimNet::new_rhw(6);
     net.connect_smr(0, 1);
     net.connect_smr(1, 2);
     net.connect_smr(2, 3);
     net.connect_smr(3, 4);
     net.connect_smr(4, 5);
     assert_wait_for_health_of_mlr!(net, [0..6, 0..6], Health::Alive);
-    net[0].set_departed_mlw_smw();
+    net[0].set_departed_mlw_smw_rhw();
     net[0].pause();
     assert_wait_for_health_of_mlr!(net, 0, Health::Departed);
 }
 
 #[test]
 fn ten_members_meshed_confirm_one_member() {
-    let mut net = btest::SwimNet::new(10);
+    let mut net = btest::SwimNet::new_rhw(10);
     net.mesh_mlw_smr();
     net[0].pause();
     assert_wait_for_health_of_mlr!(net, 0, Health::Confirmed);

--- a/components/butterfly/tests/rumor/departure.rs
+++ b/components/butterfly/tests/rumor/departure.rs
@@ -4,7 +4,7 @@ use habitat_butterfly::{client::Client,
 
 #[test]
 fn two_members_share_departures() {
-    let mut net = btest::SwimNet::new(2);
+    let mut net = btest::SwimNet::new_rhw(2);
     net.mesh_mlw_smr();
     net.add_departure(0);
     net.wait_for_gossip_rounds(1);
@@ -15,7 +15,7 @@ fn two_members_share_departures() {
 
 #[test]
 fn departure_via_client() {
-    let mut net = btest::SwimNet::new(3);
+    let mut net = btest::SwimNet::new_rhw(3);
     net.mesh_mlw_smr();
 
     net.wait_for_gossip_rounds(1);

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -7,7 +7,7 @@ use habitat_common::FeatureFlag;
 
 #[test]
 fn three_members_run_election() {
-    let mut net = btest::SwimNet::new(3);
+    let mut net = btest::SwimNet::new_rhw(3);
     net.mesh_mlw_smr();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
@@ -23,7 +23,7 @@ fn three_members_run_election() {
 
 #[test]
 fn three_members_run_election_from_one_starting_rumor() {
-    let mut net = btest::SwimNet::new(3);
+    let mut net = btest::SwimNet::new_rhw(3);
     net.mesh_mlw_smr();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
@@ -35,7 +35,7 @@ fn three_members_run_election_from_one_starting_rumor() {
 
 #[test]
 fn five_members_elect_a_new_leader_when_the_old_one_dies() {
-    let mut net = btest::SwimNet::new(5);
+    let mut net = btest::SwimNet::new_rhw(5);
     net.mesh_mlw_smr();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.add_service(1, "core/witcher/1.2.3/20161208121212");
@@ -63,9 +63,9 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
     let paused_id = net[paused].member_id();
     assert_wait_for_health_of_mlr!(net, paused, Health::Confirmed);
     if paused == 0 {
-        net[1].restart_elections_rsw_mlr(FeatureFlag::empty());
+        net[1].restart_elections_rsw_mlr_rhw(FeatureFlag::empty());
     } else {
-        net[0].restart_elections_rsw_mlr(FeatureFlag::empty());
+        net[0].restart_elections_rsw_mlr_rhw(FeatureFlag::empty());
     }
 
     for i in 0..5 {
@@ -92,7 +92,7 @@ fn five_members_elect_a_new_leader_when_the_old_one_dies() {
 #[test]
 #[allow(clippy::cognitive_complexity)]
 fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
-    let mut net = btest::SwimNet::new_with_suitability(vec![1, 0, 0, 0, 0]);
+    let mut net = btest::SwimNet::new_with_suitability_rhw(vec![1, 0, 0, 0, 0]);
     net[0].myself().lock_smw().set_persistent();
     net[4].myself().lock_smw().set_persistent();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
@@ -129,8 +129,8 @@ fn five_members_elect_a_new_leader_when_they_are_quorum_partitioned() {
     let new_leader_id;
     net.partition(0..2, 2..5);
     assert_wait_for_health_of_mlr!(net, [0..2, 2..5], Health::Confirmed);
-    net[0].restart_elections_rsw_mlr(FeatureFlag::empty());
-    net[4].restart_elections_rsw_mlr(FeatureFlag::empty());
+    net[0].restart_elections_rsw_mlr_rhw(FeatureFlag::empty());
+    net[4].restart_elections_rsw_mlr_rhw(FeatureFlag::empty());
     assert_wait_for_election_status!(net, 0, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 1, "witcher.prod", ElectionStatus::NoQuorum);
     assert_wait_for_election_status!(net, 2, "witcher.prod", ElectionStatus::Finished);

--- a/components/butterfly/tests/rumor/service.rs
+++ b/components/butterfly/tests/rumor/service.rs
@@ -2,7 +2,7 @@ use crate::btest;
 
 #[test]
 fn two_members_share_services() {
-    let mut net = btest::SwimNet::new(2);
+    let mut net = btest::SwimNet::new_rhw(2);
     net.mesh_mlw_smr();
     net.add_service(0, "core/witcher/1.2.3/20161208121212");
     net.wait_for_rounds(2);

--- a/components/butterfly/tests/rumor/service_config.rs
+++ b/components/butterfly/tests/rumor/service_config.rs
@@ -6,7 +6,7 @@ use habitat_core::service::ServiceGroup;
 
 #[test]
 fn two_members_share_service_config() {
-    let mut net = btest::SwimNet::new(2);
+    let mut net = btest::SwimNet::new_rhw(2);
     net.mesh_mlw_smr();
     net.add_service_config(0, "witcher", "tcp-backlog = 128");
     net.wait_for_gossip_rounds(1);
@@ -18,7 +18,7 @@ fn two_members_share_service_config() {
 
 #[test]
 fn service_config_via_client() {
-    let mut net = btest::SwimNet::new(2);
+    let mut net = btest::SwimNet::new_rhw(2);
     net.mesh_mlw_smr();
 
     net.wait_for_gossip_rounds(1);

--- a/components/butterfly/tests/rumor/service_file.rs
+++ b/components/butterfly/tests/rumor/service_file.rs
@@ -4,7 +4,7 @@ use habitat_core::service::ServiceGroup;
 
 #[test]
 fn two_members_share_service_files() {
-    let mut net = btest::SwimNet::new(2);
+    let mut net = btest::SwimNet::new_rhw(2);
     net.mesh_mlw_smr();
     net.add_service_file(0,
                          "witcher",
@@ -19,7 +19,7 @@ fn two_members_share_service_files() {
 
 #[test]
 fn service_file_via_client() {
-    let mut net = btest::SwimNet::new(2);
+    let mut net = btest::SwimNet::new_rhw(2);
     net.mesh_mlw_smr();
 
     net.wait_for_gossip_rounds(1);

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
     logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
-    let result = start_rsr_imlw_mlw_gsw_smw(flags);
+    let result = start_rsr_imlw_mlw_gsw_smw_rhw(flags);
     let exit_code = match result {
         Ok(_) => 0,
         Err(ref err) => {
@@ -116,7 +116,8 @@ fn boot() -> Option<LauncherCli> {
 /// * `MemberList::entries` (write)
 /// * `GatewayState::inner` (write)
 /// * `Server::member` (write)
-fn start_rsr_imlw_mlw_gsw_smw(feature_flags: FeatureFlag) -> Result<()> {
+/// * `RumorHeat::inner` (write)
+fn start_rsr_imlw_mlw_gsw_smw_rhw(feature_flags: FeatureFlag) -> Result<()> {
     if feature_flags.contains(FeatureFlag::TEST_BOOT_FAIL) {
         outputln!("Simulating boot failure");
         return Err(Error::TestBootFail);
@@ -146,7 +147,7 @@ fn start_rsr_imlw_mlw_gsw_smw(feature_flags: FeatureFlag) -> Result<()> {
         ("bash", Some(_)) => sub_bash(),
         ("run", Some(m)) => {
             let launcher = launcher.ok_or(Error::NoLauncher)?;
-            sub_run_rsr_imlw_mlw_gsw_smw(m, launcher, feature_flags)
+            sub_run_rsr_imlw_mlw_gsw_smw_rhw(m, launcher, feature_flags)
         }
         ("sh", Some(_)) => sub_sh(),
         ("term", Some(_)) => sub_term(),
@@ -162,10 +163,11 @@ fn sub_bash() -> Result<()> { command::shell::bash() }
 /// * `MemberList::entries` (write)
 /// * `GatewayState::inner` (write)
 /// * `Server::member` (write)
-fn sub_run_rsr_imlw_mlw_gsw_smw(m: &ArgMatches,
-                                launcher: LauncherCli,
-                                feature_flags: FeatureFlag)
-                                -> Result<()> {
+/// * `RumorHeat::inner` (write)
+fn sub_run_rsr_imlw_mlw_gsw_smw_rhw(m: &ArgMatches,
+                                    launcher: LauncherCli,
+                                    feature_flags: FeatureFlag)
+                                    -> Result<()> {
     set_supervisor_logging_options(m);
 
     let cfg = mgrcfg_from_sup_run_matches(m, feature_flags)?;
@@ -203,7 +205,7 @@ fn sub_run_rsr_imlw_mlw_gsw_smw(m: &ArgMatches,
         None
     };
 
-    manager.run_rsw_imlw_mlw_gsw_smw(svc)
+    manager.run_rsw_imlw_mlw_gsw_smw_rhw(svc)
 }
 
 fn sub_sh() -> Result<()> { command::shell::sh() }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -149,14 +149,17 @@ impl ServiceUpdater {
     /// # Locking (see locking.md)
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (read)
+    /// * `RumorHeat::inner` (write)
     #[allow(clippy::cognitive_complexity)]
-    pub fn check_for_updated_package_rsw_mlr(&mut self,
-                                             service: &Service,
-                                             // TODO (CM): Strictly speaking, we don't need to
-                                             // pass CensusRing down into here, just the census
-                                             // group for our service.
-                                             census_ring: &CensusRing)
-                                             -> Option<PackageIdent> {
+    pub fn check_for_updated_package_rsw_mlr_rhw(&mut self,
+                                                 service: &Service,
+                                                 // TODO (CM): Strictly speaking, we don't need
+                                                 // to
+                                                 // pass CensusRing down into here, just the
+                                                 // census
+                                                 // group for our service.
+                                                 census_ring: &CensusRing)
+                                                 -> Option<PackageIdent> {
         debug!("Checking for updated package!");
 
         // TODO (CM): can we do without this?
@@ -191,9 +194,9 @@ impl ServiceUpdater {
                                     u64::max_value()
                                 };
                                 self.butterfly
-                                    .start_update_election_rsw_mlr(&service.service_group,
-                                                                   suitability,
-                                                                   0);
+                                    .start_update_election_rsw_mlr_rhw(&service.service_group,
+                                                                       suitability,
+                                                                       0);
                                 *st = RollingState::InElection
                             }
                             _ => return None,
@@ -201,7 +204,7 @@ impl ServiceUpdater {
                     } else {
                         debug!("Rolling update, using default suitability");
                         self.butterfly
-                            .start_update_election_rsw_mlr(&service.service_group, 0, 0);
+                            .start_update_election_rsw_mlr_rhw(&service.service_group, 0, 0);
                         *st = RollingState::InElection;
                     }
                 }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -154,10 +154,8 @@ impl ServiceUpdater {
     pub fn check_for_updated_package_rsw_mlr_rhw(&mut self,
                                                  service: &Service,
                                                  // TODO (CM): Strictly speaking, we don't need
-                                                 // to
-                                                 // pass CensusRing down into here, just the
-                                                 // census
-                                                 // group for our service.
+                                                 // to pass CensusRing down into here, just the
+                                                 // census group for our service.
                                                  census_ring: &CensusRing)
                                                  -> Option<PackageIdent> {
         debug!("Checking for updated package!");

--- a/docs/dev/design_documents/locking.md
+++ b/docs/dev/design_documents/locking.md
@@ -38,6 +38,7 @@ must be acquired in the conventional order and released in the reverse order:
 1. `GatewayState::inner` (`gs`)
 1. `Server::member` (`sm`)
 1. `Server::block_list` (`sbl`)
+1. `RumorHeat::inner` (`rh`)
 
 Any function which is documented to acquire a lock should not be called with
 any lock that occurs later in the lock order held. For example, since


### PR DESCRIPTION
Also add docs and annotate all functions.

This is in service of https://github.com/habitat-sh/habitat/issues/6435

NOTE:  This PR will almost certainly have conflicts with https://github.com/habitat-sh/habitat/pull/6941.  https://github.com/habitat-sh/habitat/pull/6941 should merge first, and I will rebase this one after that one merges.

![](https://media.giphy.com/media/1FT20zgiDr8Bi/giphy.gif)

Signed-off-by: Josh Black <raskchanky@gmail.com>