### PR TITLE
Move changelog update back to staged_workload_released

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -51,14 +51,10 @@ subscriptions:
           only_if_team_member:
             - habitat-sh/habitat-core-maintainers
 
-
-  - workload: pull_request_merged:{{agent_id}}:*
-    actions:
-      - built_in:update_changelog
-
   - workload: staged_workload_released:{{agent_id}}:release_staging:*
     actions:
       - built_in:bump_version
+      - built_in:update_changelog
       - trigger_pipeline:release_habitat:
           only_if: built_in:bump_version
 


### PR DESCRIPTION
When working with the staging area, you can't have both it and respond to pull_request_merged. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>