### PR TITLE
wire up e2e hab pkg download tests into expeditor

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -372,7 +372,7 @@ steps:
 
   - label: "[:linux: test_pkg_download]"
     command:
-      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - .expeditor/scripts/end_to_end/setup_environment.sh dev
       - test/end-to-end/test_pkg_download.sh
     expeditor:
       executor:

--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -370,6 +370,17 @@ steps:
             - BUILD_PKG_TARGET=x86_64-windows
             - BUILDKITE_AGENT_ACCESS_TOKEN
 
+  - label: "[:linux: test_pkg_download]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh DEV
+      - test/end-to-end/test_pkg_download.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - ACCEPTANCE_HAB_AUTH_TOKEN
+
   - wait
 
   - label: "[:habicat: Promote to Acceptance]"

--- a/test/end-to-end/test_pkg_download.sh
+++ b/test/end-to-end/test_pkg_download.sh
@@ -25,7 +25,7 @@ IDENT_FILE="ident_file"
 HAB_AUTH_TOKEN=${ACCEPTANCE_HAB_AUTH_TOKEN:-${HAB_AUTH_TOKEN}}
 
 echo
-echo "==========Testing command ${HAB}, using cache dir ${CACHE_DIR}"
+echo "==========Testing with command ${HAB}, using cache dir ${CACHE_DIR}"
 echo
 
 before_test() {

--- a/test/end-to-end/test_pkg_download.sh
+++ b/test/end-to-end/test_pkg_download.sh
@@ -10,7 +10,7 @@
 # command line testing.
 #
 # Assumptions:
-# 1. ACCEPTANCE_HAB_AUTH_TOKEN or HAB_AUTH_TOKEN Environment variables are set and valid
+# 1. HAB_AUTH_TOKEN Environment variables is set and valid
 # 2. ${CACHE_DIR} can be set to a writable location on the filesystem
 
 set -euo pipefail
@@ -22,7 +22,8 @@ set -euo pipefail
 HAB=${HAB_TEST_CMD:-hab}
 CACHE_DIR="test-cache"
 IDENT_FILE="ident_file"
-HAB_AUTH_TOKEN=${ACCEPTANCE_HAB_AUTH_TOKEN:-${HAB_AUTH_TOKEN}}
+# we explicitly define --channel where needed in the tests
+export HAB_BLDR_CHANNEL=
 
 echo
 echo "--- Testing with command ${HAB}, using cache dir ${CACHE_DIR}"
@@ -102,7 +103,7 @@ success_from_command_line() {
 
     echo "--- Testing command line idents"
 
-    CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/gzip"
+    CMD="$HAB pkg download --channel stable --download-directory=${CACHE_DIR} core/gzip"
     echo "Testing command line: ${CMD}"
     ${CMD}
 
@@ -115,7 +116,7 @@ success_from_file() {
     echo "--- Testing file idents"
 
     echo "core/gzip" > ${IDENT_FILE}
-    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"
+    CMD="$HAB pkg download --channel stable --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"
     echo "Testing command line: ${CMD}"
     ${CMD}
 
@@ -133,7 +134,7 @@ success_from_file_with_comments_and_emtpy_lines() {
 
  core/gzip 
 IDENT_FILE
-    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"
+    CMD="$HAB pkg download --channel stable --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"
     echo "Testing command line: ${CMD}"
     ${CMD}
 
@@ -145,7 +146,7 @@ success_from_alternate_arch() {
 
     echo "--- Testing command line idents"
 
-    CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/rust --target=x86_64-windows"
+    CMD="$HAB pkg download --channel stable --download-directory=${CACHE_DIR} core/rust --target=x86_64-windows"
     echo "Testing command line: ${CMD}"
     ${CMD}
 

--- a/test/end-to-end/test_pkg_download.sh
+++ b/test/end-to-end/test_pkg_download.sh
@@ -10,8 +10,7 @@
 # command line testing.
 #
 # Assumptions:
-# 1. HAB_AUTH_TOKEN Environment variables is set and valid
-# 2. ${CACHE_DIR} can be set to a writable location on the filesystem
+# 1. ${CACHE_DIR} can be set to a writable location on the filesystem
 
 set -euo pipefail
 
@@ -22,8 +21,6 @@ set -euo pipefail
 HAB=${HAB_TEST_CMD:-hab}
 CACHE_DIR="test-cache"
 IDENT_FILE="ident_file"
-# we explicitly define --channel where needed in the tests
-unset HAB_BLDR_CHANNEL
 
 echo
 echo "--- Testing with command ${HAB}, using cache dir ${CACHE_DIR}"

--- a/test/end-to-end/test_pkg_download.sh
+++ b/test/end-to-end/test_pkg_download.sh
@@ -23,7 +23,7 @@ HAB=${HAB_TEST_CMD:-hab}
 CACHE_DIR="test-cache"
 IDENT_FILE="ident_file"
 # we explicitly define --channel where needed in the tests
-export HAB_BLDR_CHANNEL=
+unset HAB_BLDR_CHANNEL
 
 echo
 echo "--- Testing with command ${HAB}, using cache dir ${CACHE_DIR}"

--- a/test/end-to-end/test_pkg_download.sh
+++ b/test/end-to-end/test_pkg_download.sh
@@ -7,7 +7,7 @@
 # for cleaner code and more fine grained tests. However, they are a
 # bit of a pain to program in bash. This is intended to provide
 # minimal testing pending our figuring out the best approach for
-# command line testing. 
+# command line testing.
 #
 
 set -euo pipefail
@@ -16,7 +16,7 @@ set -euo pipefail
 #
 # Uses the `HAB_INTERNAL_BLDR_CHANNEL` environment variable to control
 # the base packages channel for the exporter.
-HAB=$HAB_TEST_CMD || "hab"
+HAB=${HAB_TEST_CMD:-hab}
 CACHE_DIR="test-cache"
 IDENT_FILE="ident_file"
 
@@ -52,7 +52,7 @@ check_gzip_idents() {
     check_ident_downloaded "core-less"
     check_ident_downloaded "core-ncurses"
 
-    count=$(find "${CACHE_DIR}/artifacts" -type f | wc -l) 
+    count=$(find "${CACHE_DIR}/artifacts" -type f | wc -l)
 
     echo "found $count downloads"
     if [ "$count" -eq "8" ]; then
@@ -68,7 +68,7 @@ check_rust_idents() {
     check_ident_downloaded "core-visual-cpp-redist-2015"
     check_ident_downloaded "core-visual-cpp-build-tools-2015"
 
-    count=$(find "${CACHE_DIR}/artifacts" -type f | wc -l) 
+    count=$(find "${CACHE_DIR}/artifacts" -type f | wc -l)
 
     echo "found $count downloads"
     if [ "$count" -eq "3" ]; then
@@ -91,15 +91,13 @@ test_expecting_fail() {
     else
 	echo "PASS (got error) $CMD"
     fi;
-    
-
 }
 
 success_from_command_line() {
     before_test
 
     echo "==========Testing command line idents"
-    
+
     CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/gzip"
     echo "Testing command line: ${CMD}"
     ${CMD}
@@ -108,24 +106,41 @@ success_from_command_line() {
 }
 
 success_from_file() {
-    
     before_test
 
     echo "==========Testing file idents"
-    
+
     echo "core/gzip" > ${IDENT_FILE}
-    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"   
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"
     echo "Testing command line: ${CMD}"
     ${CMD}
 
-    check_gzip_idents   
+    check_gzip_idents
+}
+
+success_from_file_with_comments_and_emtpy_lines() {
+    before_test
+
+    echo "==========Testing file idents when file has white spaces and comments"
+
+    cat << IDENT_FILE > ${IDENT_FILE}
+# this is a series
+# of comments, followed by empty lines and whitespaces
+
+ core/gzip 
+IDENT_FILE
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"
+    echo "Testing command line: ${CMD}"
+    ${CMD}
+
+    check_gzip_idents
 }
 
 success_from_alternate_arch() {
     before_test
-    
+
     echo "==========Testing command line idents"
-    
+
     CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/rust --target=x86_64-windows"
     echo "Testing command line: ${CMD}"
     ${CMD}
@@ -136,23 +151,30 @@ success_from_alternate_arch() {
 bad_package_as_arg() {
     before_test
 
-    CMD="$HAB pkg download --download-directory=${CACHE_DIR} arglebargle"   
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} arglebargle"
     test_expecting_fail "Bad package on command line" "$CMD"
+}
+
+no_package_from_args() {
+    before_test
+
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR}"
+    test_expecting_fail "No package identifers provided" "$CMD"
 }
 
 bad_package_in_file() {
     before_test
-	
+
     echo "arglebargle" > ${IDENT_FILE}
 
-    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"   
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"
     test_expecting_fail "Bad package in provided file" "$CMD"
 }
 
 no_such_package() {
     before_test
 
-    CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/half_life_4"   
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/half_life_4"
     test_expecting_fail "Bad package on command line" "$CMD"
 
 }
@@ -183,14 +205,14 @@ bad_token() {
 
 bad_url() {
     before_test
-    
+
     CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/gzip --url='https://www.example.org'"
     test_expecting_fail "Bad url" "$CMD"
 }
 
 bad_channel() {
     before_test
-    
+
     CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/gzip --channel=number_five"
     test_expecting_fail "Bad channel" "$CMD"
 }
@@ -199,12 +221,14 @@ bad_channel() {
 # functional tests
 success_from_command_line
 success_from_file
+success_from_file_with_comments_and_emtpy_lines
 
 success_from_alternate_arch
 
 # failure tests
 
 bad_package_as_arg
+no_package_from_args
 bad_package_in_file
 no_such_package
 cannot_create_dir
@@ -212,4 +236,3 @@ bad_target
 bad_token
 bad_url
 bad_channel
-

--- a/test/end-to-end/test_pkg_download.sh
+++ b/test/end-to-end/test_pkg_download.sh
@@ -25,7 +25,7 @@ IDENT_FILE="ident_file"
 HAB_AUTH_TOKEN=${ACCEPTANCE_HAB_AUTH_TOKEN:-${HAB_AUTH_TOKEN}}
 
 echo
-echo "==========Testing with command ${HAB}, using cache dir ${CACHE_DIR}"
+echo "--- Testing with command ${HAB}, using cache dir ${CACHE_DIR}"
 echo
 
 before_test() {
@@ -88,7 +88,7 @@ test_expecting_fail() {
     CMD=$2
 
     echo
-    echo "==========Testing ${DESC}"
+    echo "--- Testing ${DESC}"
     if ${CMD}; then
 	echo "FAIL (expected error) $CMD"
 	exit 1
@@ -100,7 +100,7 @@ test_expecting_fail() {
 success_from_command_line() {
     before_test
 
-    echo "==========Testing command line idents"
+    echo "--- Testing command line idents"
 
     CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/gzip"
     echo "Testing command line: ${CMD}"
@@ -112,7 +112,7 @@ success_from_command_line() {
 success_from_file() {
     before_test
 
-    echo "==========Testing file idents"
+    echo "--- Testing file idents"
 
     echo "core/gzip" > ${IDENT_FILE}
     CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${IDENT_FILE}"
@@ -125,7 +125,7 @@ success_from_file() {
 success_from_file_with_comments_and_emtpy_lines() {
     before_test
 
-    echo "==========Testing file idents when file has white spaces and comments"
+    echo "--- Testing file idents when file has white spaces and comments"
 
     cat << IDENT_FILE > ${IDENT_FILE}
 # this is a series
@@ -143,7 +143,7 @@ IDENT_FILE
 success_from_alternate_arch() {
     before_test
 
-    echo "==========Testing command line idents"
+    echo "--- Testing command line idents"
 
     CMD="$HAB pkg download --download-directory=${CACHE_DIR} core/rust --target=x86_64-windows"
     echo "Testing command line: ${CMD}"

--- a/test/end-to-end/test_pkg_download.sh
+++ b/test/end-to-end/test_pkg_download.sh
@@ -9,6 +9,9 @@
 # minimal testing pending our figuring out the best approach for
 # command line testing.
 #
+# Assumptions:
+# 1. ACCEPTANCE_HAB_AUTH_TOKEN or HAB_AUTH_TOKEN Environment variables are set and valid
+# 2. ${CACHE_DIR} can be set to a writable location on the filesystem
 
 set -euo pipefail
 
@@ -19,6 +22,7 @@ set -euo pipefail
 HAB=${HAB_TEST_CMD:-hab}
 CACHE_DIR="test-cache"
 IDENT_FILE="ident_file"
+HAB_AUTH_TOKEN=${ACCEPTANCE_HAB_AUTH_TOKEN:-${HAB_AUTH_TOKEN}}
 
 echo
 echo "==========Testing command ${HAB}, using cache dir ${CACHE_DIR}"


### PR DESCRIPTION
This PR accomplishes the following:

 * wires up e2e tests for hab pkg download
 * covers bugs/features recently merged for the new download command
 * finally, adds some minor cleanups and enhancements to the `test/end-to-end/test_pkg_download.sh` script