### PR TITLE
Add HAB_AUTH_TOKEN and BUILDKITE_AGENT_TOKEN back on Windows

### DIFF
--- a/.expeditor/scripts/release_habitat/build_component.ps1
+++ b/.expeditor/scripts/release_habitat/build_component.ps1
@@ -16,6 +16,13 @@ if($Component.Equals("")) {
     Write-Error "--- :error: Component to build not specified, please use the -Component flag"
 }
 
+# We have to do this because everything that comes from vault is quoted on windows.
+# TODO: This can be removed when we go live!
+$Rawtoken=$Env:ACCEPTANCE_HAB_AUTH_TOKEN
+$Env:HAB_AUTH_TOKEN=$Rawtoken.Replace("`"","")
+
+$Env:buildkiteAgentToken = $Env:BUILDKITE_AGENT_ACCESS_TOKEN
+
 $Env:HAB_BLDR_URL=$Env:ACCEPTANCE_HAB_BLDR_URL
 $Env:HAB_PACKAGE_TARGET=$Env:BUILD_PKG_TARGET
 


### PR DESCRIPTION
Turns out this functionality was smuggled into the `Install-BuildkiteAgent` function that was deleted in #7043.

Signed-off-by: Christopher Maier <cmaier@chef.io>