### PR TITLE
hab pkg bulkupload origin creation option

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -471,6 +471,24 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .ok_if(&[StatusCode::NO_CONTENT])
     }
 
+    /// Check an origin exists
+    ///
+    ///  # Failures
+    ///
+    ///  * Origin is not found
+    ///  * Remote Builder is not available
+    fn check_origin(&self, origin: &str, token: &str) -> Result<()> {
+        debug!("Checking for existence of origin: {}", origin);
+
+        let path = format!("depot/origins/{}", origin);
+
+        self.0
+            .get(&path)
+            .bearer_auth(token)
+            .send()?
+            .ok_if(&[StatusCode::OK])
+    }
+
     /// Delete an origin
     ///
     ///  # Failures

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -286,6 +286,8 @@ pub trait BuilderAPIProvider: Sync + Send {
 
     fn delete_origin_secret(&self, origin: &str, token: &str, key: &str) -> Result<()>;
 
+    fn check_origin(&self, origin: &str, token: &str) -> Result<()>;
+
     fn delete_origin(&self, origin: &str, token: &str) -> Result<()>;
 
     fn list_origin_secrets(&self, origin: &str, token: &str) -> Result<Vec<String>>;

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -202,6 +202,7 @@ pub enum Status {
     Demoted,
     Demoting,
     Determining,
+    Discovering,
     Downloading,
     DryRunDeleting,
     Encrypting,
@@ -241,6 +242,7 @@ impl Status {
             Status::Demoted => (Glyph::CheckMark, "Demoted".into(), Color::Info),
             Status::Demoting => (Glyph::RightArrow, "Demoting".into(), Color::Info),
             Status::Determining => (Glyph::Cloud, "Determining".into(), Color::Info),
+            Status::Discovering => (Glyph::Cloud, "Discovering".into(), Color::Info),
             Status::Downloading => (Glyph::DownArrow, "Downloading".into(), Color::Info),
             Status::DryRunDeleting => {
                 (Glyph::BoxedX, "Would be deleted (Dry run)".into(), Color::Critical)

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -565,7 +565,10 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                      of the value of this option.")
                 (@arg FORCE: --force "Skip checking availability of package and \
                     force uploads, potentially overwriting a stored copy of a package.")
-                (@arg AUTO_BUILD: --("auto-build") "Enable auto-build for all packages in this upload. Only applicable to SaaS Builder.")
+                (@arg AUTO_BUILD: --("auto-build") "Enable auto-build for all packages in this upload. \
+                    Only applicable to SaaS Builder.")
+                (@arg AUTO_CREATE_ORIGINS: --("auto-create-origins") "Skip the confirmation prompt and \
+                    automatically create origins that do not exist in the target Builder.")
                 (@arg UPLOAD_DIRECTORY: +required {dir_exists}
                     "Directory Path from which artifacts will be uploaded.")
             )

--- a/components/hab/src/command/pkg.rs
+++ b/components/hab/src/command/pkg.rs
@@ -1,5 +1,6 @@
 pub mod binlink;
 pub mod build;
+pub mod bulkupload;
 pub mod channels;
 pub mod delete;
 pub mod demote;

--- a/components/hab/src/command/pkg/bulkupload.rs
+++ b/components/hab/src/command/pkg/bulkupload.rs
@@ -1,0 +1,128 @@
+//! Uploads packages from cache to a [Depot](../depot).
+//!
+//! # Examples
+//!
+//! ```bash
+//! $ hab pkg bulkupload /path/to/artifact_download_dir \
+//!     -u http://localhost:9632
+//! ```
+//!
+//! Will upload all packages in cache to Builder.
+
+use crate::{api_client::{self,
+                         BuildOnUpload,
+                         Client},
+            command,
+            common::ui::{Glyph,
+                         Status,
+                         UIReader,
+                         UIWriter,
+                         UI},
+            error::{Error,
+                    Result},
+            hcore::{package::PackageArchive,
+                    ChannelIdent},
+            PRODUCT,
+            VERSION};
+use glob::glob_with;
+use reqwest::StatusCode;
+use std::{collections::BTreeSet,
+          path::{Path,
+                 PathBuf}};
+
+/// Bulk Upload the packages from the cache to a Depot.
+///
+/// # Failures
+///
+/// * Fails if it cannot create a missing origin
+/// * Fails if it cannot upload the artifact
+#[allow(clippy::too_many_arguments)]
+pub fn start(ui: &mut UI,
+             bldr_url: &str,
+             additional_release_channel: &Option<ChannelIdent>,
+             token: &str,
+             artifact_path: &Path,
+             force_upload: bool,
+             auto_build: BuildOnUpload,
+             auto_create_origins: bool,
+             key_path: &Path)
+             -> Result<()> {
+    const OPTIONS: glob::MatchOptions = glob::MatchOptions { case_sensitive:              true,
+                                                             require_literal_separator:   true,
+                                                             require_literal_leading_dot: true, };
+    let artifact_paths =
+        vec_from_glob_with(&artifact_path.join("*.hart").display().to_string(), OPTIONS);
+
+    ui.begin(format!("Preparing to upload artifacts to the '{}' channel on {}",
+                     additional_release_channel.clone()
+                                               .unwrap_or_else(ChannelIdent::unstable),
+                     bldr_url))?;
+    ui.status(Status::Using,
+              format!("{} for artifacts and {} for signing keys",
+                      &artifact_path.display(),
+                      key_path.display()))?;
+    ui.status(Status::Found,
+              format!("{} artifact(s) for upload.", artifact_paths.len()))?;
+    ui.status(Status::Discovering,
+              String::from("origin names from local artifact cache"))?;
+
+    let mut origins = BTreeSet::new();
+    for artifact_path in &artifact_paths {
+        let ident = PackageArchive::new(&artifact_path).ident()?;
+        origins.insert(ident.origin);
+    }
+    let mut origins_to_create: Vec<String> = Vec::new();
+    let api_client = Client::new(bldr_url, PRODUCT, VERSION, None)?;
+
+    for origin in origins {
+        match api_client.check_origin(&origin, token) {
+            Ok(()) => {
+                ui.status(Status::Custom(Glyph::CheckMark,
+                                         format!("Origin '{}' already exists", &origin)),
+                          String::from(""))?;
+            }
+            Err(api_client::Error::APIError(StatusCode::NOT_FOUND, _)) => {
+                ui.status(Status::Missing, format!("origin '{}'", &origin))?;
+                origins_to_create.push(origin);
+            }
+            Err(err) => return Err(Error::from(err)),
+        }
+    }
+
+    if !origins_to_create.is_empty() {
+        if !auto_create_origins {
+            ui.warn(String::from("Origins are required for uploading the artifacts. The \
+                                  Builder account that creates the origin is the owner."))?;
+            if !ask_create_origins(ui)? {
+                return Ok(());
+            };
+        };
+        for origin_to_create in origins_to_create {
+            command::origin::create::start(ui, &bldr_url, &token, &origin_to_create)?;
+        }
+    };
+
+    for artifact_path in &artifact_paths {
+        command::pkg::upload::start(ui,
+                                    &bldr_url,
+                                    &additional_release_channel,
+                                    &token,
+                                    &artifact_path,
+                                    force_upload,
+                                    auto_build,
+                                    &key_path)?
+    }
+
+    Ok(())
+}
+
+fn vec_from_glob_with(pattern: &str, options: glob::MatchOptions) -> Vec<PathBuf> {
+    glob_with(pattern, options).unwrap()
+                               .map(std::result::Result::unwrap)
+                               .collect()
+}
+
+fn ask_create_origins(ui: &mut UI) -> Result<bool> {
+    Ok(ui.prompt_yes_no("Create the above missing origins under your Builder account?",
+                        Some(true))?)
+}


### PR DESCRIPTION
Closes https://github.com/habitat-sh/habitat/issues/7101

## UX ⚙️ 
```
vagrant@chef-builder:~$ ./hab pkg bulkupload --url https://chef-builder.test --create-origins transfer/
» Preparing to upload artifacts to the 'unstable' channel on https://chef-builder.test
→ Using transfer/artifacts for artifacts and transfer/keys for signing keys.
→ Found 48 artifact(s) for upload.
☁ Discovering origin names from artifact metadata..
✓  chef
✓  core
✓  effortless
→ Found 3 origin(s) that may need to be created.
Ø Your Builder id will own any origin created. Be sure this is what you intend!
Ownership transfer is not yet implemented and will require SQL commands. [Yes/no/quit] 
...
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>