### PR TITLE
[CI] Ensure version file can be properly sourced

### DIFF
--- a/.expeditor/scripts/release_habitat/package_and_upload_binary.sh
+++ b/.expeditor/scripts/release_habitat/package_and_upload_binary.sh
@@ -20,7 +20,7 @@ import_gpg_keys
 
 # Unsure we *really* need to bother with this tmp_root business, but
 # it does help to contain things a bit.
-tmp_root="$(mktemp -d -t "repackage-XXXX")"
+tmp_root="$(mktemp --directory --tmpdir=$(pwd) -t "repackage-XXXX")"
 cd "${tmp_root}"
 
 echo "--- Downloading core/hab for $BUILD_PKG_TARGET from ${channel} channel"

--- a/.expeditor/scripts/release_habitat/shared.sh
+++ b/.expeditor/scripts/release_habitat/shared.sh
@@ -10,12 +10,15 @@ get_release_channel() {
 
 # Read the contents of the VERSION file. This will be used to
 # determine where generated artifacts go in S3.
+#
+# As long as you don't `cd` out of the repository, this will do the
+# trick.
 get_version_from_repo() {
-    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+    dir="$(git rev-parse --show-toplevel)"
     if [[ -n "${DO_FAKE_RELEASE:-}" ]]; then
-        cat "$dir/../../../VERSION_FAKE"
+        cat "$dir/VERSION_FAKE"
     else
-        cat "$dir/../../../VERSION"
+        cat "$dir/VERSION"
     fi
 }
 


### PR DESCRIPTION
Rather than relying on `BASH_SOURCE` in a sourced file, we'll simply
ask `git` what our top-level directory is, and resolve our version
file from there.

Additionally, we'll create a temporary directory inside our current
directory, rather than `/tmp`, when generating our binary-only
artifacts. This keeps everything within the checkout directory.

Signed-off-by: Christopher Maier <cmaier@chef.io>