### PR TITLE
Automatically sync packages need for e2e tests with builder instance

### DIFF
--- a/test/fixtures/plans/Sync-Packages.ps1
+++ b/test/fixtures/plans/Sync-Packages.ps1
@@ -1,0 +1,154 @@
+<#
+
+.SYNOPSIS
+Sync the packages in a specified directory with packages stored in builder
+
+.DESCRIPTION
+Sync-Packages recursivly looks for plan files in `PlansPath. For each plan the following is done:
+
+* Extract the package name and origin from the plan file to determine the package identifier
+* Fetch the last time the package was updated from `<BuilderUrl>/v1/depot/pkgs/<package-identifier>/latest`
+* Compare the most recent write time of files in the plans directory with the packages last update
+  time. If the package update time is more recent, the package is already up to date and we can
+  skip this package.
+* Build the package
+* Install the package
+* Upload the package to `BuilderUrl` with an optional `Channel`
+* Verify that the new package update time is more recent than the file modification time
+
+The packages are built and installed from most to least nested. This allows packages to depend on
+packages that are nested below it.
+
+#>
+
+[CmdletBinding()]
+Param (
+    [string]
+    # The builder URL to upload packages to 
+    $BuilderUrl = "https://bldr.acceptance.habitat.sh",
+    
+    [Parameter(Mandatory = $true)]
+    [string]
+    # The token to authenticate with when accessing the builder instance
+    $BuilderAuthToken,
+    
+    [string]
+    # The channel to tag packages with when uploading
+    $Channel,
+    
+    [Parameter(Mandatory = $true)]
+    [string]
+    # The path to the directory containing the plans to build and to sync with builder
+    $PlansPath
+)
+
+$ErrorActionPreference = "Stop"
+
+###################################################################################################
+
+function Get-PackageUpdateTime {
+    Param([string]$PackageIdentifier)
+
+    $uri = "$($BuilderUrl)/v1/depot/pkgs/$($PackageIdentifier)/latest"
+    $json = try { 
+        (Invoke-WebRequest -Uri $uri -ErrorAction Stop).Content
+    }
+    catch {
+        $statusCode = $_.Exception.Response.StatusCode.value__
+        if ($statusCode -eq 404) {
+            return $null
+        }
+        else {
+            throw("'$($uri)' returned unexpected status code '$($statusCode)'")
+        }
+    } 
+    $packageUpdated = ($json | ConvertFrom-Json).updated_at
+    if (!$packageUpdated) {
+        throw ("No 'updated_at' field found on json")
+    }
+    $packageUpdated
+}
+
+###################################################################################################
+
+# Get the directory containing the plans to build
+$plansDirectory = Get-Item $PlansPath
+
+# Based on OS determine the plan file name
+$planFileName = if ($IsLinux) {
+    "plan.sh"
+}
+elseif ($IsWindows) {
+    "plan.ps1"
+}
+else {
+    $(throw "Must be run on Linux or Windows")
+}
+
+# Get all plan files sorted by most to least nested. We build packages in order
+# of nesting level allowing packages to depend on packages nested under the current level.
+$planFiles = Get-ChildItem -Recurse -Filter $planFileName $plansDirectory |
+    Sort-Object -Descending { $_.FullName.length }
+
+# Directory that stores the built hart files
+$resultsDirectory = Join-Path $plansDirectory results
+
+# Process each plan
+foreach ($planFile in $planFiles) {
+    $directory = $planFile.Directory
+
+    # Get the package identifier by searching the contents of the plan file
+    $matches = (Select-String -Path $planFile -Pattern 'pkg_name="(.+)"').Matches
+    if ($matches.Count -eq 0) {
+        throw ("Unable to find 'pkg_name' in '$($planFile)'")
+    }
+    $packageName = $matches[0].Groups[1].Value
+    $matches = (Select-String -Path $planFile -Pattern 'pkg_origin="(.+)"').Matches
+    if ($matches.Count -eq 0) {
+        throw ("Unable to find 'pkg_origin' in '$($planFile)'")
+    }
+    $packageOrigin = $matches[0].Groups[1].Value
+    $packageIdentifier = "$($packageOrigin)/$($packageName)"
+
+    # Check if this package can be skipped because it is already up to date
+    $directoryModified = (Get-ChildItem -Recurse $directory |
+        Sort-Object LastWriteTime |
+        Select-Object -Last 1).LastWriteTimeUtc
+    $packageUpdated = Get-PackageUpdateTime $packageIdentifier
+    if ($null -ne $packageUpdated -AND $packageUpdated -gt $directoryModified) {
+        Write-Output "Skipping '$($packageIdentifier)' package was last updated '$($packageUpdated.ToString("yyyy-MM-ddTHH:MM:ssZ"))' directory modified '$($directoryModified.ToString("yyyy-MM-ddTHH:MM:ssZ"))'"
+        continue
+    }
+
+    Write-Output "Building plan '$($planFile)' with package identifier '$($packageIdentifier)'"
+
+    # Build the package
+    $contextPath = ($directory.FullName -replace "$($plansDirectory.FullName)").substring(1)
+    $env:HAB_ORIGIN = $packageOrigin
+    hab pkg build --reuse --src $plansDirectory --keys $packageOrigin $contextPath 2>&1 | Out-Null
+
+    # Find the most recently built package
+    $hart = Get-ChildItem -Recurse -Filter *.hart $resultsDirectory |
+        Sort-Object LastWriteTimeUtc |
+        Select-Object -Last 1
+    if (!$hart) {
+        throw ("Failed to find hart file in '$($resultsDirectory)'")
+    }
+
+    # Install the package so other packages can depend on it
+    hab pkg install $hart
+
+    # Upload the package
+    if (!$Channel) {
+        hab pkg upload --url $BuilderUrl --auth $BuilderAuthToken --force $hart
+    }
+    else {
+        hab pkg upload --url $BuilderUrl --auth $BuilderAuthToken --channel $Channel --force $hart
+    }
+
+    # Verify that the package is now up to date
+    $packageUpdated = Get-PackageUpdateTime $packageIdentifier
+    if ($null -eq $packageUpdated -OR $packageUpdated -lt $directoryModified) {
+        throw ("Expected '$($packageIdentifier)' to be up to date! Package was last updated '$($packageUpdated.ToString("yyyy-MM-ddTHH:MM:ssZ"))' directory modified '$($directoryModified.ToString("yyyy-MM-ddTHH:MM:ssZ"))'.")
+    }
+}

--- a/test/fixtures/plans/linux/test1/plan.sh
+++ b/test/fixtures/plans/linux/test1/plan.sh
@@ -1,0 +1,11 @@
+pkg_name="minimal_package_1"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+
+do_build() { :; }
+do_install() { :; }
+
+
+
+

--- a/test/fixtures/plans/linux/test2/test3/plan.sh
+++ b/test/fixtures/plans/linux/test2/test3/plan.sh
@@ -1,0 +1,7 @@
+pkg_name="minimal_package_3"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+
+do_build() { :; }
+do_install() { :; }

--- a/test/fixtures/plans/linux/test2/test3/test4/plan.sh
+++ b/test/fixtures/plans/linux/test2/test3/test4/plan.sh
@@ -1,0 +1,7 @@
+pkg_name="minimal_package_4"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+
+do_build() { :; }
+do_install() { :; }

--- a/test/fixtures/plans/linux/test2/test6/plan.sh
+++ b/test/fixtures/plans/linux/test2/test6/plan.sh
@@ -1,0 +1,7 @@
+pkg_name="minimal_package_6"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+
+do_build() { :; }
+do_install() { :; }


### PR DESCRIPTION
The objective is to make all plans defined in [`test/fixtures/plans`](https://github.com/habitat-sh/habitat/tree/dmcneil/automatically-upload-e2e-test-packages/test/fixtures/plans) available for use in the end-to-end test pipeline. The current plans are just there for testing and will be removed before merging.

The first step is to make a script that can sync the plans in a directory with the packages on a builder instance. This script is defined [here](https://github.com/habitat-sh/habitat/blob/dmcneil/automatically-upload-e2e-test-packages/test/fixtures/plans/Sync-Packages.ps1). Sync-Packages recursively looks for plan files in `PlansPath`. For each plan, the following is done:

* Extract the package name and origin from the plan file to determine the package identifier
* Fetch the last time the package was updated from `<BuilderUrl>/v1/depot/pkgs/<package-identifier>/latest`
* Compare the most recent write time of files in the plan's directory with the packages last update
  time. If the package update time is more recent, the package is already up to date and we can
  skip this package.
* Build the package
* Install the package
* Upload the package to `BuilderUrl` with an optional `Channel`
* Verify that the packages update time is now more recent than the file modification time

The packages are built and installed from most to least nested. This allows packages to depend on
packages that are nested below it.

*Question*: Because the machines running the pipelines are ephemeral, I do not believe we will be able to use the last write time of the files in the package directory to determine if the package is up to date. What should we use? Probably the git history?

**The next step is currently not implemented, waiting to be sure this is the direction we want to go** The next step is to execute this script as part of the [`end_to_end.pipeline.yaml`](https://github.com/habitat-sh/habitat/blob/dmcneil/automatically-upload-e2e-test-packages/.expeditor/end_to_end.pipeline.yml) . This script will be run once on a linux machine and once on a windows machine to build the appropriate packages for each OS. These steps will run before actually executing the end-to-end tests. 

Signed-off-by: David McNeil <mcneil.david2@gmail.com>