### PR TITLE
Noindex/nofollow blog pages

### DIFF
--- a/www/source/layouts/blog_index.slim
+++ b/www/source/layouts/blog_index.slim
@@ -1,6 +1,7 @@
 doctype html
 html prefix="og: http://ogp.me/ns#"
   head
+    meta name="robots" content="none">
     meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible"
     meta charset="utf-8"
     meta content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" name="viewport"


### PR DESCRIPTION
This PR limits what Swiftype and other crawlers see by adding "none" to blog pages.

Signed-off-by: kagarmoe <kgarmoe@chef.io>