### PR TITLE
Sign sha256sum for compatibility with existing bintray releases

### DIFF
--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -133,6 +133,7 @@ store_in_s3() {
 
     checksum_file "${artifact}"
     gpg_sign "${artifact}"
+    gpg_sign "${artifact}.sha256sum"
 
     local versioned_url
     versioned_url="$(s3_file_url_root "${version}")"
@@ -146,6 +147,9 @@ store_in_s3() {
     s3_cp \
         "${artifact}.sha256sum" \
         "${versioned_url}/${artifact}.sha256sum"
+    s3_cp \
+        "${artifact}.sha256sum.asc" \
+        "${versioned_url}/${artifact}.sha256sum.asc"
 }
 
 # Recursively copy all the Habitat artifacts of a given version into


### PR DESCRIPTION
The install.sh script expects a signed sha256sum file.  In order to minimize changes to that script as part of our migration to packages.chef.io, we will sign the sha256sum file as part of the upload to s3. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>