### PR TITLE
HTTP 200 indicates successful response from `hab bldr channel delete`

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -1019,7 +1019,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .delete(&path)
             .bearer_auth(token)
             .send()?
-            .ok_if(&[StatusCode::CREATED])
+            .ok_if(&[StatusCode::OK])
     }
 
     /// Promote all packages in channel


### PR DESCRIPTION
Closes https://github.com/habitat-sh/habitat/issues/7001

Previously the `hab bldr channel delete` operation was requiring a HTTP 201 response to be indicative of success. 

This PR changes the success indicator from HTTP 201 to a 200.

Validation with compiled changes:
```
vagrant@chef-builder:~$ hab bldr channel create --url https://chef-builder.test -o jeremymv2 mychan
Ω Creating channel mychan.
✓ Created channel mychan.
vagrant@chef-builder:~$ hab bldr channel destroy --url https://chef-builder.test -o jeremymv2 mychan
☒ Deleting channel mychan.
✓ Deleted channel mychan.
vagrant@chef-builder:~$
```
Signed-off-by: Jeremy J. Miller <jm@chef.io>