### PR TITLE
Update docs for new cert handling

### DIFF
--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -49,6 +49,8 @@ sidebar_links:
       link: "/docs/using-builder/#multiple-plans-builder"
     - title: Set up Automated Builds
       link: "/docs/using-builder/#automated-builds"
+    - title: Using Custom Certificates
+      link: "/docs/using-builder/#using-custom-certs"
   - title: Managing Services
     link: "/docs/using-habitat"
     sub_links:

--- a/www/source/docs/using-builder.html.md.erb
+++ b/www/source/docs/using-builder.html.md.erb
@@ -517,7 +517,7 @@ If you attempt to perform an operation using the Habitat client that talks to a 
 ✗✗✗
 ```
 
-One way to deal with this issue is to use the `SSL_CERT_FILE` environment variable, and point it to the path of the custom certificate prior to performing the client operation.
+One option to remediate this error is to define a `SSL_CERT_FILE` environment variable pointing to the custom certificate path before performing the client operation.
 
 With the release of Habitat 0.85.0, there is another option that is now available. Habitat will now look for custom certificates in its `~/.hab/cache/ssl` directory (or `/hab/cache/ssl` if running as root). Multiple certificates (for example, a self-signed certificate, and a custom certificate authority certificate) can be copied over to the cache directory and will become automatically avaialable for use by the Habitat client.
 

--- a/www/source/docs/using-builder.html.md.erb
+++ b/www/source/docs/using-builder.html.md.erb
@@ -508,7 +508,7 @@ For a detailed explanation of features, requirements and setup instructions, [se
 ---
 ## <a name="using-custom-certs" id="using-custom-certs" data-magellan-target="using-custom-certs">Using Custom Certificates</a>
 
-Dealing with custom certificates (for example, self-signed) is a fairly common scenario in enterprise environments. For example, if you are running a Chef Habitat Builder Depot on-premises, you might have a self-signed SSL certificate on the instance.
+Many enterprise environments use custom certificates (for example, self-signed). For example, an on-premises Chef Habitat Builder Depot might have a self-signed SSL certificate.
 
 If you attempt to perform an operation using the Habitat client that talks to a service with a custom certificate, you might get an error such as:
 ```

--- a/www/source/docs/using-builder.html.md.erb
+++ b/www/source/docs/using-builder.html.md.erb
@@ -521,6 +521,6 @@ One option to remediate this error is to define a `SSL_CERT_FILE` environment va
 
 The Habitat 0.85.0 release in September 2019 improved the handling of custom certificates.  Now Habitat knows to look for custom certificates in the `~/.hab/cache/ssl` directory, which is `/hab/cache/ssl` when you are running as root. Copying multiple certificates--for example, a self-signed certificate and a custom certificate authority certificate--to the Chef Habitat cache directory makes them automatically available to the Habitat client.
 
-The `/hab/cache/ssl` directory is also made available inside a Habitat Studio. So, if you have populated the cache directory before entering the Studio, you will find that its contents are populated with the files from outside the Studio. In addition, when entering the Habitat Studio, the `SSL_CERT_FILE` environment variable will be propagated to the Studio, and the file that it is pointing to will also be copied over to the `/hab/cache/ssl` directory.
+The `/hab/cache/ssl` directory is also available inside a Habitat Studio. As long as the certificates are inside the cache directory before you enter the Studio, you'll also find them inside the Studio. In addition, if you've set the `SSL_CERT_FILE` environment variable, you'll also find both it and the file that it points to inside the Studio`/hab/cache/ssl` directory.
 
 Note: The filename `cert.pem` is reserved for Habitat, so please do not use that file name when copying certs into the cache directory.

--- a/www/source/docs/using-builder.html.md.erb
+++ b/www/source/docs/using-builder.html.md.erb
@@ -519,7 +519,7 @@ Attempting to perform an operation using the Habitat client to communicate with 
 
 One option to remediate this error is to define a `SSL_CERT_FILE` environment variable pointing to the custom certificate path before performing the client operation.
 
-With the release of Habitat 0.85.0, there is another option that is now available. Habitat will now look for custom certificates in its `~/.hab/cache/ssl` directory (or `/hab/cache/ssl` if running as root). Multiple certificates (for example, a self-signed certificate, and a custom certificate authority certificate) can be copied over to the cache directory and will become automatically avaialable for use by the Habitat client.
+The Habitat 0.85.0 release in September 2019 improved the handling of custom certificates.  Now Habitat knows to look for custom certificates in the `~/.hab/cache/ssl` directory, which is `/hab/cache/ssl` when you are running as root. Copying multiple certificates--for example, a self-signed certificate and a custom certificate authority certificate--to the Chef Habitat cache directory makes them automatically available to the Habitat client.
 
 The `/hab/cache/ssl` directory is also made available inside a Habitat Studio. So, if you have populated the cache directory before entering the Studio, you will find that its contents are populated with the files from outside the Studio. In addition, when entering the Habitat Studio, the `SSL_CERT_FILE` environment variable will be propagated to the Studio, and the file that it is pointing to will also be copied over to the `/hab/cache/ssl` directory.
 

--- a/www/source/docs/using-builder.html.md.erb
+++ b/www/source/docs/using-builder.html.md.erb
@@ -19,6 +19,7 @@ description: Documentation for Chef Habitat uploading, auto-building, and deploy
   - [Using Multiple Plans](#multiple-plans-builder)
   - [Set up Automated Builds](#automated-builds)
   - [Install and Use Builder On-Premises](#on-prem)
+  - [Using Custom Certificates](#using-custom-certs)
 
 ---
 ## <a name="builder-account" id="builder-account" data-magellan-target="builder-account">Create a Builder Account</a>
@@ -504,3 +505,22 @@ Currently, our on-premises Builder depot only stores packages for download and u
 
 For a detailed explanation of features, requirements and setup instructions, [see the GitHub repository](https://github.com/habitat-sh/on-prem-builder).
 
+---
+## <a name="using-custom-certs" id="using-custom-certs" data-magellan-target="using-custom-certs">Using Custom Certificates</a>
+
+Dealing with custom certificates (for example, self-signed) is a fairly common scenario in enterprise environments. For example, if you are running a Chef Habitat Builder Depot on-premises, you might have a self-signed SSL certificate on the instance.
+
+If you attempt to perform an operation using the Habitat client that talks to a service with a custom certificate, you might get an error such as:
+```
+✗✗✗
+✗✗✗ the handshake failed: The OpenSSL library reported an error: error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed:s3_clnt.c:1269:: unable to get local issuer certificate
+✗✗✗
+```
+
+One way to deal with this issue is to use the `SSL_CERT_FILE` environment variable, and point it to the path of the custom certificate prior to performing the client operation.
+
+With the release of Habitat 0.85.0, there is another option that is now available. Habitat will now look for custom certificates in its `~/.hab/cache/ssl` directory (or `/hab/cache/ssl` if running as root). Multiple certificates (for example, a self-signed certificate, and a custom certificate authority certificate) can be copied over to the cache directory and will become automatically avaialable for use by the Habitat client.
+
+The `/hab/cache/ssl` directory is also made available inside a Habitat Studio. So, if you have populated the cache directory before entering the Studio, you will find that its contents are populated with the files from outside the Studio. In addition, when entering the Habitat Studio, the `SSL_CERT_FILE` environment variable will be propagated to the Studio, and the file that it is pointing to will also be copied over to the `/hab/cache/ssl` directory.
+
+Note: The filename `cert.pem` is reserved for Habitat, so please do not use that file name when copying certs into the cache directory.

--- a/www/source/docs/using-builder.html.md.erb
+++ b/www/source/docs/using-builder.html.md.erb
@@ -510,7 +510,7 @@ For a detailed explanation of features, requirements and setup instructions, [se
 
 Many enterprise environments use custom certificates (for example, self-signed). For example, an on-premises Chef Habitat Builder Depot might have a self-signed SSL certificate.
 
-If you attempt to perform an operation using the Habitat client that talks to a service with a custom certificate, you might get an error such as:
+Attempting to perform an operation using the Habitat client to communicate with a service that has a custom certificate can produce an error, such as:
 ```
 ✗✗✗
 ✗✗✗ the handshake failed: The OpenSSL library reported an error: error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed:s3_clnt.c:1269:: unable to get local issuer certificate

--- a/www/source/docs/using-builder.html.md.erb
+++ b/www/source/docs/using-builder.html.md.erb
@@ -523,4 +523,4 @@ The Habitat 0.85.0 release in September 2019 improved the handling of custom cer
 
 The `/hab/cache/ssl` directory is also available inside a Habitat Studio. As long as the certificates are inside the cache directory before you enter the Studio, you'll also find them inside the Studio. In addition, if you've set the `SSL_CERT_FILE` environment variable, you'll also find both it and the file that it points to inside the Studio`/hab/cache/ssl` directory.
 
-Note: The filename `cert.pem` is reserved for Habitat, so please do not use that file name when copying certs into the cache directory.
+Note: The `cert.pem` file name is reserved for Habitat. Do not use `cert.pem` as a file name when copying certs into the cache directory.


### PR DESCRIPTION
Resolves https://github.com/habitat-sh/habitat/issues/6798

This change adds documentation for using the new custom certificate model with hab 0.85.0.

Since the most common usage is to connect to Builder, it is added to the section on working with Builder.

![Screenshot from 2019-09-13 11-17-33](https://user-images.githubusercontent.com/13542112/64885479-22ed1500-d619-11e9-8385-d7570aea6634.png)

Signed-off-by: Salim Alam <salam@chef.io>