### PR TITLE
filter out dead members when comparing a rolling leader version to followers

### DIFF
--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -245,10 +245,8 @@ impl ServiceUpdater {
                     }
                     LeaderState::Waiting => {
                         match census_ring.census_group_for(&service.service_group) {
-                            Some(census_group) => {
-                                if census_group.members()
-                                               .any(|cm| cm.pkg != census_group.me().unwrap().pkg)
-                                {
+                            Some(cg) => {
+                                if cg.active_members().any(|c| c.pkg != cg.me().unwrap().pkg) {
                                     debug!("Update leader still waiting for followers...");
                                     return None;
                                 }


### PR DESCRIPTION
In a `rolling` update consider this scenario:

- You have a working and updating ring of supervisors.
- You eventually kill off all group members or some followers (Note: things go wrong in different ways when a leader dies and followers remain to be covered in a [different issue](https://github.com/habitat-sh/habitat/issues/7160)).
- You add new members or continue to maintain a working quorum
- The next rolling update will never complete because the leaser looks to see if all followers (alive or dead) have updated.

This changes the final point above to only compare live members.

This arose from #7150 

Signed-off-by: mwrock <matt@mattwrock.com>