### PR TITLE
Trigger finish release pipeline as post_commit action of promotion to current

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -123,7 +123,7 @@ subscriptions:
       - bash:.expeditor/scripts/expeditor_promote.sh
       - bash:.expeditor/scripts/purge_cdn.sh:
           post_commit: true
-      - trigger_pipeline:finish_release
+      - trigger_pipeline:finish_release:
           post_commit: true
 
 schedules:

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -98,6 +98,7 @@ subscriptions:
     actions:
       - trigger_pipeline:test_scenarios
 
+
   # Scheduled Pipelines
   ########################################################################
 
@@ -121,6 +122,8 @@ subscriptions:
       - built_in:rollover_changelog
       - bash:.expeditor/scripts/expeditor_promote.sh
       - bash:.expeditor/scripts/purge_cdn.sh:
+          post_commit: true
+      - trigger_pipeline:finish_release
           post_commit: true
 
 schedules:


### PR DESCRIPTION
When a set of artifacts is promoted to current, there are a number of actions that need to be taken. This wires up our pipeline to start as a post_commit action on the promotion from current.  This pipeline should not start until after the promotion is finished, and only if it succeeds. 

@tduffield   Is this the correct pattern for what I'm trying to accomplish when the pipelines exist in the same repo, or should it subscribe to a workload completed like we did in https://github.com/habitat-sh/homebrew-habitat/blob/master/.expeditor/config.yml#L9

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>