### PR TITLE
core: use synchronous signal handling on unix

### DIFF
--- a/components/core/src/os/signals.rs
+++ b/components/core/src/os/signals.rs
@@ -10,9 +10,9 @@ use std::sync::atomic::{AtomicBool,
 mod unix;
 
 #[cfg(unix)]
-pub use self::unix::{pending_sigchld,
-                     pending_sighup,
-                     init};
+pub use self::unix::{init,
+                     pending_sigchld,
+                     pending_sighup};
 
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 

--- a/components/core/src/os/signals.rs
+++ b/components/core/src/os/signals.rs
@@ -10,9 +10,9 @@ use std::sync::atomic::{AtomicBool,
 mod unix;
 
 #[cfg(unix)]
-pub use self::unix::{check_for_signal,
-                     init,
-                     SignalEvent};
+pub use self::unix::{pending_sigchld,
+                     pending_sighup,
+                     init};
 
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
@@ -28,4 +28,4 @@ pub fn init() {
 }
 
 /// Returns `true` if we have received a signal to shut down.
-pub fn check_for_shutdown() -> bool { SHUTDOWN.compare_and_swap(true, false, Ordering::SeqCst) }
+pub fn pending_shutdown() -> bool { SHUTDOWN.compare_and_swap(true, false, Ordering::SeqCst) }

--- a/components/core/src/os/signals/unix.rs
+++ b/components/core/src/os/signals/unix.rs
@@ -3,9 +3,13 @@
 use crate::os::process::{Signal,
                          SignalCode};
 use std::{collections::VecDeque,
+          mem,
+          ptr,
+          io,
           sync::{atomic::Ordering,
                  Mutex,
-                 Once}};
+                 Once},
+          thread};
 
 static INIT: Once = Once::new();
 
@@ -13,26 +17,12 @@ lazy_static::lazy_static! {
     static ref CAUGHT_SIGNALS: Mutex<VecDeque<SignalCode>> = Mutex::new(VecDeque::new());
 }
 
-// Functions from POSIX libc.
-extern "C" {
-    fn signal(sig: SignalCode,
-              cb: unsafe extern "C" fn(SignalCode))
-              -> unsafe extern "C" fn(SignalCode);
-}
-
-unsafe extern "C" fn handle_signal(signal: SignalCode) {
-    CAUGHT_SIGNALS.lock()
-                  .expect("Signal mutex poisoned")
-                  .push_back(signal);
-}
-
-unsafe extern "C" fn handle_shutdown_signal(_signal: SignalCode) {
-    super::SHUTDOWN.store(true, Ordering::SeqCst);
-}
-
 pub fn init() {
     INIT.call_once(|| {
-            self::set_signal_handlers();
+            // TODO(ssd) 2019-10-16: We could bubble this error up
+            // further if we want, but in either case this should be a
+            // hard failure.
+            self::start_signal_handler().expect("starting signal handler failed");
         });
 }
 
@@ -62,19 +52,121 @@ pub fn check_for_signal() -> Option<SignalEvent> {
     }
 }
 
-fn set_signal_handlers() {
-    unsafe {
-        signal(libc::SIGINT, handle_shutdown_signal);
-        signal(libc::SIGTERM, handle_shutdown_signal);
+fn start_signal_handler() -> io::Result<()> {
+    let mut handled_signals = Sigset::empty()?;
+    handled_signals.addsig(libc::SIGINT)?;
+    handled_signals.addsig(libc::SIGTERM)?;
+    handled_signals.addsig(libc::SIGHUP)?;
+    handled_signals.addsig(libc::SIGQUIT)?;
+    handled_signals.addsig(libc::SIGALRM)?;
+    handled_signals.addsig(libc::SIGUSR1)?;
+    handled_signals.addsig(libc::SIGUSR2)?;
+    handled_signals.addsig(libc::SIGCHLD)?;
+    handled_signals.block()?;
+    thread::Builder::new().name("signal-handler".to_string())
+                          .spawn(move || {
+                              loop {
+                                  // Using expect here seems reasonable because our understanding of wait() is that it only
+                                  // returns an error if we called it with a bad signal.
+                                  let signal = handled_signals.wait().expect("sigwait failed");
+                                  debug!("signal-handler thread received signal {:?}!", signal);
+                                  match signal {
+                                      libc::SIGINT | libc::SIGTERM => {
+                                          super::SHUTDOWN.store(true, Ordering::SeqCst);
+                                      }
+                                      _ => {
+                                          CAUGHT_SIGNALS.lock()
+                                                        .expect("Signal mutex poisoned")
+                                                        .push_back(signal);
+                                      }
+                                  };
+                              }
+                          })?;
+    Ok(())
+}
 
-        signal(libc::SIGHUP, handle_signal);
-        signal(libc::SIGQUIT, handle_signal);
-        signal(libc::SIGALRM, handle_signal);
-        signal(libc::SIGUSR1, handle_signal);
-        signal(libc::SIGUSR2, handle_signal);
-        signal(libc::SIGCHLD, handle_signal);
+// Sigset is a wrapper for the underlying libc type.
+struct Sigset {
+    inner: libc::sigset_t
+}
+
+impl Sigset {
+    // empty returns an empty Sigset.
+    //
+    // For more information on the relevant libc function see:
+    //
+    // http://man7.org/linux/man-pages/man3/sigsetops.3.html
+    //
+    fn empty() -> io::Result<Sigset> {
+        let mut set: libc::sigset_t = unsafe { mem::zeroed() };
+        let ret = unsafe { libc::sigemptyset(&mut set) };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(Sigset{inner: set})
+        }
+    }
+
+    // addsig adds the given signal to the Sigset.
+    //
+    // For more information on the relevant libc function see:
+    //
+    // http://man7.org/linux/man-pages/man3/sigsetops.3.html
+    //
+    fn addsig(&mut self, signal: SignalCode) -> io::Result<()> {
+        let ret = unsafe { libc::sigaddset(&mut self.inner, signal) };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    // block sets the calling thread's signal mask to the current
+    // sigmask, blocking delivery of all signals in the sigmask.
+    //
+    // This should be called before wait() to avoid race conditions.
+    //
+    // For more information on the relevant libc function see:
+    //
+    // http://man7.org/linux/man-pages/man3/pthread_sigmask.3.html
+    //
+    fn block(&self) -> io::Result<()> {
+        let ret = unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, &self.inner, ptr::null_mut()) };
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    // wait blocks until a signal in the current sigset has been
+    // delivered to the thread.
+    //
+    // Callers should call block() before this function to avoid race
+    // conditions.
+    //
+    // For information on the relevant libc function see:
+    //
+    // http://man7.org/linux/man-pages/man3/sigwait.3.html
+    //
+    // The manual page on linux only lists a single failure case:
+    //
+    // > EINVAL set contains an invalid signal number.
+    //
+    // thus most callers should be able to expect success.
+    //
+    fn wait(&self) -> io::Result<SignalCode> {
+        let mut signal: libc::c_int = 0;
+        let ret = unsafe { libc::sigwait(&self.inner, &mut signal) };
+        if ret != 0 {
+            Err(io::Error::from_raw_os_error(ret))
+        } else {
+            Ok(signal)
+        }
     }
 }
+
 
 /// These are the signals that we can eventually translate into
 /// some kind of event

--- a/components/launcher/src/main.rs
+++ b/components/launcher/src/main.rs
@@ -2,6 +2,7 @@ use env_logger;
 use habitat_common::output::{self,
                              OutputFormat,
                              OutputVerbosity};
+use habitat_core::os::signals;
 use habitat_launcher::server;
 use log::{error,
           log,
@@ -11,10 +12,9 @@ use std::{env,
 
 fn main() {
     env_logger::init();
-
     let args: Vec<String> = env::args().skip(1).collect();
     set_global_logging_options(&args);
-
+    signals::init();
     match server::run(args) {
         Err(err) => {
             error!("Launcher exiting with 1 due to err: {}", err);

--- a/components/launcher/src/server.rs
+++ b/components/launcher/src/server.rs
@@ -418,7 +418,6 @@ impl ServiceTable {
 
 pub fn run(args: Vec<String>) -> Result<i32> {
     let mut server = Server::new(args)?;
-    signals::init();
     liveliness_checker::spawn_thread_alive_checker();
     let loop_value: ThreadUnregistered<_, _> = loop {
         let checked_thread = liveliness_checker::mark_thread_alive();

--- a/components/sup/src/command/shell.rs
+++ b/components/sup/src/command/shell.rs
@@ -3,11 +3,11 @@ use crate::error::{Error,
 use habitat_common::{outputln,
                      util::path};
 use habitat_core::fs::find_command;
-use libc;
+
+use habitat_core::os::process::become_command;
+
 use std::{env,
-          ffi::CString,
-          path::PathBuf,
-          ptr};
+          path::PathBuf};
 
 /// Our output key
 static LOGKEY: &str = "SH";
@@ -40,11 +40,6 @@ fn exec_shell(cmd: &str) -> Result<()> {
         Some(p) => p,
         None => return Err(Error::ExecCommandNotFound(cmd.to_string())),
     };
-    let c_cmd = CString::new(cmd_path.to_string_lossy().into_owned())?;
-    let mut argv = [c_cmd.as_ptr(), ptr::null()];
-    debug!("Exec {:?}", &cmd_path.display());
-    unsafe {
-        libc::execvp(c_cmd.as_ptr(), argv.as_mut_ptr());
-    }
+    become_command(cmd_path, &[])?;
     Ok(())
 }

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -43,7 +43,8 @@ use habitat_core::crypto::dpapi::encrypt;
 use habitat_core::{self,
                    crypto::{self,
                             SymKey},
-                   os::process::ShutdownTimeout,
+                   os::{process::ShutdownTimeout,
+                        signals},
                    url::{bldr_url_from_env,
                          default_bldr_url},
                    ChannelIdent};
@@ -82,6 +83,16 @@ fn main() {
     logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
+    // On Windows initializing the signal handler will create a ctrl+c handler for the
+    // process which will disable default windows ctrl+c behavior and allow us to
+    // handle the signal via pending_shutdown(). Currently the supervisor does not
+    // call pending_shutdown(), effectively ignoring ctrl+c. On Windows, we
+    // let the launcher catch ctrl+c and gracefully shut down services. When IGNORE_SIGNALS is set,
+    // ctrl+c should simply halt the supervisor.
+    if !flags.contains(FeatureFlag::IGNORE_SIGNALS) {
+        signals::init();
+    }
+
     let result = start_rsr_imlw_mlw_gsw_smw_rhw_msw(flags);
     let exit_code = match result {
         Ok(_) => 0,

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -956,17 +956,6 @@ impl Manager {
             debug!("http-gateway started");
         }
 
-        // On Windows initializng the signal handler will create a ctrl+c handler for the
-        // process which will disable default windows ctrl+c behavior and allow us to
-        // handle via check_for_signal. However, if the supervsor is in a long running
-        // non-run hook, the below loop will not get to check_for_signal in a reasonable
-        // amount of time and the supervisor will not respond to ctrl+c. On Windows, we
-        // let the launcher catch ctrl+c and gracefully shut down services. ctrl+c should
-        // simply halt the supervisor
-        if !self.feature_flags.contains(FeatureFlag::IGNORE_SIGNALS) {
-            signals::init();
-        }
-
         // Enter the main Supervisor loop. When we break out, it'll be
         // because we've been instructed to shutdown. The value we
         // break out with governs exactly how we shut down.

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -58,9 +58,8 @@ use habitat_common::{liveliness_checker,
                              ListenCtlAddr},
                      FeatureFlag};
 #[cfg(unix)]
-use habitat_core::os::{process::{ShutdownSignal,
-                                 Signal},
-                       signals::SignalEvent};
+use habitat_core::os::process::{ShutdownSignal,
+                                Signal};
 use habitat_core::{crypto::SymKey,
                    env,
                    fs::FS_ROOT_PATH,
@@ -1013,8 +1012,7 @@ impl Manager {
             #[cfg(unix)]
             match self.feature_flags.contains(FeatureFlag::IGNORE_SIGNALS) {
                 false => {
-                    if let Some(SignalEvent::Passthrough(Signal::HUP)) = signals::check_for_signal()
-                    {
+                    if signals::pending_sighup() {
                         outputln!("Supervisor shutting down for signal");
                         break ShutdownMode::Restarting;
                     }


### PR DESCRIPTION
## Summary

Issue #7044 describes multiple problems with the current signal
handling approach. These problems were introduced in 8e138274be and
render our current signal handling unsafe. Specifically, taking a
mutex and allocating memory from inside an signal handler can result
in a deadlock or state corruption.

When using asynchronous signal handling via signal handlers, the code
in the signal handler are restricted to limited number of safe
operations (i.e. flipping an atomic, calling async-signal-safe
functions).

This change hopes to solve the existing issues and avoid future
problems caused by signal handlers by moving us to synchronous signal
handling.

## Move to Synchronous signal handling

The strategy used here is described in _The Linux
Programming Interface_[0]:

> - All threads block all of the asynchronous signals that the process
>   might receive. The simplest way to do this is to block the signals
>   in the main thread before any other threads are created. Each
>   subsequently created thread will inherit a copy of the main
>   thread's signal mask.
>
> - Create a single dedicated thread that accepts incoming signals
>   using _sigwaitinfo()_, _sigtimedwait()_, or _sigwait()_...

On Linux, signals::init() will now:

- Block all signals that we plan on handling
- Starts a thread that processes signals synchronously.

Because we want to block the signals early in the process, we move
signals::init() much earlier into main.

## Move to a more explicit interface

This change also moves us from using a VecDequeue under a Mutex for
tracking signals to signal-specific AtomicBools, replacing the generic
`check_for_signal()` function with two more-specific
`pending_sighup()` and `pending_sigchld()` functions.

This has two advantages:

1) No mutexes or memory allocations in our signal handling code. This
   matters less since we have also moved to synchronous handling of
   signals, bug gives us some flexibility to change our approach more
   safely in the future.

2) Clearer alignment between this interface and the application
   behavior.

The old check_for_signal() API looks like it intended to provide the
groundwork for a variety of signal-based behavior; however, in
reality, we are handling a small number of signals. The generic nature
of that interface and the fact that the code is shared between two
processes was obscuring the fact that we actually have a small amount
of signal-related behavior across the two services:

*Linux Behavior*
```
| signal    | hab-launch behavior | hab-sup behavior     |
|-----------+---------------------+----------------------|
| SIGINT    | Graceful shutdown   | Handled but ignored  |
| SIGTERM   | Graceful shutdown   | Handled but ignored  |
| SIGHUP    | Send to hab-sup     | Shutdown for restart |
| SIGCHLD   | Reap zombies        | Handled but ignored  |
| SIGQUIT   | Handled but ignored | Handled but ignored  |
| SIGALRM   | Handled but ignored | Handled but ignored  |
| SIGUSR1   | Handled but ignored | Handled but ignored  |
| SIGUSR2   | Handled but ignored | Handled but ignored  |
| All other | Default disposition | Default disposition  |
```

*Windows Behavior*

Windows uses a library which appears to handle the CTRL_C_EVENT. 


The set of changes should not substantively change the behavior on either platform, 
although we are now installing the handler earlier in the startup of the relevant applications.

This more explicit interface has the disadvantage of not being
well-suited to a larger variety of signal-based behavior. However, it
seems to me that we can always implement something smarter when that
actually becomes an issue.

## Resources

[0] Kerrisk, Michael. _The Linux Programming Interface_, 685. San
Franscisco: No Starch Press, 2010.
[1] http://man7.org/linux/man-pages/man2/sigprocmask.2.html
[2] http://man7.org/linux/man-pages/man3/sigwait.3.html
[3] http://man7.org/linux/man-pages/man3/pthread_sigmask.3.html
[4] http://man7.org/linux/man-pages/man3/sigsetops.3.html
[5] http://man7.org/linux/man-pages/man7/signal.7.html

Signed-off-by: Steven Danna <steve@chef.io>