### PR TITLE
fixes using a svc_user on windows

### DIFF
--- a/.buildkite/release_pipeline.yaml
+++ b/.buildkite/release_pipeline.yaml
@@ -271,6 +271,7 @@ steps:
           environment:
             - HAB_BLDR_CHANNEL
             - HAB_AUTH_TOKEN
+            - HAB_CRYPTO_KEY
             - HAB_LICENSE
             - BUILDKITE_JOB_ID
             - BUILDKITE_AGENT_ACCESS_TOKEN

--- a/components/sup/src/manager/service/spec.rs
+++ b/components/sup/src/manager/service/spec.rs
@@ -107,8 +107,16 @@ pub struct ServiceSpec {
     #[serde(with = "serde_string")]
     pub desired_state: DesiredState,
     pub shutdown_timeout: Option<ShutdownTimeout>,
-    pub health_check_interval: HealthCheckInterval,
     pub svc_encrypted_password: Option<String>,
+    // it is important that the health check interval
+    // is the last field to be serialized because it
+    // is serialized as a table. Individual values
+    // serialized after the health check interval will
+    // break the parser.
+    // Note that there is an issue to ultimately fix this:
+    // https://github.com/habitat-sh/habitat/issues/6469
+    // and eliminate the need to keep this field last.
+    pub health_check_interval: HealthCheckInterval,
 }
 
 impl ServiceSpec {


### PR DESCRIPTION
fixes #6834 

This addresses two key bugs around using a `svc_user` on windows.

* Fixes the serialization of a spec to toml by moving the health check interval to the last field.
* Ignores `svc_user` in the install hook and runs as the current user instead. This is because the install hook does not have access to the svc_user password.

Note there is an end to end test for this included in #7027