### PR TITLE
Add auth option to tar exporter

### DIFF
--- a/components/pkg-export-tar/src/cli.rs
+++ b/components/pkg-export-tar/src/cli.rs
@@ -107,6 +107,13 @@ impl<'a, 'b> Cli<'a, 'b> {
                         "Install base packages from the specified release channel \
                          (default: stable)",
                     ),
+            )
+            .arg(
+                Arg::with_name("BLDR_AUTH_TOKEN")
+                    .long("auth")
+                    .short("z")
+                    .value_name("BLDR_AUTH_TOKEN")
+                    .help("Provide a Builder auth token for private pkg export"),
             );
 
         Cli { app }


### PR DESCRIPTION
Update tar exporter with auth option
Porting over https://github.com/habitat-sh/habitat/pull/5203/files

Signed-off-by: Salim Alam <salam@chef.io>