### PR TITLE
Add tests to validate SSL behavior on Windows

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -280,6 +280,17 @@ steps:
             - BUILD_PKG_TARGET=x86_64-windows
             - BUILDKITE_AGENT_ACCESS_TOKEN
 
+  - label: "[:windows: test_ssl_certificate_loading]"
+    command:
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_ssl_certificate_loading
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          environment:
+            - BUILD_PKG_TARGET=x86_64-windows
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+
   - wait
 
   - label: "[:habicat: Promote to Acceptance]"

--- a/test/end-to-end/test_ssl_certificate_loading.ps1
+++ b/test/end-to-end/test_ssl_certificate_loading.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference="stop" 
+
+Write-Host "--- Generating a signing key"
+hab origin key generate "$env:HAB_ORIGIN"
+
+Write-Host "--- Testing fresh install of Habitat can communicate with builder"
+Context "Habitat SSL Cache" {
+    BeforeEach {
+        Remove-Item c:\hab\cache\ssl -Recurse -Force 
+    }
+
+    Describe "Fresh Install" {
+        # Note this isn't a pure fresh install, as we had to bootstrap this machine with 
+        # The previous release in order to test the current build.  However, the BeforeEach
+        # block above ensures we don't have any cached certs that this may be pulling in. 
+        It "Can install packages" {
+            hab pkg install core/7zip --channel stable
+            $LASTEXITCODE | Should -Be 0
+        }
+    }
+
+    Describe "Custom Certificates" {
+        It "Can install packages when an invalid certificate is present" {
+            New-Item -Type Directory -Path c:\hab\cache\ssl
+            New-Item -Type File -Path c:\hab\cache\ssl\invalid-certifcate.pem
+            Add-Content -Path c:\hab\cache\ssl\invalid-certificate.pem "I AM NOT A CERTIFICATE" 
+
+            hab pkg install core/nginx --channel stable
+            $LASTEXITCODE | Should -Be 0
+        }
+
+        It "Loads custom certificates" {
+            New-Item -Type Directory -Path c:\hab\cache\ssl
+            hab pkg install core/openssl --channel stable
+            hab pkg exec core/openssl openssl req -newkey rsa:2048 -batch -nodes -keyout key.pem -x509 -days 365 -out c:\hab\cache\ssl\custom-certificate.pem
+
+            $env:RUST_LOG="debug"
+            Start-Process hab -ArgumentList "pkg search core/lessmsi" -RedirectStandardError err.log -wait
+            $env:RUST_LOG="info"
+            Get-Content -Raw -Path err.log | Should -Match "Processing cert file: C:\\hab/cache/ssl\\custom-certificate.pem"
+        }
+    }
+
+    Describe "Studio" {
+        It "Makes custom certificates available in the studio" {
+            $customCertFile = "c:\hab\cache\ssl\custom-certificate.pem"
+            # We can use unix style pathing here to get the real root of the studio
+            # That way we don't have to worry about the studio name if our 
+            # CWD ever changes from 'workdir'
+            $studioCertFile = "/hab/cache/ssl/custom-certificate.pem"
+            New-Item -Type Directory -Path c:\hab\cache\ssl
+            hab pkg install core/openssl --channel stable
+            hab pkg exec core/openssl openssl req -newkey rsa:2048 -batch -nodes -keyout key.pem -x509 -days 365 -out $customCertFile
+
+            $result = hab studio run "(Test-Path $studioCertFile).ToString()"
+            Write-Host $result
+            $result[-1] | Should -Be "True"
+        }
+    }
+}


### PR DESCRIPTION
This adds tests to validate the following scenarios:

- A fresh install of the hab cli can interact with Builder and install packages
- An invalid certificate that has been cached is ignored by the hab cli
- A custom certificate that has been cached manually is available in the studio
- A self-signed certificate is loaded by the hab cli


This finishes the Windows portion of #6800 and closes #6800 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>