### PR TITLE
add # to correctly comment out redirect stderr in run hook example

### DIFF
--- a/www/source/docs/reference.html.md.erb
+++ b/www/source/docs/reference.html.md.erb
@@ -886,7 +886,7 @@ A run hook can use the following as a template:
 ```bash hooks/run
 #!/bin/sh
 
-redirect stderr
+#redirect stderr
 exec 2>&1
 
 # Set some environment variables


### PR DESCRIPTION
Signed-off-by: ericcalabretta <eric.calabretta@gmail.com>

The hooks/run example doesn't have `redirect stderr` commented out. Users that copy/paste & are not familiar with bash may think that's a needed command rather than a comment to describe the next line `exec 2>&1`

https://www.habitat.sh/docs/reference/#related-article-runtime-settings