### PR TITLE
add windows system paths to environment PATH variable if included

### DIFF
--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -274,6 +274,23 @@ pub fn user_config_path<T: AsRef<Path>>(service_name: T) -> PathBuf {
     user_path(service_name).join("config")
 }
 
+/// This produces a list of the default windows system paths
+/// that are set by default on any modern version of windows.
+/// This also arranges them in the same order as they would be by
+/// default. The ordering is likely not super important but we
+/// might as well match how windows sets them just in case.
+pub fn windows_system_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(sys_root) = env::var_os("SystemRoot") {
+        let system32 = Path::new(&sys_root).join("system32");
+        paths.push(system32.clone());
+        paths.push(PathBuf::from(sys_root));
+        paths.push(system32.join("wbem"));
+        paths.push(system32.join("WindowsPowerShell").join("v1.0"));
+    }
+    paths
+}
+
 /// Represents the service directory for a given package.
 pub struct SvcDir<'a> {
     service_name: &'a str,

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -293,7 +293,16 @@ mod test {
               rootfs.path(),
               force).unwrap();
         #[cfg(windows)]
-        assert!(fs::read_to_string(rootfs_bin_dir.join(magicate_link)).unwrap().contains(&format!("PATH={}{}", rootfs_src_dir.to_string_lossy(), ";%PATH%")));
+        assert!(
+                fs::read_to_string(rootfs_bin_dir.join(magicate_link)).unwrap()
+                                                                      .contains(&format!(
+            "PATH={};{};{}",
+            rootfs_src_dir.to_string_lossy(),
+            env::join_paths(hcore::fs::windows_system_paths()).unwrap()
+                                                              .to_string_lossy(),
+            "%PATH%"
+        ))
+        );
         assert_eq!(rootfs_src_dir.join("magicate.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(magicate_link)).unwrap()
                                                                           .target);
@@ -305,7 +314,16 @@ mod test {
               rootfs.path(),
               force).unwrap();
         #[cfg(windows)]
-        assert!(fs::read_to_string(rootfs_bin_dir.join(hypnoanalyze_link)).unwrap().contains(&format!("PATH={}{}", rootfs_src_dir.to_string_lossy(), ";%PATH%")));
+        assert!(
+                fs::read_to_string(rootfs_bin_dir.join(hypnoanalyze_link)).unwrap()
+                                                                          .contains(&format!(
+            "PATH={};{};{}",
+            rootfs_src_dir.to_string_lossy(),
+            env::join_paths(hcore::fs::windows_system_paths()).unwrap()
+                                                              .to_string_lossy(),
+            "%PATH%"
+        ))
+        );
         assert_eq!(rootfs_src_dir.join("hypnoanalyze.exe"),
                    Binlink::from_file(&rootfs_bin_dir.join(hypnoanalyze_link)).unwrap()
                                                                               .target);


### PR DESCRIPTION
fixes #6657 

On Windows these added paths are set by default on all modern windows systems. Any Windows application expects these paths to be present.

Signed-off-by: mwrock <matt@mattwrock.com>