### PR TITLE
Order objects used for template data

### DIFF
--- a/components/common/src/templating.rs
+++ b/components/common/src/templating.rs
@@ -5,27 +5,23 @@ pub mod hooks;
 pub mod package;
 pub mod test_helpers;
 
-use std::{fmt,
-          ops::{Deref,
-                DerefMut},
-          result};
-
-use regex::Regex;
-
-use handlebars::{Handlebars,
-                 RenderError,
-                 TemplateFileError};
-use serde::Serialize;
-use serde_json;
-
+pub use self::context::RenderContext;
 use crate::{error::{Error,
                     Result},
             hcore::{fs,
                     package::PackageInstall},
             templating::hooks::{Hook,
                                 InstallHook}};
-
-pub use self::context::RenderContext;
+use handlebars::{Handlebars,
+                 RenderError,
+                 TemplateFileError};
+use regex::Regex;
+use serde::Serialize;
+use serde_json;
+use std::{fmt,
+          ops::{Deref,
+                DerefMut},
+          result};
 
 // This is specifically for finding syntax violations to object access in handlebars templates.
 // This should eventually be removed when we have upgraded the handlebars library and provided

--- a/components/common/src/templating/context.rs
+++ b/components/common/src/templating/context.rs
@@ -33,19 +33,17 @@
 //! their focused and single-use purpose; they shouldn't be used for
 //! anything else, and so, they _can't_ be used for anything else.
 
-use std::{borrow::Cow,
-          collections::HashMap,
-          path::PathBuf,
-          result};
-
-use serde::{ser::SerializeMap,
-            Serialize,
-            Serializer};
-
 use super::{config::Cfg,
             package::{Env,
                       Pkg}};
 use crate::hcore::package::PackageIdent;
+use serde::{ser::SerializeMap,
+            Serialize,
+            Serializer};
+use std::{borrow::Cow,
+          collections::BTreeMap,
+          path::PathBuf,
+          result};
 
 /// The context of a rendering call, exposing information on the
 /// currently-running Supervisor and service, its service group, and
@@ -99,7 +97,7 @@ struct Package<'a> {
     env:     Cow<'a, Env>,
     // TODO (CM): Ideally, this would be Vec<u16>, since they're ports.
     exposes: Cow<'a, Vec<String>>,
-    exports: Cow<'a, HashMap<String, String>>,
+    exports: Cow<'a, BTreeMap<String, String>>,
     // TODO (CM): Maybe Path instead of Cow<'a PathBuf>?
     path:                    Cow<'a, PathBuf>,
     svc_path:                Cow<'a, PathBuf>,
@@ -279,11 +277,11 @@ two = 2
                         PackageIdent::new("test", "pkg2", Some("2.0.0"), Some("20180321150416")),
                         PackageIdent::new("test", "pkg3", Some("3.0.0"), Some("20180321150416")),];
 
-        let mut env_hash = HashMap::new();
+        let mut env_hash = BTreeMap::new();
         env_hash.insert("PATH".into(), "/foo:/bar:/baz".into());
         env_hash.insert("SECRET".into(), "sooperseekrit".into());
 
-        let mut export_hash = HashMap::new();
+        let mut export_hash = BTreeMap::new();
         export_hash.insert("blah".into(), "stuff.thing".into());
         export_hash.insert("port".into(), "test_port".into());
 

--- a/components/common/src/templating/helpers.rs
+++ b/components/common/src/templating/helpers.rs
@@ -9,10 +9,6 @@ mod to_toml;
 mod to_uppercase;
 mod to_yaml;
 
-use serde::Serialize;
-use serde_json::{self,
-                 Value as Json};
-
 pub use self::{each_alive::EACH_ALIVE,
                pkg_path_for::PKG_PATH_FOR,
                str_concat::STR_CONCAT,
@@ -23,6 +19,9 @@ pub use self::{each_alive::EACH_ALIVE,
                to_toml::TO_TOML,
                to_uppercase::TO_UPPERCASE,
                to_yaml::TO_YAML};
+use serde::Serialize;
+use serde_json::{self,
+                 Value as Json};
 
 // Taken from `handlebars::context::JsonTruthy`. The trait is marked public but it's in a private
 // module. It's super useful so let's pull it into here.

--- a/components/common/src/templating/helpers/each_alive.rs
+++ b/components/common/src/templating/helpers/each_alive.rs
@@ -1,5 +1,6 @@
-use std::collections::BTreeMap;
-
+use super::{super::RenderResult,
+            to_json,
+            JsonTruthy};
 use handlebars::{Handlebars,
                  Helper,
                  HelperDef,
@@ -7,10 +8,7 @@ use handlebars::{Handlebars,
                  RenderError,
                  Renderable};
 use serde_json::Value as Json;
-
-use super::{super::RenderResult,
-            to_json,
-            JsonTruthy};
+use std::collections::BTreeMap;
 
 #[derive(Clone, Copy)]
 pub struct EachAliveHelper;

--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -216,7 +216,7 @@ pub trait Hook: fmt::Debug + Sized + Send {
         let args = vec!["-NonInteractive", "-command", ps_cmd.as_str()];
         Ok(Child::spawn("pwsh.exe",
                         &args,
-                        &pkg.env,
+                        &pkg.env.to_hash_map(),
                         &pkg.svc_user,
                         svc_encrypted_password)?)
     }

--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -480,7 +480,7 @@ impl<'a> HookOutput<'a> {
         }
     }
 
-    /// Try to write a stream to stdout and to `path`  
+    /// Try to write a stream to stdout and to `path`
     fn tee_standard_stream(preamble_str: &str, reader: impl Read, path: &Path) {
         let mut file_result = File::create(path);
         if let Err(e) = &file_result {

--- a/components/common/src/templating/package.rs
+++ b/components/common/src/templating/package.rs
@@ -11,8 +11,10 @@ use crate::{error::{Error,
 use serde::{ser::SerializeStruct,
             Serialize,
             Serializer};
-use std::{collections::BTreeMap,
+use std::{collections::{BTreeMap,
+                        HashMap},
           env,
+          iter::FromIterator,
           ops::Deref,
           path::PathBuf,
           result};
@@ -47,6 +49,10 @@ impl Env {
         let path = Self::transform_path(env.get(PATH_KEY))?;
         env.insert(PATH_KEY.to_string(), path);
         Ok(Env(env))
+    }
+
+    pub fn to_hash_map(&self) -> HashMap<String, String> {
+        HashMap::from_iter(self.0.clone().into_iter())
     }
 
     fn transform_path(path: Option<&String>) -> Result<String> {

--- a/components/common/src/templating/package.rs
+++ b/components/common/src/templating/package.rs
@@ -1,23 +1,21 @@
-use std::{collections::HashMap,
+use crate::{error::{Error,
+                    Result},
+            hcore::{fs,
+                    os::{process::{ShutdownSignal,
+                                   ShutdownTimeout},
+                         users},
+                    package::{PackageIdent,
+                              PackageInstall},
+                    util::serde_string},
+            util::path};
+use serde::{ser::SerializeStruct,
+            Serialize,
+            Serializer};
+use std::{collections::BTreeMap,
           env,
           ops::Deref,
           path::PathBuf,
           result};
-
-use crate::hcore::{fs,
-                   os::{process::{ShutdownSignal,
-                                  ShutdownTimeout},
-                        users},
-                   package::{PackageIdent,
-                             PackageInstall},
-                   util::serde_string};
-use serde::{ser::SerializeStruct,
-            Serialize,
-            Serializer};
-
-use crate::{error::{Error,
-                    Result},
-            util::path};
 
 const DEFAULT_USER: &str = "hab";
 const DEFAULT_GROUP: &str = "hab";
@@ -25,16 +23,16 @@ const DEFAULT_GROUP: &str = "hab";
 const PATH_KEY: &str = "PATH";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Env(HashMap<String, String>);
+pub struct Env(BTreeMap<String, String>);
 
 impl Deref for Env {
-    type Target = HashMap<String, String>;
+    type Target = BTreeMap<String, String>;
 
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
-impl From<HashMap<String, String>> for Env {
-    fn from(inner_map: HashMap<String, String>) -> Self { Env(inner_map) }
+impl From<BTreeMap<String, String>> for Env {
+    fn from(inner_map: BTreeMap<String, String>) -> Self { Env(inner_map) }
 }
 
 impl Env {
@@ -72,7 +70,7 @@ pub struct Pkg {
     pub deps: Vec<PackageIdent>,
     pub env: Env,
     pub exposes: Vec<String>,
-    pub exports: HashMap<String, String>,
+    pub exports: BTreeMap<String, String>,
     pub path: PathBuf,
     pub svc_path: PathBuf,
     pub svc_config_path: PathBuf,

--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -1358,7 +1358,7 @@ core/bar=pub:core/publish sub:core/subscribe
                        "PSModulePath=/should/not/be/ignored;c:/my/dir;/should/really/not/be/\
                         ignored\n");
 
-        let mut expected = HashMap::new();
+        let mut expected = BTreeMap::new();
         let fs_root_path = fs_root.into_path();
         expected.insert("FOO".to_string(), "bar".to_string());
         expected.insert("JAVA_HOME".to_string(), "/my/java/home".to_string());

--- a/components/core/src/package/metadata.rs
+++ b/components/core/src/package/metadata.rs
@@ -3,7 +3,7 @@ use crate::{error::{Error,
             package::PackageIdent};
 use serde_derive::Serialize;
 use std::{self,
-          collections::HashMap,
+          collections::BTreeMap,
           env,
           fmt,
           fs::File,
@@ -22,12 +22,12 @@ const ENV_PATH_SEPARATOR: char = ':';
 #[cfg(windows)]
 const ENV_PATH_SEPARATOR: char = ';';
 
-pub fn parse_key_value(s: &str) -> Result<HashMap<String, String>> {
-    Ok(HashMap::from_iter(s.lines()
-                           .map(|l| l.splitn(2, '=').collect::<Vec<_>>())
-                           .map(|kv| {
-                               (kv[0].to_string(), kv[1].to_string())
-                           })))
+pub fn parse_key_value(s: &str) -> Result<BTreeMap<String, String>> {
+    Ok(BTreeMap::from_iter(s.lines()
+                            .map(|l| l.splitn(2, '=').collect::<Vec<_>>())
+                            .map(|kv| {
+                                (kv[0].to_string(), kv[1].to_string())
+                            })))
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -100,7 +100,7 @@ pub struct PkgEnv {
 }
 
 impl PkgEnv {
-    pub fn new(values: HashMap<String, String>, separators: &HashMap<String, String>) -> Self {
+    pub fn new(values: BTreeMap<String, String>, separators: &BTreeMap<String, String>) -> Self {
         Self { inner: values.into_iter()
                             .map(|(key, value)| {
                                 if let Some(sep) = separators.get(&key) {
@@ -295,7 +295,7 @@ port=front-end.port
 
     #[test]
     fn can_parse_environment_file() {
-        let mut m: HashMap<String, String> = HashMap::new();
+        let mut m: BTreeMap<String, String> = BTreeMap::new();
         m.insert("PATH".to_string(),
                  "/hab/pkgs/python/setuptools/35.0.1/20170424072606/bin".to_string());
         m.insert(
@@ -309,7 +309,7 @@ port=front-end.port
 
     #[test]
     fn can_parse_environment_sep_file() {
-        let mut m: HashMap<String, String> = HashMap::new();
+        let mut m: BTreeMap<String, String> = BTreeMap::new();
         m.insert("PATH".to_string(), ":".to_string());
         m.insert("PYTHONPATH".to_string(), ":".to_string());
 
@@ -318,7 +318,7 @@ port=front-end.port
 
     #[test]
     fn can_parse_exports_file() {
-        let mut m: HashMap<String, String> = HashMap::new();
+        let mut m: BTreeMap<String, String> = BTreeMap::new();
         m.insert("status-port".to_string(), "status.port".to_string());
         m.insert("port".to_string(), "front-end.port".to_string());
 
@@ -350,7 +350,7 @@ port=front-end.port
 
     #[test]
     fn build_pkg_env_is_empty() {
-        let result = PkgEnv::new(HashMap::new(), &HashMap::new());
+        let result = PkgEnv::new(BTreeMap::new(), &BTreeMap::new());
         assert!(result.is_empty());
     }
 

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -101,7 +101,7 @@ impl Binlink {
     }
 
     #[cfg(windows)]
-    fn stub_template(&self, env: HashMap<String, String>) -> Result<String> {
+    fn stub_template(&self, env: BTreeMap<String, String>) -> Result<String> {
         let mut exports = String::new();
         for (key, mut value) in env.into_iter() {
             if key == "PATH" {

--- a/components/hab/src/command/pkg/env.rs
+++ b/components/hab/src/command/pkg/env.rs
@@ -1,10 +1,8 @@
-use std::{collections::HashMap,
+use crate::{error::Result,
+            hcore::package::{PackageIdent,
+                             PackageInstall}};
+use std::{collections::BTreeMap,
           path::Path};
-
-use crate::hcore::package::{PackageIdent,
-                            PackageInstall};
-
-use crate::error::Result;
 
 pub fn start(ident: &PackageIdent, fs_root_path: &Path) -> Result<()> {
     let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;
@@ -14,14 +12,14 @@ pub fn start(ident: &PackageIdent, fs_root_path: &Path) -> Result<()> {
 }
 
 #[cfg(unix)]
-fn render_environment(env: HashMap<String, String>) {
+fn render_environment(env: BTreeMap<String, String>) {
     for (key, value) in env.into_iter() {
         println!("export {}=\"{}\"", key, value);
     }
 }
 
 #[cfg(windows)]
-fn render_environment(env: HashMap<String, String>) {
+fn render_environment(env: BTreeMap<String, String>) {
     for (key, value) in env.into_iter() {
         println!("$env:{}=\"{}\"", key, value);
     }

--- a/components/launcher-client/src/client.rs
+++ b/components/launcher-client/src/client.rs
@@ -7,11 +7,11 @@ use habitat_launcher_protocol::{self as protocol,
 use ipc_channel::ipc::{IpcOneShotServer,
                        IpcReceiver,
                        IpcSender};
-use std::{collections::HashMap,
+use std::{collections::BTreeMap,
           io,
           path::Path};
 
-type Env = HashMap<String, String>;
+type Env = BTreeMap<String, String>;
 type IpcServer = IpcOneShotServer<Vec<u8>>;
 
 pub struct LauncherCli {

--- a/components/launcher-protocol/src/types.rs
+++ b/components/launcher-protocol/src/types.rs
@@ -2,8 +2,10 @@ use crate::{error::{Error,
                     Result},
             generated};
 use prost::Message;
-use std::{collections::HashMap,
-          fmt};
+use std::{collections::{BTreeMap,
+                        HashMap},
+          fmt,
+          iter::FromIterator};
 
 pub trait LauncherMessage
     where Self: Clone + fmt::Debug
@@ -129,7 +131,7 @@ pub struct Spawn {
     pub svc_user:     Option<String>,
     pub svc_group:    Option<String>,
     pub svc_password: Option<String>,
-    pub env:          HashMap<String, String>,
+    pub env:          BTreeMap<String, String>,
     pub svc_user_id:  Option<u32>,
     pub svc_group_id: Option<u32>,
 }
@@ -145,7 +147,7 @@ impl LauncherMessage for Spawn {
                    svc_user:     proto.svc_user,
                    svc_group:    proto.svc_group,
                    svc_password: proto.svc_password,
-                   env:          proto.env,
+                   env:          BTreeMap::from_iter(proto.env.into_iter()),
                    svc_user_id:  proto.svc_user_id,
                    svc_group_id: proto.svc_group_id, })
     }
@@ -158,7 +160,7 @@ impl From<Spawn> for generated::Spawn {
                            svc_user:     value.svc_user,
                            svc_group:    value.svc_group,
                            svc_password: value.svc_password,
-                           env:          value.env,
+                           env:          HashMap::from_iter(value.env.into_iter()),
                            svc_user_id:  value.svc_user_id,
                            svc_group_id: value.svc_group_id, }
     }

--- a/components/sup/src/manager/service/context.rs
+++ b/components/sup/src/manager/service/context.rs
@@ -799,6 +799,42 @@ two = 2
     }
 
     #[test]
+    fn binds_are_output_in_consistent_order() {
+        let mut render_context = default_render_context();
+        let mut new_binds = BTreeMap::new();
+
+        new_binds.insert("foo".to_string(),
+                         BindGroup { leader:  None,
+                                     first:   None,
+                                     members: vec![], });
+        new_binds.insert("bar".to_string(),
+                         BindGroup { leader:  None,
+                                     first:   None,
+                                     members: vec![], });
+        new_binds.insert("quux".to_string(),
+                         BindGroup { leader:  None,
+                                     first:   None,
+                                     members: vec![], });
+        new_binds.insert("baz".to_string(),
+                         BindGroup { leader:  None,
+                                     first:   None,
+                                     members: vec![], });
+
+        render_context.bind = Binds(new_binds);
+
+        let j = serde_json::to_string(&render_context).expect("can't serialize to JSON");
+        assert_valid(&j, "render_context_schema.json");
+
+        // The point here is to just render our context to a string repeatedly and compare it to
+        // our original rendered string. Our goal was to have consistent ordering of binds on every
+        // render and this should be sufficient to tell us if that's the case.
+        for _ in 0..50 {
+            let x = serde_json::to_string(&render_context).expect("can't serialize to JSON");
+            assert_eq!(j, x);
+        }
+    }
+
+    #[test]
     fn no_leader_renders_correctly() {
         let ctx = default_render_context();
 
@@ -818,7 +854,7 @@ two = 2
 
         // Let's create a new leader, with a custom member_id
         let mut svc_member = default_svc_member();
-        svc_member.member_id = Cow::Owned("deadbeefdeadbeefdeadbeefdeadbeef".into());
+        svc_member.member_id = Cow::Owned("samshamandthepharaohs".into());
 
         // Set up our own bind with a leader
         let mut bind_map = BTreeMap::new();
@@ -834,7 +870,7 @@ two = 2
                              LEADER{{/if}}",
                             &ctx);
 
-        assert_eq!(output, "deadbeefdeadbeefdeadbeefdeadbeef");
+        assert_eq!(output, "samshamandthepharaohs");
     }
 
     // Technically, `bind.<SERVICE>.first` could be None, according to

--- a/components/sup/src/manager/service/pipe_hook_client.rs
+++ b/components/sup/src/manager/service/pipe_hook_client.rs
@@ -161,7 +161,7 @@ impl PipeHookClient {
         let args = vec!["-NonInteractive", "-Command", ps_cmd.as_str()];
         let child = Child::spawn("pwsh.exe",
                                  &args,
-                                 &pkg.env,
+                                 &pkg.env.to_hash_map(),
                                  &pkg.svc_user,
                                  svc_encrypted_password)?;
         debug!("spawned powershell server for {} {} hook on pipe: {}",

--- a/components/sup/src/test_helpers.rs
+++ b/components/sup/src/test_helpers.rs
@@ -1,9 +1,8 @@
+use crate::json;
+use serde_json;
 use std::{fs::File,
           io::Read,
           path::PathBuf};
-
-use crate::json;
-use serde_json;
 use valico::json_schema;
 
 /// Asserts that `json_string` is valid according to the specified JSON schema.


### PR DESCRIPTION
Previously, we used `HashMap` to hold key/value pairs for template data.  Unfortunately, `HashMap` iterates over its data in a non-deterministic order.  This can cause problems when the checksum of the rendered file has changed, because the supervisor will reload the service.

We now use `BTreeMap` to hold these key/value pairs.  It has a compatible API with `HashMap` and it iterates over its data in sorted order, which should fix this issue.

![](https://media.giphy.com/media/3o85xpnljIRrnsVsly/giphy.gif)

Fixes https://github.com/habitat-sh/habitat/issues/6713