### PR TITLE
Initialize health check gateway state to Unknown

### DIFF
--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -393,6 +393,7 @@ impl Service {
     /// checks for the service
     fn start_health_checks(&mut self, executor: &TaskExecutor) {
         debug!("Starting health checks for {}", self.pkg.ident);
+        self.health_state().init_gateway_state_gsw();
         let (handle, f) =
             sup_futures::cancelable_future(self.health_state().check_repeatedly_gsw());
 

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -140,6 +140,16 @@ impl State {
                 gateway_state }
     }
 
+    // Initialize the gateway_state for this health check to Unknown.
+    //
+    // # Locking (see locking.md)
+    // # `GatewayState::inner` (write)
+    pub fn init_gateway_state_gsw(self) {
+        self.gateway_state
+            .lock_gsw()
+            .set_health_of(self.service_group, HealthCheckResult::Unknown);
+    }
+
     /// Creates a future that runs the health check and then waits for
     /// a suitable interval. Multiple such iterations will then be
     /// chained together for an unending stream of health checks.


### PR DESCRIPTION
Previously, the gateway state had no health check information for a
given service until the first health-check. This resulted in a 404 for
the `/services/SERVICE_NAME/SERVICE_GROUP/health` endpoint. However,
according to the documentation, a 404 response code means the service
isn't loaded:

```
 /{name}/{group}/health:
     get:
         description: Health check status and output for the given service group
         responses:
             200:
                 description: Health Check - Ok / Warning
                 body:
                     application/json:
                         type: healthCheckOutput
             404:
                 description: Service not loaded
             500:
                 description: Health Check - Unknown
             503:
                 description: Health Check - Critical
```

This change avoids the problem by populating the gateway state with
Unknown when we start the health checks. As a result we now return 500
for the health endpoint of a loaded service until the first
health-check comes back, in accordance with the API documentation.

Fixes #6747 


REVIEWER NOTES:

- I'm not actually sure this is the best solution. It is a bit hard to follow all of the conditions in which we might call start_health_checks.  We could instead check for the existence of the health check directly in http_gateway.rs by checking `service_from_services(&service_group, state.gateway_state.lock_gsr().services_data())`