### PR TITLE
[CI] Add the correct AWS account to the e2e pipeline

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -4,6 +4,8 @@ expeditor:
     ACCEPTANCE_HAB_AUTH_TOKEN:
       path: account/static/habitat/chef-ci
       field: scotthain-sig-key
+  accounts:
+    - aws/chef-cd
   defaults:
     buildkite:
       timeout_in_minutes: 30


### PR DESCRIPTION
This is required for the final promotion to work.

Signed-off-by: Christopher Maier <cmaier@chef.io>