### PR TITLE
Reorder pipeline stages for maximum parallelism

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -155,6 +155,9 @@ steps:
 
   - wait
 
+  # Now that we've got a new Studio, we can build everything else
+  # using the build toolchain we just built.
+
   - label: "[:linux: build launcher]"
     command:
       - .expeditor/scripts/release_habitat/build_component.sh launcher
@@ -178,19 +181,6 @@ steps:
   - label: "[:windows: build launcher]"
     command:
       - powershell .expeditor/scripts/release_habitat/build_component.ps1 launcher
-    expeditor:
-      executor:
-        docker:
-          host_os: windows
-          environment:
-            - BUILD_PKG_TARGET=x86_64-windows
-            - BUILDKITE_AGENT_ACCESS_TOKEN
-
-  - wait
-
-  - label: ":windows: Build windows service"
-    command:
-      - powershell .expeditor/scripts/release_habitat/build_component.ps1 windows-service
     expeditor:
       executor:
         docker:
@@ -229,8 +219,6 @@ steps:
           environment:
             - BUILD_PKG_TARGET=x86_64-windows
             - BUILDKITE_AGENT_ACCESS_TOKEN
-
-  - wait
 
   - label: "[:linux: build hab-pkg-aci]"
     command:
@@ -325,6 +313,18 @@ steps:
             - BUILD_PKG_TARGET=x86_64-linux
 
   - wait
+
+  # Windows Service must be built after the Windows Launcher
+  - label: ":windows: Build windows service"
+    command:
+      - powershell .expeditor/scripts/release_habitat/build_component.ps1 windows-service
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          environment:
+            - BUILD_PKG_TARGET=x86_64-windows
+            - BUILDKITE_AGENT_ACCESS_TOKEN
 
   # The cfize export currently has a dependency on
   # hab-pkg-export-docker, so it must be built after that.


### PR DESCRIPTION
While the `windows-service` package must be built after the Windows
Launcher package, there is nothing that prevents Launcher and
Supervisor packages from being built in parallel, since they are
mutually independent on a Habitat dependency level.

Similarly, none of the exporters depend directly on either the
Launcher or the Supervisor, so they can all be built at the same time
as those two packages.

Now, we build the Windows Service toward the end, alongside the
`core/hab-pkg-cfize` exporter, which itself has a hard dependency on
`core/hab-pkg-export-docker`.

By reordering these and building more packages in parallel, we should
be able to get through the entire pipeline in less overall time.

Signed-off-by: Christopher Maier <cmaier@chef.io>