### PR TITLE
`hab pkg bulkupload` packages from a directory

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -169,7 +169,7 @@ impl BuilderAPIClient {
                 -> Result<PathBuf> {
         debug!("Downloading file to path: {}", dst_path.display());
         let mut resp = self.maybe_add_authz(rb, token).send()?;
-        resp.ok_if(StatusCode::OK)?;
+        resp.ok_if(&[StatusCode::OK])?;
 
         fs::create_dir_all(&dst_path)?;
         let file_name = resp.get_header(X_FILENAME)?;
@@ -260,7 +260,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
         };
 
         let mut resp = self.0.get_with_custom_url(&path, custom).send()?;
-        resp.ok_if(StatusCode::OK)?;
+        resp.ok_if(&[StatusCode::OK])?;
 
         Ok(resp.json()?)
     }
@@ -282,7 +282,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
         };
 
         let mut resp = self.0.get_with_custom_url(&path, custom).send()?;
-        resp.ok_if(StatusCode::OK)?;
+        resp.ok_if(&[StatusCode::OK])?;
 
         Ok(resp.json()?)
     }
@@ -337,7 +337,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
                                u.set_query(Some(&format!("target={}", &target.to_string())))
                            })
                            .send()?;
-        resp.ok_if(StatusCode::OK)?;
+        resp.ok_if(&[StatusCode::OK])?;
 
         let mut encoded = String::new();
         resp.read_to_string(&mut encoded).map_err(Error::IO)?;
@@ -377,7 +377,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .bearer_auth(token)
             .json(&body)
             .send()?
-            .ok_if(StatusCode::NO_CONTENT)
+            .ok_if(&[StatusCode::NO_CONTENT])
     }
 
     /// Cancel a job group
@@ -394,7 +394,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .post(&url)
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::NO_CONTENT)
+            .ok_if(&[StatusCode::NO_CONTENT])
     }
 
     /// Download a public encryption key from a remote Builder to the given filepath.
@@ -433,7 +433,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .bearer_auth(token)
             .json(&body)
             .send()?
-            .ok_if(StatusCode::CREATED)
+            .ok_if(&[StatusCode::CREATED])
     }
 
     /// Create secret for an origin
@@ -460,7 +460,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .bearer_auth(token)
             .json(&body)
             .send()?
-            .ok_if(StatusCode::CREATED)
+            .ok_if(&[StatusCode::CREATED])
     }
 
     /// Delete a secret for an origin
@@ -478,7 +478,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .delete(&path)
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::NO_CONTENT)
+            .ok_if(&[StatusCode::NO_CONTENT])
     }
 
     /// Delete an origin
@@ -497,7 +497,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .delete(&path)
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::NO_CONTENT)
+            .ok_if(&[StatusCode::NO_CONTENT])
     }
 
     /// List all secrets keys for an origin
@@ -510,7 +510,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
 
         let path = format!("depot/origins/{}/secret", origin);
         let mut resp = self.0.get(&path).bearer_auth(token).send()?;
-        resp.ok_if(StatusCode::OK)?;
+        resp.ok_if(&[StatusCode::OK])?;
 
         let mut encoded = String::new();
         resp.read_to_string(&mut encoded)
@@ -567,7 +567,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
         debug!("Showing origin keys: {}", origin);
 
         let mut resp = self.0.get(&origin_keys_path(origin)).send()?;
-        resp.ok_if(StatusCode::OK)?;
+        resp.ok_if(&[StatusCode::OK])?;
 
         let mut encoded = String::new();
         resp.read_to_string(&mut encoded)
@@ -602,7 +602,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
 
         let mut resp = self.maybe_add_authz(self.0.get_with_custom_url(&path, custom), token)
                            .send()?;
-        resp.ok_if(StatusCode::OK)?;
+        resp.ok_if(&[StatusCode::OK])?;
 
         let mut encoded = String::new();
         resp.read_to_string(&mut encoded)
@@ -647,10 +647,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             Body::sized(file, file_size)
         };
         let mut resp = self.0.post(&path).bearer_auth(token).body(body).send()?;
-        match resp.status() {
-            StatusCode::OK | StatusCode::CREATED => Ok(()),
-            _ => Err(err_from_response(&mut resp)),
-        }
+        resp.ok_if(&[StatusCode::OK, StatusCode::CREATED])
     }
 
     /// Upload a secret origin key to a remote Builder.
@@ -687,7 +684,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             Body::sized(file, file_size)
         };
         let mut resp = self.0.post(&path).bearer_auth(token).body(body).send()?;
-        resp.ok_if(StatusCode::OK)
+        resp.ok_if(&[StatusCode::OK])
     }
 
     /// Download the latest release of a package.
@@ -751,7 +748,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
                                    }),
                              token)
             .send()?
-            .ok_if(StatusCode::OK)
+            .ok_if(&[StatusCode::OK])
     }
 
     /// Returns a package struct for the latest package.
@@ -783,7 +780,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
                                                 }),
                                             token)
                            .send()?;
-        resp.ok_if(StatusCode::OK)?;
+        resp.ok_if(&[StatusCode::OK])?;
 
         let mut encoded = String::new();
         resp.read_to_string(&mut encoded)
@@ -853,10 +850,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
                            .body(body)
                            .send()?;
 
-        match resp.status() {
-            StatusCode::OK | StatusCode::CREATED => Ok(()),
-            _ => Err(err_from_response(&mut resp)),
-        }
+        resp.ok_if(&[StatusCode::OK, StatusCode::CREATED])
     }
 
     fn x_put_package(&self, pa: &mut PackageArchive, token: &str) -> Result<()> {
@@ -885,7 +879,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .bearer_auth(token)
             .body(body)
             .send()?
-            .ok_if(StatusCode::OK)
+            .ok_if(&[StatusCode::OK])
     }
 
     /// Delete a package from Builder
@@ -912,7 +906,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .delete_with_custom_url(&path, custom)
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::NO_CONTENT)
+            .ok_if(&[StatusCode::NO_CONTENT])
     }
 
     /// Promote a package to a given channel
@@ -947,7 +941,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .put_with_custom_url(&path, custom)
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::OK)
+            .ok_if(&[StatusCode::OK])
     }
 
     /// Demote a package from a given channel
@@ -982,7 +976,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .put_with_custom_url(&path, custom)
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::OK)
+            .ok_if(&[StatusCode::OK])
     }
 
     /// Create a custom channel
@@ -998,7 +992,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .post(&path)
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::CREATED)
+            .ok_if(&[StatusCode::CREATED])
     }
 
     /// Delete a custom channel
@@ -1014,7 +1008,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .delete(&path)
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::CREATED)
+            .ok_if(&[StatusCode::CREATED])
     }
 
     /// Promote all packages in channel
@@ -1040,7 +1034,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             })
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::OK)
+            .ok_if(&[StatusCode::OK])
     }
 
     /// Demote all packages from channel
@@ -1066,7 +1060,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             })
             .bearer_auth(token)
             .send()?
-            .ok_if(StatusCode::OK)
+            .ok_if(&[StatusCode::OK])
     }
 
     /// Returns a vector of PackageIdent structs

--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -853,7 +853,10 @@ impl BuilderAPIProvider for BuilderAPIClient {
                            .body(body)
                            .send()?;
 
-        resp.ok_if(StatusCode::OK)
+        match resp.status() {
+            StatusCode::OK | StatusCode::CREATED => Ok(()),
+            _ => Err(err_from_response(&mut resp)),
+        }
     }
 
     fn x_put_package(&self, pa: &mut PackageArchive, token: &str) -> Result<()> {

--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -647,7 +647,10 @@ impl BuilderAPIProvider for BuilderAPIClient {
             Body::sized(file, file_size)
         };
         let mut resp = self.0.post(&path).bearer_auth(token).body(body).send()?;
-        resp.ok_if(StatusCode::OK)
+        match resp.status() {
+            StatusCode::OK | StatusCode::CREATED => Ok(()),
+            _ => Err(err_from_response(&mut resp)),
+        }
     }
 
     /// Upload a secret origin key to a remote Builder.

--- a/components/builder-api-client/src/response.rs
+++ b/components/builder-api-client/src/response.rs
@@ -20,15 +20,18 @@ impl fmt::Display for NetError {
 }
 
 pub trait ResponseExt {
-    fn ok_if(&mut self, code: reqwest::StatusCode) -> Result<()>;
+    fn ok_if<'a>(&'a mut self,
+                 code: impl IntoIterator<Item = &'a reqwest::StatusCode>)
+                 -> Result<()>;
     fn get_header<'a, K: AsHeaderName>(&'a self, name: K) -> Result<&'a str>;
 }
 
 impl ResponseExt for reqwest::Response {
-    fn ok_if(&mut self, code: reqwest::StatusCode) -> Result<()> {
+    fn ok_if<'a>(&'a mut self,
+                 code: impl IntoIterator<Item = &'a reqwest::StatusCode>)
+                 -> Result<()> {
         debug!("Response Status: {:?}", self.status());
-
-        if self.status() == code {
+        if code.into_iter().any(|&code| code == self.status()) {
             Ok(())
         } else {
             Err(err_from_response(self))

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -20,6 +20,7 @@ dirs = "*"
 env_logger = "*"
 flate2 = "*"
 futures = "*"
+glob = "*"
 habitat_api_client = { path = "../builder-api-client" }
 habitat_common = { path = "../common" }
 habitat_core = { path = "../core" }

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -548,7 +548,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
             // alas no hyphens in subcommand names..
             // https://github.com/clap-rs/clap/issues/1297
             (@subcommand bulkupload =>
-                (about: "\n!!! ATTENTION !!!\nThis command is ALPHA and subject to change.\n\nBulk Uploads Habitat Artifacts to a Depot from a local directory.")
+                (about: "Bulk Uploads Habitat Artifacts to a Depot from a local directory.")
                 (aliases: &["bul", "bulk"])
                 (@arg BLDR_URL: -u --url +takes_value {valid_url} "Specify an alternate Depot \
                     endpoint. If not specified, the value will be taken from the HAB_BLDR_URL \

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -545,6 +545,27 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                     (ex: core/redis, core/busybox-static/1.42.2/21120102031201)")
                 (@arg NO_DEPS: --("no-deps") "Don't uninstall dependencies")
             )
+            // alas no hyphens in subcommand names..
+            // https://github.com/clap-rs/clap/issues/1297
+            (@subcommand bulkupload =>
+                (about: "\n!!! ATTENTION !!!\nThis command is ALPHA and subject to change.\n\nBulk Uploads Habitat Artifacts to a Depot from a local directory.")
+                (aliases: &["bul", "bulk"])
+                (@arg BLDR_URL: -u --url +takes_value {valid_url} "Specify an alternate Depot \
+                    endpoint. If not specified, the value will be taken from the HAB_BLDR_URL \
+                    environment variable if defined. (default: https://bldr.habitat.sh)")
+                (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
+                (@arg CHANNEL: --channel -c +takes_value
+                    "Optional additional release channel to upload package to. \
+                     Packages are always uploaded to `unstable`, regardless \
+                     of the value of this option.")
+                (@arg FORCE: --force "Skips checking availability of package and \
+                    force uploads, potentially overwriting a stored copy of a package. \
+                    (default: false)")
+                (@arg AUTO_BUILD: --("auto-build") "Enable auto-build for all packages in this upload. Only applicable to SaaS Builder. \
+                    (default: false)")
+                (@arg UPLOAD_DIRECTORY: +required {dir_exists}
+                    "Directory Path from which artifacts will be uploaded.")
+            )
             (@subcommand upload =>
                 (about: "Uploads a local Habitat Artifact to Builder")
                 (aliases: &["u", "up", "upl", "uplo", "uploa"])
@@ -560,20 +581,12 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                     force uploads, potentially overwriting a stored copy of a package. \
                     (default: false)")
                 (@arg NO_BUILD: --("no-build")  "Disable auto-build for all packages in this upload.")
+                (@arg HART_FILE: +required +multiple {file_exists}
+                    "One or more filepaths to a Habitat Artifact \
+                    (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
                 (arg: arg_cache_key_path("Path to search for public origin keys to upload. \
                     Default value is hab/cache/keys if root and .hab/cache/keys under the home \
                     directory otherwise."))
-                (@arg CACHE_DIRECTORY: --cache +takes_value {dir_exists} default_value("/hab/cache")
-                    "Path to search for artifacts referenced in --input-file.")
-                (@group upload =>
-                    (@attributes +required)
-                    (@arg INPUT_FILE: -i --("input-file") +takes_value {file_exists}
-                        "Input file containing a newline delimited list of PackageIdentTarget strings to upload. \
-                        (ex entry: 'acme/wal-g/0.1.16/20190416172109/x86_64-linux')")
-                    (@arg HART_FILE: +multiple {file_exists}
-                        "One or more filepaths to a Habitat Artifact \
-                        (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
-                )
             )
             (@subcommand delete =>
                 (about: "Removes a package from Builder")

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -560,12 +560,20 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                     force uploads, potentially overwriting a stored copy of a package. \
                     (default: false)")
                 (@arg NO_BUILD: --("no-build")  "Disable auto-build for all packages in this upload.")
-                (@arg HART_FILE: +required +multiple {file_exists}
-                    "One or more filepaths to a Habitat Artifact \
-                    (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
                 (arg: arg_cache_key_path("Path to search for public origin keys to upload. \
                     Default value is hab/cache/keys if root and .hab/cache/keys under the home \
                     directory otherwise."))
+                (@arg CACHE_DIRECTORY: --cache +takes_value {dir_exists} default_value("/hab/cache")
+                    "Path to search for artifacts referenced in --input-file.")
+                (@group upload =>
+                    (@attributes +required)
+                    (@arg INPUT_FILE: -i --("input-file") +takes_value {file_exists}
+                        "Input file containing a newline delimited list of PackageIdentTarget strings to upload. \
+                        (ex entry: 'acme/wal-g/0.1.16/20190416172109/x86_64-linux')")
+                    (@arg HART_FILE: +multiple {file_exists}
+                        "One or more filepaths to a Habitat Artifact \
+                        (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
+                )
             )
             (@subcommand delete =>
                 (about: "Removes a package from Builder")

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -558,11 +558,9 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                     "Optional additional release channel to upload package to. \
                      Packages are always uploaded to `unstable`, regardless \
                      of the value of this option.")
-                (@arg FORCE: --force "Skips checking availability of package and \
-                    force uploads, potentially overwriting a stored copy of a package. \
-                    (default: false)")
-                (@arg AUTO_BUILD: --("auto-build") "Enable auto-build for all packages in this upload. Only applicable to SaaS Builder. \
-                    (default: false)")
+                (@arg FORCE: --force "Skip checking availability of package and \
+                    force uploads, potentially overwriting a stored copy of a package.")
+                (@arg AUTO_BUILD: --("auto-build") "Enable auto-build for all packages in this upload. Only applicable to SaaS Builder.")
                 (@arg UPLOAD_DIRECTORY: +required {dir_exists}
                     "Directory Path from which artifacts will be uploaded.")
             )

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -845,9 +845,8 @@ fn sub_pkg_sign(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 
 fn sub_pkg_bulkupload(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let upload_dir = bulkupload_dir_from_matches(m);
-    // upload_dir is required via clap and exists
-    let artifact_path = upload_dir.as_ref().unwrap().join("artifacts");
-    let key_path = upload_dir.as_ref().unwrap().join("keys");
+    let artifact_path = upload_dir.join("artifacts");
+    let key_path = upload_dir.join("keys");
     let url = bldr_url_from_matches(&m)?;
     let additional_release_channel = channel_from_matches(&m);
     let force_upload = m.is_present("FORCE");
@@ -1773,8 +1772,10 @@ fn supervisor_services() -> Result<Vec<PackageIdent>> {
     Ok(out)
 }
 
-fn bulkupload_dir_from_matches(matches: &ArgMatches<'_>) -> Option<PathBuf> {
-    matches.value_of("UPLOAD_DIRECTORY").map(PathBuf::from)
+fn bulkupload_dir_from_matches(matches: &ArgMatches<'_>) -> PathBuf {
+    matches.value_of("UPLOAD_DIRECTORY")
+           .map(PathBuf::from)
+           .expect("CLAP-validated upload dir")
 }
 
 fn vec_from_glob_with(pattern: &str, options: glob::MatchOptions) -> Vec<PathBuf> {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -863,16 +863,16 @@ fn sub_pkg_bulkupload(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let artifact_paths =
         vec_from_glob_with(&artifact_path.join("*.hart").display().to_string(), options);
 
-    ui.begin(format!("Preparing to upload hartifacts to the '{}' channel on {}",
+    ui.begin(format!("Preparing to upload artifacts to the '{}' channel on {}",
                      additional_release_channel.clone()
                                                .unwrap_or_else(ChannelIdent::unstable),
                      url))?;
     ui.status(Status::Using,
-              format!("{} for hartifacts and {} for signing keys.",
+              format!("{} for artifacts and {} for signing keys.",
                       &artifact_path.display(),
                       &key_path.display()))?;
     ui.status(Status::Found,
-              format!("{} hartifacts for upload.", artifact_paths.len()))?;
+              format!("{} artifacts for upload.", artifact_paths.len()))?;
 
     for artifact_path in &artifact_paths {
         command::pkg::upload::start(ui,

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -847,15 +847,15 @@ fn sub_pkg_bulkupload(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let upload_dir = bulkupload_dir_from_matches(m);
     let artifact_path = upload_dir.join("artifacts");
     let key_path = upload_dir.join("keys");
-    let url = bldr_url_from_matches(&m)?;
-    let additional_release_channel = channel_from_matches(&m);
+    let url = bldr_url_from_matches(m)?;
+    let additional_release_channel = channel_from_matches(m);
     let force_upload = m.is_present("FORCE");
     let auto_build = if m.is_present("AUTO_BUILD") {
         BuildOnUpload::PackageDefault
     } else {
         BuildOnUpload::Disable
     };
-    let token = auth_token_param_or_env(&m)?;
+    let token = auth_token_param_or_env(m)?;
     let options = glob::MatchOptions { case_sensitive:              true,
                                        require_literal_separator:   true,
                                        require_literal_leading_dot: true, };
@@ -869,11 +869,11 @@ fn sub_pkg_bulkupload(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     ui.status(Status::Using,
               format!("{} for artifacts and {} for signing keys.",
                       &artifact_path.display(),
-                      &key_path.display()))?;
+                      key_path.display()))?;
     ui.status(Status::Found,
               format!("{} artifacts for upload.", artifact_paths.len()))?;
 
-    for artifact_path in &artifact_paths {
+    for artifact_path in artifact_paths {
         command::pkg::upload::start(ui,
                                     &url,
                                     &additional_release_channel,

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -856,11 +856,11 @@ fn sub_pkg_bulkupload(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
         BuildOnUpload::Disable
     };
     let token = auth_token_param_or_env(m)?;
-    let options = glob::MatchOptions { case_sensitive:              true,
-                                       require_literal_separator:   true,
-                                       require_literal_leading_dot: true, };
+    const OPTIONS: glob::MatchOptions = glob::MatchOptions { case_sensitive:              true,
+                                                             require_literal_separator:   true,
+                                                             require_literal_leading_dot: true, };
     let artifact_paths =
-        vec_from_glob_with(&artifact_path.join("*.hart").display().to_string(), options);
+        vec_from_glob_with(&artifact_path.join("*.hart").display().to_string(), OPTIONS);
 
     ui.begin(format!("Preparing to upload artifacts to the '{}' channel on {}",
                      additional_release_channel.clone()

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -860,12 +860,12 @@ fn sub_pkg_bulkupload(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let options = glob::MatchOptions { case_sensitive:              true,
                                        require_literal_separator:   true,
                                        require_literal_leading_dot: true, };
-    let artifact_paths = vec_from_glob_with(&artifact_path.join("*.hart").display().to_string(),
-                                            &options);
+    let artifact_paths =
+        vec_from_glob_with(&artifact_path.join("*.hart").display().to_string(), options);
 
     ui.begin(format!("Preparing to upload hartifacts to the '{}' channel on {}",
                      additional_release_channel.clone()
-                                               .unwrap_or(ChannelIdent::unstable()),
+                                               .unwrap_or_else(ChannelIdent::unstable),
                      url))?;
     ui.status(Status::Using,
               format!("{} for hartifacts and {} for signing keys.",
@@ -1777,10 +1777,10 @@ fn bulkupload_dir_from_matches(matches: &ArgMatches<'_>) -> Option<PathBuf> {
     matches.value_of("UPLOAD_DIRECTORY").map(PathBuf::from)
 }
 
-fn vec_from_glob_with(pattern: &str, options: &glob::MatchOptions) -> Vec<PathBuf> {
-    glob_with(pattern, *options).unwrap()
-                                .map(|r| r.unwrap())
-                                .collect()
+fn vec_from_glob_with(pattern: &str, options: glob::MatchOptions) -> Vec<PathBuf> {
+    glob_with(pattern, options).unwrap()
+                               .map(std::result::Result::unwrap)
+                               .collect()
 }
 
 /// A Builder URL, but *only* if the user specified it via CLI args or


### PR DESCRIPTION
Closes https://github.com/habitat-sh/habitat/issues/6903
Closes https://github.com/habitat-sh/habitat/issues/6981

This PR adds a new subcommand: `hab pkg bulkupload` which uploads artifacts from a directory created by a [new](https://github.com/habitat-sh/habitat/pull/6945) command: `hab pkg download` .

@chefsalim  @markan FYI

The purpose of this PR is to help simplify the process of bootstrapping a Depot. It takes into account the internal discussion we've had around the UX.

Additionally, it allows for HTTP 201 responses when keys or packages are uploaded for the first time or via the `--force` argument.

Signed-off-by: Jeremy J. Miller <jm@chef.io>