### PR TITLE
pass supervisor pid to named pipe server instead of querying it from server to fix win7

### DIFF
--- a/components/sup/static/named_pipe_service.ps1
+++ b/components/sup/static/named_pipe_service.ps1
@@ -1,6 +1,7 @@
 param (
     [string]$HookPath,
-    [string]$PipeName
+    [string]$PipeName,
+    [int]$ParentPID
 )
 
 function Restore-Environment($origEnv) {
@@ -20,8 +21,7 @@ Write-Host "Starting PS pipe server for $PipeName with PID $PID"
 Copy-Item $HookPath "${HookPath}.ps1" -Force
 
 # Get a handle for this service's parent (should be the supervisor)
-$parent_pid = (Get-CimInstance -Class Win32_Process -Filter "ProcessID=$PID").ParentProcessId
-$parent = Get-Process -Id $parent_pid
+$parent = Get-Process -Id $ParentPID
 
 try {
     $np = new-object System.IO.Pipes.NamedPipeServerStream($PipeName, [System.IO.Pipes.PipeDirection]::InOut)


### PR DESCRIPTION
This fixes an issue with the named pipe server found in a customer lab running windows 7. It turns out that `Get-CimInstance` which is used to query the parent process from powershell is broken on windows 7/2008R2 unless you install the Windows Management Framework 5.1 or higher.

The fix here is pretty trivial which is just have the parent tell the server what its PID is. I tested this on windows 2008 R2.

Signed-off-by: mwrock <matt@mattwrock.com>