### PR TITLE
use -file instead of -command when forwarding args to hab-studio.ps1 so that args are passed as individual args and not as a single string

### DIFF
--- a/components/studio/bin/hab-studio.bat
+++ b/components/studio/bin/hab-studio.bat
@@ -1,2 +1,2 @@
 @echo off
-"%~dp0powershell/pwsh.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -Command ". '%~dp0hab-studio.ps1'" %*
+"%~dp0powershell/pwsh.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -File "%~dp0hab-studio.ps1" %*

--- a/components/studio/test/shared/test-all.ps1
+++ b/components/studio/test/shared/test-all.ps1
@@ -10,3 +10,12 @@ foreach($test_case in Get-ChildItem test/shared/studio-internals -Filter "test-s
   Write-Host "--- Running $test_case"
   & ./test/shared/studio-enter.ps1 -studio_command "$studio_command" -test_case "$studio_internals/$test_case"
 }
+
+Write-Host "--- Testing studio run `"write-host 'i said `"hello world`"'"
+$out = & $studio_command run "write-host 'i said """"hello world""""'"
+Write-Host $out
+if($out[-1] -ne "i said `"hello world`"") {
+  Write-Host "Unexpected output from hab studio run"
+  Write-Host "Expected i said `"hello world`""
+  exit 1
+}

--- a/components/studio/test/studio-from-source/test.ps1
+++ b/components/studio/test/studio-from-source/test.ps1
@@ -2,8 +2,6 @@ $ErrorActionPreference = "Stop"
 
 $env:HAB_LICENSE = "accept-no-persist"
 
-$env:studio_command = "bin/hab-studio.ps1"
-
 hab pkg install core/powershell
 hab pkg install core/7zip
 hab pkg install core/hab 
@@ -19,7 +17,7 @@ Copy-Item "$(hab pkg path core/7zip)/bin/*" "bin/7zip"
 Copy-Item "$(hab pkg path core/hab-plan-build-ps1)/bin/*" "bin/"
 
 try {
-    & test/shared/test-all.ps1 -studio_command "bin/hab-studio.ps1"
+    & test/shared/test-all.ps1 -studio_command "bin/hab-studio.bat"
     $exit_code = $LASTEXITCODE
 } finally {
     # The tests can exit before the Studio or Await have closed all open 
@@ -29,6 +27,8 @@ try {
     Remove-Item "bin/7zip" -Recurse
     Remove-Item "bin/powershell" -Recurse
     Remove-Item "bin/hab" -Recurse
-    Remove-Item "bin/*"
+    Remove-Item "bin/environment.ps1"
+    Remove-Item "bin/shared.ps1"
+    Remove-Item "bin/hab-plan-build.ps1"
 }
 exit $exit_code


### PR DESCRIPTION
fixes #6409 

This used the `-File` arg instead of the `-Command` arg to invoke the `hab-studio.ps1` script. This allows all parameters passed to the studio to be passed as individual arguments to the script. The `-Command` argument previously used just runs the provided value as a string. So passing `run "Write-Host 'hi there'"` gets translated to `script.ps1 Write-Host 'hi there'` and therefore `write-host` and `'hi there'` are interpreted as 2 separate parameters instead of the single studio command.

Note that unlike a linux chroot studio, the studio command and its args must all be quoted so that it is interpreted as a single parameter. While this differs from a chroot studio it is the same behavior as a linux docker studio.

Also note that if you want to include quotes in the command, escaping the embedded quotes can get very tricky. More so when calling `hab studio run` in a powershell console than from `cmd.exe`. Honestly I have not found a good explanation as to why this is so weird but I have discovered I am not the only one frustrated. As an example, if I wanted to run `write-host '"i am free like an autumn breeze" said Jenny Starbird'` I would enter:
powershell console:
```
hab studio run "write-host '""""""i am free like an autumn breeze"""""" said Jenny Starbird'"
```

`cmd console:
```
hab studio run "write-host '"""i am free like an autumn breeze""" said Jenny Starbird'"
```

Signed-off-by: mwrock <matt@mattwrock.com>