### PR TITLE
Disable build-on-upload for packages in the release pipeline

### DIFF
--- a/.expeditor/scripts/release_habitat/build_component.ps1
+++ b/.expeditor/scripts/release_habitat/build_component.ps1
@@ -60,7 +60,7 @@ Invoke-Expression "$baseHabExe pkg build components\$Component --keys core"
 . results\last_build.ps1
 
 Write-Host "--- Running hab pkg upload for $Component to channel $Channel"
-Invoke-Expression "$baseHabExe pkg upload results\$pkg_artifact --channel=$Channel"
+Invoke-Expression "$baseHabExe pkg upload results\$pkg_artifact --channel=$Channel --no-build"
 Set-TargetMetadata $pkg_ident
 
 Invoke-Expression "buildkite-agent annotate --append --context 'release-manifest' '<br>* ${pkg_ident} (x86_64-windows)'"

--- a/.expeditor/scripts/release_habitat/build_component.sh
+++ b/.expeditor/scripts/release_habitat/build_component.sh
@@ -39,6 +39,7 @@ echo "--- :habicat: Uploading ${pkg_ident:?} to ${HAB_BLDR_URL} in the '${channe
 ${hab_binary} pkg upload \
               --channel="${channel}" \
               --auth="${HAB_AUTH_TOKEN}" \
+              --no-build \
               "results/${pkg_artifact:?}"
 
 echo "<br>* ${pkg_ident:?} (${BUILD_PKG_TARGET:?})" | buildkite-agent annotate --append --context "release-manifest"

--- a/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
+++ b/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
@@ -57,6 +57,7 @@ echo "--- :habicat: Uploading ${pkg_ident:?} to ${HAB_BLDR_URL} in the '${channe
 ${hab_binary} pkg upload \
               --channel="${channel}" \
               --auth="${HAB_AUTH_TOKEN}" \
+              --no-build \
               "results/${pkg_artifact:?}"
 
 echo "<br>* ${pkg_ident} (${BUILD_PKG_TARGET})" | buildkite-agent annotate --append --context "release-manifest"


### PR DESCRIPTION
This disables builds generated by pkg upload from our release pipeline. This prevents double-builds (merge notification from GitHub + pkg upload from pipeline), which would generate unnecessary work on our Builder workers.  

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>