### PR TITLE
set BUILD_PKG_TARGET Env variable to fix failed pkg download tests

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -379,6 +379,7 @@ steps:
         docker:
           privileged: true
           environment:
+            - BUILD_PKG_TARGET=x86_64-linux
             - ACCEPTANCE_HAB_AUTH_TOKEN
 
   - wait


### PR DESCRIPTION
This should fix the following BK error:

https://buildkite.com/chef/habitat-sh-habitat-master-end-to-end/builds/203#65d703c6-8202-4a9a-bab7-93239e31f01f/152-158

Signed-off-by: Jeremy J. Miller <jm@chef.io>