### PR TITLE
Ma/hab 7056/message cleanup

### DIFF
--- a/components/hab/src/command/pkg/download.rs
+++ b/components/hab/src/command/pkg/download.rs
@@ -139,8 +139,8 @@ impl<'a> DownloadTask<'a> {
         // This was written intentionally with an eye towards data parallelism
         // Any or all of these phases should naturally fit a fork-join model
 
-        ui.begin(format!("Preparing to resolve packages and download transitive \
-                          dependendencies for {} package idents",
+        ui.begin(format!("Preparing to resolve packages and download transitive dependencies \
+                          for {} package idents",
                          self.idents.len()))?;
         ui.begin(format!("Using channel {} from {}", self.channel, self.url))?;
         ui.begin(format!("Storing in download directory {:?} ", self.download_path))?;


### PR DESCRIPTION
Simplify hab pkg download output. The current output is redundant and is difficult to use in narrow console windows.

This PR removes some redundant messages, shortens lines, and generally cleans up the output. I've tested it and it looks good in 80 columns. Also clean up some typos.

closes #7056
closes #7054 

```
mark@souschef{111}% ../habitat/target/debug/hab pkg download --download-directory foo --target x86_64-linux  core/gzip
» Resolving dependencies for 1 package idents
» Using channel stable from https://bldr.habitat.sh
» Using target x86_64-linux
» Storing in download directory "foo" 
☛ Verifying the download directory "foo"
☁ Determining latest version of core/gzip
→ Using core/gzip/1.9/20190115013612
→ Found 8 artifacts
↓ Downloading Downloading 8 artifacts (and their signing keys)
… Using cached core/less/530/20190115013008
… Using cached core/linux-headers/4.17.12/20190115002705
… Using cached core/glibc/2.27/20190115002733
… Using cached core/gcc-libs/8.2.0/20190115011926
… Using cached core/grep/3.1/20190115012541
… Using cached core/ncurses/6.1/20190115012027
… Using cached core/gzip/1.9/20190115013612
… Using cached core/pcre/8.42/20190115012526
mark@souschef{111}% rm -rf foo
mark@souschef{112}% ../habitat/target/debug/hab pkg download --download-directory foo --target x86_64-linux  core/gzip
» Resolving dependencies for 1 package idents
» Using channel stable from https://bldr.habitat.sh
» Using target x86_64-linux
» Storing in download directory "foo" 
☛ Verifying the download directory "foo"
☁ Determining latest version of core/gzip
→ Using core/gzip/1.9/20190115013612
→ Found 8 artifacts
↓ Downloading Downloading 8 artifacts (and their signing keys)
↓ Downloading core/linux-headers/4.17.12/20190115002705
    965.22 KB / 965.22 KB | [==============================] 100.00 % 5.91 MB/s 
↓ Downloading public key for signer "core-20180119235000"
    75 B / 75 B | [======================================] 100.00 % 474.64 KB/s 
↓ Downloading core/ncurses/6.1/20190115012027
    848.13 KB / 848.13 KB - [==============================] 100.00 % 5.29 MB/s 
↓ Downloading core/gcc-libs/8.2.0/20190115011926
    3.33 MB / 3.33 MB / [==================================] 100.00 % 7.92 MB/s 
↓ Downloading core/glibc/2.27/20190115002733
    13.83 MB / 13.83 MB - [================================] 100.00 % 9.31 MB/s 
↓ Downloading core/less/530/20190115013008
    83.00 KB / 83.00 KB - [================================] 100.00 % 1.64 MB/s 
↓ Downloading core/pcre/8.42/20190115012526
    737.67 KB / 737.67 KB / [==============================] 100.00 % 4.75 MB/s 
↓ Downloading core/gzip/1.9/20190115013612
    61.76 KB / 61.76 KB \ [================================] 100.00 % 1.35 MB/s 
↓ Downloading core/grep/3.1/20190115012541
    170.21 KB / 170.21 KB / [==============================] 100.00 % 2.28 MB/s
```