### PR TITLE
Purge CDN on channel promote

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -111,9 +111,14 @@ subscriptions:
   - workload: project_promoted:{{agent_id}}:acceptance:*
     actions:
       - bash:.expeditor/scripts/expeditor_promote.sh
+      - bash:.expeditor/scripts/purge_cdn.sh:
+          post_commit: true
+
   - workload: project_promoted:{{agent_id}}:current:*
     actions:
       - bash:.expeditor/scripts/expeditor_promote.sh
+      - bash:.expeditor/scripts/purge_cdn.sh:
+          post_commit: true
 
 schedules:
   - name: cargo_update

--- a/.expeditor/scripts/buildkite_promote.sh
+++ b/.expeditor/scripts/buildkite_promote.sh
@@ -53,4 +53,12 @@ maybe_run promote_packages_to_builder_channel manifest.json "${destination_chann
 
 version="$(jq -r '.version' < manifest.json)"
 echo "--- Promoting binary packages and manifest to the ${destination_channel} channel in S3"
-maybe run promote_version_in_s3 "${version}" "${destination_channel}"
+maybe_run promote_version_in_s3 "${version}" "${destination_channel}"
+
+echo "--- Purging fastly cache for 'dev' channel"
+# While this is probably not necessary as we generally `hab pkg install` for packages
+# from the 'dev' channel,  we did run into issues with wedged packages as we were 
+# testing the migration to packages.chef.io. Rather than potentially waste hours of 
+# troubleshooting down the road, we'll purge the 'dev' channel at the end of every build.
+maybe_run .expeditor/scripts/purge_cdn.sh
+

--- a/.expeditor/scripts/purge_cdn.sh
+++ b/.expeditor/scripts/purge_cdn.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eou pipefail
+
+target_channel="${EXPEDITOR_TARGET_CHANNEL:-dev}"
+
+echo "Purging '${target_channel}/habitat/latest' Surrogate Key group from Fastly"
+curl -X POST -H "Fastly-Key: $FASTLY_API_TOKEN" "https://api.fastly.com/service/1ga2Kt6KclvVvCeUYJ3MRp/purge/${target_channel}/habitat/latest"
+


### PR DESCRIPTION
When we promote to a channel, we need to purge the fastly cache to ensure that clients pull the correct version.  

Since the mechanism for promote-to-dev is slightly different from other channels, the method for invocation of purge-cdn.sh is also slightly different and it relies on a default value for the channel.  

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>