### PR TITLE
remove IGNORE_SIGNALS feature

### DIFF
--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -81,7 +81,6 @@ bitflags::bitflags! {
         const TEST_EXIT          = 0b0000_0000_0010;
         const TEST_BOOT_FAIL     = 0b0000_0000_0100;
         const REDACT_HTTP        = 0b0000_0000_1000;
-        const IGNORE_SIGNALS     = 0b0000_0001_0000;
         const OFFLINE_INSTALL    = 0b0000_0100_0000;
         const IGNORE_LOCAL       = 0b0000_1000_0000;
         const EVENT_STREAM       = 0b0001_0000_0000;
@@ -95,7 +94,6 @@ lazy_static! {
                            (FeatureFlag::TEST_EXIT, "HAB_FEAT_TEST_EXIT"),
                            (FeatureFlag::TEST_BOOT_FAIL, "HAB_FEAT_BOOT_FAIL"),
                            (FeatureFlag::REDACT_HTTP, "HAB_FEAT_REDACT_HTTP"),
-                           (FeatureFlag::IGNORE_SIGNALS, "HAB_FEAT_IGNORE_SIGNALS"),
                            (FeatureFlag::OFFLINE_INSTALL, "HAB_FEAT_OFFLINE_INSTALL"),
                            (FeatureFlag::IGNORE_LOCAL, "HAB_FEAT_IGNORE_LOCAL"),
                            (FeatureFlag::EVENT_STREAM, "HAB_FEAT_EVENT_STREAM"),

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -244,18 +244,7 @@ impl Server {
                                            .service(routes())
                              }).workers(thread_count);
 
-            // On Windows the default actix signal handler will create a ctrl+c handler for the
-            // process which will disable default windows ctrl+c behavior and allow us to
-            // handle via check_for_signal in the supervisor service loop. However, if the
-            // supervisor is in a long running non-run hook, that loop will not get to
-            // check_for_signal in a reasonable amount of time and the supervisor will not
-            // respond to ctrl+c. On Windows, we let the launcher catch ctrl+c and gracefully
-            // shut down services. ctrl+c should simply halt the supervisor. The IgnoreSignals
-            // feature is always enabled in the Habitat Windows Service which relies on ctrl+c
-            // signals to stop the supervisor.
-            if feature_flags.contains(FeatureFlag::IGNORE_SIGNALS) {
-                server = server.disable_signals();
-            }
+            server = server.disable_signals();
 
             let bind = match tls_config {
                 Some(c) => server.bind_rustls(listen_addr.to_string(), c),

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -83,15 +83,7 @@ fn main() {
     logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
-    // On Windows initializing the signal handler will create a ctrl+c handler for the
-    // process which will disable default windows ctrl+c behavior and allow us to
-    // handle the signal via pending_shutdown(). Currently the supervisor does not
-    // call pending_shutdown(), effectively ignoring ctrl+c. On Windows, we
-    // let the launcher catch ctrl+c and gracefully shut down services. When IGNORE_SIGNALS is set,
-    // ctrl+c should simply halt the supervisor.
-    if !flags.contains(FeatureFlag::IGNORE_SIGNALS) {
-        signals::init();
-    }
+    signals::init();
 
     let result = start_rsr_imlw_mlw_gsw_smw_rhw_msw(flags);
     let exit_code = match result {

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1006,18 +1006,12 @@ impl Manager {
                 break ShutdownMode::Departed;
             }
 
-            // This formulation is gross, but it doesn't seem to compile on Windows otherwise.
-            #[allow(clippy::match_bool)]
-            #[allow(clippy::single_match)]
             #[cfg(unix)]
-            match self.feature_flags.contains(FeatureFlag::IGNORE_SIGNALS) {
-                false => {
-                    if signals::pending_sighup() {
-                        outputln!("Supervisor shutting down for signal");
-                        break ShutdownMode::Restarting;
-                    }
+            {
+                if signals::pending_sighup() {
+                    outputln!("Supervisor shutting down for signal");
+                    break ShutdownMode::Restarting;
                 }
-                _ => {}
             }
 
             if let Some(package) = self.check_for_updated_supervisor() {

--- a/components/windows-service/App.config
+++ b/components/windows-service/App.config
@@ -6,7 +6,6 @@
     of the windows-service. Use the 'ENV_RUST_LOG' setting instead and set it to 'debug'.
     -->
     <add key="debug" value="false" />
-    <add key="ENV_HAB_FEAT_IGNORE_SIGNALS" value="true" />
     <add key="launcherArgs" value="--no-color" />
   </appSettings>
 </configuration>

--- a/test/end-to-end/test_supervisor_windows_shutdown.ps1
+++ b/test/end-to-end/test_supervisor_windows_shutdown.ps1
@@ -12,6 +12,7 @@ Describe "Clean Habitat Shutdown" {
         try  { Invoke-WebRequest "http://localhost" -Method HEAD -UseBasicParsing }
         catch [System.Net.WebException] { $response = $_.Exception.Response }
         $response.Server | Should -BeLike "nginx/*"
+        Test-Path C:\hab\svc\nginx\PID | Should -Be $true
     }
     It "Stops all processes" {
         Stop-Service Habitat
@@ -19,5 +20,6 @@ Describe "Clean Habitat Shutdown" {
         Get-Process hab-launch -ErrorAction SilentlyContinue | Should -Be $null
         Get-Process pwsh -ErrorAction SilentlyContinue | Should -Be $null
         Get-Process nginx -ErrorAction SilentlyContinue | Should -Be $null
+        Test-Path C:\hab\svc\nginx\PID | Should -Be $false
     }
 }


### PR DESCRIPTION
resolves #5908 

This also adds a e2e test to ensure a service's PID file is removed on shutdown which could not happen when the `IGNORE_SIGNALS` feature is enabled.

Signed-off-by: mwrock <matt@mattwrock.com>