### PR TITLE
Move install_rustup to top-level shared Bash library

### DIFF
--- a/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
+++ b/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
@@ -39,10 +39,7 @@ import_keys
 sudo mkdir -p /hab/cache/keys
 sudo cp -r ~/.hab/cache/keys/* /hab/cache/keys/
 
-echo "--- :rust: Installing Rust"
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-# This ensures the appropriate binaries are on our path
-source "${HOME}/.cargo/env"
+install_rustup
 
 # set the rust toolchain
 rust_toolchain="$(cat rust-toolchain)"

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -36,6 +36,17 @@ curlbash_hab() {
     echo "--- :habicat: Hab binary set to $hab_binary"
 }
 
+install_rustup() {
+  if command -v rustup && command -v cargo &>/dev/null; then
+    echo "--- :rust: rustup is currently installed."
+  else
+    echo "--- :rust: Installing rustup."
+    curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y --profile=minimal
+    # shellcheck disable=SC1090
+    source "$HOME"/.cargo/env
+  fi
+}
+
 get_toolchain() {
     dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
     cat "$dir/../../rust-toolchain"

--- a/.expeditor/scripts/verify/shared.sh
+++ b/.expeditor/scripts/verify/shared.sh
@@ -24,17 +24,6 @@ get_rustfmt_toolchain() {
   cat "$dir/../../../RUSTFMT_VERSION"
 }
 
-install_rustup() {
-  if command -v rustup && command -v cargo &>/dev/null; then
-    echo "--- :rust: rustup is currently installed."
-  else
-    echo "--- :rust: Installing rustup."
-    curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y --profile=minimal
-    # shellcheck disable=SC1090
-    source "$HOME"/.cargo/env
-  fi
-}
-
 install_rustfmt() {
   local toolchain="${1?toolchain argument required}"
   install_rust_toolchain "$toolchain"


### PR DESCRIPTION
This allows the release pipeline macOS stage to use the same `rustup` installation logic (in particular, the recently-added `--profile=minimal` tweak; see #7072).

Signed-off-by: Christopher Maier <cmaier@chef.io>