### PR TITLE
Install Buildkite Agent in Windows container again

### DIFF
--- a/.expeditor/scripts/release_habitat/build_component.ps1
+++ b/.expeditor/scripts/release_habitat/build_component.ps1
@@ -26,6 +26,8 @@ $Env:buildkiteAgentToken = $Env:BUILDKITE_AGENT_ACCESS_TOKEN
 $Env:HAB_BLDR_URL=$Env:ACCEPTANCE_HAB_BLDR_URL
 $Env:HAB_PACKAGE_TARGET=$Env:BUILD_PKG_TARGET
 
+Install-BuildkiteAgent
+
 # Install jq if it doesn't exist
 choco install jq -y | Out-Null
 

--- a/.expeditor/scripts/release_habitat/shared.ps1
+++ b/.expeditor/scripts/release_habitat/shared.ps1
@@ -1,5 +1,15 @@
 . $PSScriptRoot\..\shared.ps1
 
+function Install-BuildkiteAgent() {
+  # Though the Windows machine we're running on has to have the
+  # buildkite-agent installed, by definition, if you need to use the
+  # buildkite-agent inside a container running on that host (e.g., to
+  # do artifact uploads, or to manipulate pipeline metadata), then
+  # you'll need to install it in the container as well.
+  Write-Host "--- Installing buildkite agent in container"
+  iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/buildkite/agent/master/install.ps1')) | Out-Null
+}
+
 function Install-LatestHabitat() {
   # Install latest hab from using install.ps1
   $env:HAB_LICENSE = "accept-no-persist"


### PR DESCRIPTION
Adds some more detailed explanation of why this is required, given
that we're already running in Buildkite to begin with.

Signed-off-by: Christopher Maier <cmaier@chef.io>