### PR TITLE
Add Windows studios e2e tests to verify SSL_CERT_FILE behavior

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -205,7 +205,18 @@ steps:
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
             - HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
-
+  
+  - label: "[:windows: test_studio_with_ssl_cert_file_envvar_set]"
+    command:
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 DEV test_studio_with_ssl_cert_file_envvar_set
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          environment:
+            - BUILD_PKG_TARGET=x86_64-windows
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+ 
   - label: "[:linux: :docker: test_studio_with_ssl_cert_file_envvar_set]"
     command:
       - .expeditor/scripts/end_to_end/setup_environment.sh DEV

--- a/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
+++ b/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Test that SSL_CERT_FILE is persisted into the studio and 
+# set to the correct internal path. 
+$ErrorActionPreference="stop" 
+
+$studio_flags = ""
+if( $env:DOCKER_STUDIO_TEST -eq $true) {
+    studio_flags = "-D"
+}
+
+function Cleanup-CachedCertificate {
+  $hab_ssl_cache="$env:SYSTEM_DRIVE\hab\cache\ssl"
+  Remove-Item -Force "$hab_ssl_cache\*" -ErrorAction SilentlyContinue
+}
+
+function New-TemporaryDirectory {
+  $parent = [System.IO.Path]::GetTempPath()
+  [string] $name = [System.Guid]::NewGuid()
+  New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+Write-Host "--- Generating a signing key"
+hab origin key generate "$env:HAB_ORIGIN"
+
+Write-Host "--- Generating self-signed ssl certificate"
+
+$tempdir = New-TemporaryDirectory
+$e2e_certname = "e2e-ssl.pem"
+hab pkg install core/openssl 
+hab pkg exec core/openssl openssl req -newkey rsa:2048 -batch -nodes -keyout key.pem -x509 -days 365 -out (Join-Path $tempdir $e2e_certname)
+
+Write-Host "--- Testing valid SSL_CERT_FILE in the studio"
+
+Context "SSL_CERT_FILE is passed into the studio" {
+    BeforeEach { 
+        $result = hab studio rm
+        Cleanup-CachedCertificate
+    }
+
+    Describe "SSL_CERT_FILE is a valid certificate" {
+        $env:SSL_CERT_FILE = (Join-Path $tempdir $e2e_certname)
+        It "Sets env:SSL_CERT_FILE in the studio"  {
+            $expected = "\hab\cache\ssl\$e2e_certname"
+            $result = hab studio run '(Get-ChildItem env:SSL_CERT_FILE).Value'
+            $result[-1] | Should -BeLike "*$expected"
+        }
+
+        It "Copies the certificate described by SSL_CERT_FILE into the studio" {
+            $result = hab studio run 'Write-Host $env:SSL_CERT_FILE'
+            $result
+            $result = hab studio run '(Test-Path $env:SSL_CERT_FILE).ToString()'
+            $result[-1] | Should -Be "True"
+        }
+
+        It "Can search builder for packages when SSL_CERT_FILE is set" {
+            $result = hab studio run "hab pkg search core/nginx"
+            $result | Should -Contain "core/nginx"
+        }
+    }
+
+    Describe "SSL_CERT_FILE is an invalid certificate" {
+        $env:SSL_CERT_FILE = (Join-Path $tempdir "invalid_certificate")
+        Set-Content -Path $env:SSL_CERT_FILE -Value "I am not a certificate"
+
+        It "Can still search packages on builder" {
+            $result = hab studio run "hab pkg search core/nginx"
+            $result | Should -Contain "core/nginx"
+        }
+    }
+
+    Describe "SSL_CERT_FILE is a directory" {
+        $env:SSL_CERT_FILE = (Join-Path $tempdir "cert-as-directory")
+        New-Item -ItemType Directory -Force -Path $env:SSL_CERT_FILE
+
+        It "Should not copy the directory into the studio" {
+            $result = hab studio run '(Test-Path $env:SSL_CERT_FILE).ToString()'
+            $result[-1] | Should -Be "False"
+        }
+
+        It "Can still search packages on builder" {
+            $result = hab studio run "hab pkg search core/nginx"
+            $result | Should -Contain "core/nginx"
+        }
+    }
+
+    Describe "SSL_CERT_FILE is a non-existant-file" {
+        $env:SSL_CERT_FILE = (Join-Path $tempdir "non-existant-file")
+        if (Test-Path $env:SSL_CERT_FILE) {
+            Remove-Item -Path $env:SSL_CERT_FILE -Force
+        }
+
+        It "Should not copy the file into the studio" {
+            $result = hab studio run '(Test-Path $env:SSL_CERT_FILE).ToString()'
+            $result[-1] | Should -Be "False"
+        }
+
+        It "Can still search packages on builder" {
+            $result = hab studio run "hab pkg search core/nginx"
+            $result | Should -Contain "core/nginx"
+        }
+    }
+}


### PR DESCRIPTION
This is the windows studio equivalent of #6944 and address a portion of #6800.  There will be a follow-on PR to this that will be the windows equivalent of #7038 

This pulls in commits from #7027 and will need to be rebased once that PR is merged

- [x] windows studio: valid SSL_CERT_FILE
- [x] windows studio: invalid SSL_CERT_FILE
- [x] windows studio: SSL_CERT_FILE is a directory
- [x] windows studio: SSL_CERT_FILE points to non-existent file

### Running the tests: 
./e2e_local.ps1 test_studio_with_ssl_cert_file_envvar_set