### PR TITLE
Auto assign prs if opened by a Habitat team member

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -40,7 +40,13 @@ staging_areas:
 subscriptions:
   - workload: pull_request_opened:{{agent_id}}:*
     actions:
-      - post_github_comment:.expeditor/templates/welcome.mustache
+      - post_github_comment:.expeditor/templates/welcome.mustache:
+          ignore_team_members:
+            - habitat-sh/habitat-core-maintainers
+      - built_in:github_auto_assign_author:
+          only_if_team_member:
+            - habitat-sh/habitat-core-maintainers
+
 
   - workload: staged_workload_released:{{agent_id}}:release_staging:*
     actions:


### PR DESCRIPTION
This will auto assign a PR to the person who opened it, if they are a member of the `habitat-core-maintainers` team.  

It will also no longer send welcome emails to team members. 

Thanks to the `chef/inspec` team for providing the examples :smile:

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>