### PR TITLE
Fully qualified package names download irrespective of channel

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -796,7 +796,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
         let mut encoded = String::new();
         resp.read_to_string(&mut encoded)
             .map_err(Error::BadResponseBody)?;
-        trace!(target: "habitat_http_client::api_client::show_package", "{:?}", encoded);
+        trace!(target: "habitat_http_client::api_client::show_package_metadata", "{:?}", encoded);
 
         let package: Package = serde_json::from_str::<Package>(&encoded)?;
         Ok(package)
@@ -1260,7 +1260,7 @@ mod tests {
         let client = BuilderAPIClient::new("http://test.com", "", "", None).expect("valid client");
 
         let sample_data = vec!["one_a", "one_b", "one_c", "one_d", "one_e", "two_a", "two_b",
-                               "two_c", "two_d", "two_e"];
+                               "two_c", "two_d", "two_e",];
 
         let searcher = seach_generator(sample_data.as_slice(), 2);
         let r = client.search_package_impl("one", 10, None, searcher)


### PR DESCRIPTION
Fix for hab 7039

When hab pkg download is provided a fully-qualified identifier, it
will fail if that package isn't in the stable channel. In other words
we would need to provide a channel that contains the package on the
command line.  That's a departure from other CLI commands since a
fully-qualified identifier is enough to find a package regardless of
what channel it might be in.

This adds a function show_package_metadata_for_fully_qualified_ident
to the builder-api-client. In the download command implementation test
for a fully qualified ident and use the appropriate call.

An alternative implementation would be to modify the
show_package_metadata function to ignore the channel and use a
different rest endpoint if the package was fully qualified, but that
might create opaque errors and regressions.

Signed-off-by: Mark Anderson <mark@chef.io>