### PR TITLE
Add additionl e2e tests validating SSL cert functionality

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -266,7 +266,75 @@ steps:
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
             - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
-
+  
+  - label: "[:linux: test_fresh_install_can_communicate_with_builder]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_fresh_install_can_communicate_with_builder.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+            - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
+  
+  - label: "[:linux: test_invalid_cached_certificates_are_ignored_by_hab]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_invalid_cached_certificates_are_ignored_by_hab.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+            - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
+  
+  - label: "[:linux: test_studio_can_build_packages]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_studio_can_build_packages.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+  
+  - label: "[:linux: test_custom_ssl_cert_is_available_in_studio]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_custom_ssl_cert_is_available_in_studio.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+  
+  - label: "[:linux: test_studio_hab_is_expected_version]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_studio_hab_is_expected_version.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+  
+  - label: "[:linux: test_self_signed_cert_is_loaded_by_hab]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_self_signed_cert_is_loaded_by_hab.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+  
   - label: "[:windows: test_windows_service_stops_on_launcher_termination]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_windows_service_stops_on_launcher_termination

--- a/.expeditor/scripts/end_to_end/shared_end_to_end.sh
+++ b/.expeditor/scripts/end_to_end/shared_end_to_end.sh
@@ -14,3 +14,4 @@ studio_run() {
 
   hab studio run "$studio_flags" "$@"
 }
+

--- a/test/end-to-end/studio-driver.exp
+++ b/test/end-to-end/studio-driver.exp
@@ -1,0 +1,38 @@
+#!/usr/bin/env expect
+
+set env(HAB_NOCOLORING) true
+set studio_test [lindex $argv 0]
+# Print out some helpful tracing messages in the test output.
+
+proc log {message} {
+    puts "LOG >>> $message"
+}
+
+# Cleanup after the test
+exit -onexit {
+    exec $studio_command rm
+}
+
+# Installing packages can take time
+set timeout 60
+
+spawn hab studio enter
+expect {
+  {\[default:/src:0]#} { 
+    log "Studio entered successfully"
+  }
+  eof {
+    error "Unable to enter studio"
+  }
+  timeout {
+    error "Timeout entering studio"
+  } 
+}
+
+send "$studio_test\n"
+send "exit\n"
+expect eof
+catch wait result
+exit [lindex $result 3]
+
+

--- a/test/end-to-end/test_custom_ssl_cert_is_available_in_studio.sh
+++ b/test/end-to-end/test_custom_ssl_cert_is_available_in_studio.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Test that an ssl certificate placed in the the users hab/cached/ssl directory
+# is persisted into the studio, and that we can communicate with Builder
+
+set -euo pipefail
+
+source .expeditor/scripts/end_to_end/shared_end_to_end.sh
+
+echo "--- Generating a signing key"
+hab origin key generate "$HAB_ORIGIN"
+
+echo "--- Generating self-signed ssl certificate"
+tempdir="$(mktemp --tmpdir --directory e2e-ssl-XXXXXX)"
+e2e_certname="custom-ssl-cert.pem"
+openssl req -newkey rsa:2048 -batch -nodes -keyout "${tempdir}/key.pem" -x509 -days 365 -out "${tempdir}/${e2e_certname}"
+
+# This test is assumed to run as root
+mkdir -p /hab/cache/ssl
+cp "${tempdir}/${e2e_certname}" /hab/cache/ssl/
+
+echo "--- Certificate is present in studio ssl cache" 
+studio_run test -f "/hab/cache/ssl/${e2e_certname}"
+

--- a/test/end-to-end/test_fresh_install_can_communicate_with_builder.sh
+++ b/test/end-to-end/test_fresh_install_can_communicate_with_builder.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Given a fresh install of Habitat we should be able to install packages from builder
+# Ensure that we don't have any ssl certificates cached that might influence our ability
+# to connect. 
+# Note: since we're testing pre-release this won't be a "pure" fresh install, as we 
+# have to curlbash install stable first, in order to get the pre-release version. 
+
+set -euo pipefail
+
+echo "--- Inspecting ssl cache directories"
+# The assumption here is that the directory is not created on a fresh install until 
+# a certificate needs to be cached. If something in the provided images or setup_environment 
+# break that assumption this test could start failing. 
+test ! -d /hab/cache/ssl
+
+# This test is expected to run in a container, so will be executed as root.  
+# Hab will always use /hab/cache/ssl when run as root, but in development scenarios
+# hab will be run as a normal user. Run the test as the `hab` user, provided by
+# setup_environment.sh
+su hab -c "test ! -d ~/.hab/cache/ssl"
+
+echo "--- Installing package from builder" 
+hab pkg install core/redis --channel stable 

--- a/test/end-to-end/test_invalid_cached_certificates_are_ignored_by_hab.sh
+++ b/test/end-to-end/test_invalid_cached_certificates_are_ignored_by_hab.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Test that when an invalid certificate is placed in the cache directory 
+# `hab` ignores that certificate. Since we don't have a way to verify a cert
+# is ignored aside from inspecting debug output, we test that we can still
+# install a package even when a bad cert is cached.
+
+set -euo pipefail
+
+source .expeditor/scripts/end_to_end/shared_end_to_end.sh
+
+echo "--- Generating a signing key"
+hab origin key generate "$HAB_ORIGIN"
+
+echo "--- Generating self-signed ssl certificate"
+e2e_certname="invalid-ssl-cert.pem"
+mkdir -p /hab/cache/ssl
+echo "I AM NOT A CERTIFICATE" > "/hab/cache/ssl/${e2e_certname}"
+
+echo "--- Test Builder communications with invalid cert"
+# Specify the stable channel, since our environment is using DEV to 
+# install `hab` packages.
+hab pkg install core/redis --channel stable

--- a/test/end-to-end/test_self_signed_cert_is_loaded_by_hab.sh
+++ b/test/end-to-end/test_self_signed_cert_is_loaded_by_hab.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This tests that a self-signed certificate in the cache is loaded 
+# by hab. We don't have a way to inspect loaded certificates at this
+# time, so we rely on inspecting debug output which is less than ideal.
+# As we improve our pipeline, this test could be replaced by attemting 
+# to talk to a builder service with a self-signed cert.
+ 
+echo "--- Generating self-signed ssl certificate"
+mkdir -p /hab/cache/ssl
+e2e_cert="/hab/cache/ssl/e2e-ssl.pem"
+openssl req -newkey rsa:2048 -batch -nodes -keyout key.pem -x509 -days 365 -out "${e2e_cert}"
+
+echo "--- Inspecting debug output for loaded certificate"
+env RUST_LOG=debug hab pkg search core/redis 2>&1 | grep "Processing cert file: ${e2e_cert}"

--- a/test/end-to-end/test_studio_can_build_packages.sh
+++ b/test/end-to-end/test_studio_can_build_packages.sh
@@ -1,0 +1,16 @@
+#!/bin/bash 
+
+# `build` is a built-in helper function that maps to `hab pkg exec core/hab-plan-build` 
+# rather than `hab pkg build` to avoid 'studio-in-studio' situations. Verify that the 
+# command functions. We assume that if the build succeeds (exits 0) we've passed this 
+# test, and leave more detailed testing to the build output to e2e tests for hab-plan-build
+
+set -euo pipefail 
+
+source .expeditor/scripts/end_to_end/shared_end_to_end.sh
+
+echo "--- Generating a signing key"
+hab origin key generate "$HAB_ORIGIN"
+
+echo "--- Test 'build' command is functional in the studio"
+studio_run build test/fixtures/minimal-package

--- a/test/end-to-end/test_studio_hab_is_expected_version.sh
+++ b/test/end-to-end/test_studio_hab_is_expected_version.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This tests that the version of hab that we are releaseing is the same 
+# version embedded in the studio package. Since the studio is built 
+# with the previous version of `hab` this is useful to verify that the
+# correct version was copied.
+ 
+echo "--- Generating signing key for $HAB_ORIGIN"
+hab origin key generate "$HAB_ORIGIN" 
+
+echo "--- Checking hab version in the studio"
+expected_version=$(hab --version)
+
+# This needs to be escaped like this so that all of the evaluation
+# happens on the inside of the studio and it remainds correctly quoted
+hab studio run test \"\$\(hab --version\)\" == \""$expected_version"\"
+

--- a/test/end-to-end/test_studio_internals.sh
+++ b/test/end-to-end/test_studio_internals.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This is a shim for testing behavior that requires `hab studio enter`.
+# It takes a single argument which is the test to run on the inside of 
+# the studio, and passes that to the expect studio-driver script.
+
+
+set -euo pipefail 
+
+studio_test="${1}"
+
+hab pkg install core/expect
+hab pkg binlink core/expect expect --force
+
+echo "--- Generating signing key for $HAB_ORIGIN"
+hab origin key generate "$HAB_ORIGIN" 
+
+echo "--- Using hab-studio $(hab studio version)"
+
+echo "--- $studio_test"
+expect test/end-to-end/studio-driver.exp "$studio_test"

--- a/test/fixtures/minimal-package/plan.sh
+++ b/test/fixtures/minimal-package/plan.sh
@@ -1,0 +1,7 @@
+pkg_name="minimal_package"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+
+do_build() { :; }
+do_install() { :; }


### PR DESCRIPTION
Additionally, some studio behavior is tested in this PR.

This adds tests to validate the following scenarios:
- A fresh install of the hab cli can interact with Builder and install packages
- An invalid certificate that has been cached is ignored by the hab cli 
- A custom certificate that has been cached manually is available in the studio
- A self-signed certificate is loaded by the hab cli
- An interactive studio can build packages with the `build` helper
- The version of the hab cli embedded in the studio package is the correct version

This finishes the Linux portion of #6800 
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>