### PR TITLE
sup: immediately set initialization_state if no init hook exists

### DIFF
--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -871,6 +871,8 @@ impl Service {
             self.initialize_handle = Some(handle);
             let f = f.map_err(|_| ());
             executor.spawn(f);
+        } else {
+            *self.initialization_state.write() = InitializationState::InitializerFinished;
         }
     }
 


### PR DESCRIPTION
I believe this broke in #7111. For services with no run hook, hab-sup
would wait forever for the service to enter the InitializerFinished
state.

Signed-off-by: Steven Danna <steve@chef.io>

REVIEW NOTE: This is mostly "bug report via pull request". I imagine we might want some tests as well for this case. 