### PR TITLE
Implement toml based file format

### DIFF
--- a/components/common/src/cli.rs
+++ b/components/common/src/cli.rs
@@ -11,7 +11,9 @@ use habitat_core::{env as henv,
                    os::process::{ShutdownSignal,
                                  ShutdownTimeout},
                    package::PackageIdent};
-use std::{path::PathBuf,
+use std::{ffi::OsStr,
+          path::{Path,
+                 PathBuf},
           str::FromStr};
 
 pub const RING_ENVVAR: &str = "HAB_RING";
@@ -82,6 +84,16 @@ pub fn cache_key_path_from_matches(matches: &ArgMatches<'_>) -> PathBuf {
     {
         CACHE_KEY_PATH => cache_key_path(Some(&*FS_ROOT)),
         val => PathBuf::from(val),
+    }
+}
+
+pub fn is_toml_file(val: &str) -> bool {
+    let extension = Path::new(&val).extension().and_then(OsStr::to_str);
+    match extension {
+        // We could do some more validation (parse the whole toml file and check it) but that seems
+        // excessive.
+        Some("toml") => true,
+        _ => false,
     }
 }
 

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -55,6 +55,7 @@ pub enum Error {
     NameLookup,
     NetErr(net::NetErr),
     PackageArchiveMalformed(String),
+    PackageSetParseError(String),
     ParseIntError(num::ParseIntError),
     PathPrefixError(path::StripPrefixError),
     ProvidesError(String),
@@ -156,6 +157,9 @@ impl fmt::Display for Error {
             Error::PackageArchiveMalformed(ref e) => {
                 format!("Package archive was unreadable or contained unexpected contents: {:?}",
                         e)
+            }
+            Error::PackageSetParseError(ref e) => {
+                format!("Package set file could not be parsed: {:?}", e)
             }
             Error::ParseIntError(ref err) => format!("{}", err),
             Error::PathPrefixError(ref err) => format!("{}", err),

--- a/test/end-to-end/fixtures/pkg_download/bad_header.toml
+++ b/test/end-to-end/fixtures/pkg_download/bad_header.toml
@@ -1,0 +1,16 @@
+this_is_garbage=true
+
+# option 1,
+# complex, target first
+[[x86_64-linux]]
+channel = "stable"
+packages = ["core/gzip", "core/grep/3.1", "core/redis/4.0.14/20190319155852"]
+
+[[x86_64-linux]]
+channel = "unstable"
+packages = ["chef/chef-client", "chef/inspec/4.18.30/20191107165916"]
+
+[[x86_64-windows]]
+channel = "stable"
+packages = ["effortless/audit-baseline"]
+

--- a/test/end-to-end/fixtures/pkg_download/bad_ident.toml
+++ b/test/end-to-end/fixtures/pkg_download/bad_ident.toml
@@ -1,0 +1,9 @@
+format_version = 1
+file_descriptor = "fooa"
+
+# option 1,
+# complex, target first
+[[x86_64-windows]]
+channel = "stable"
+packages = ["effortless/audit-baseline/not/a/real/ident"]
+

--- a/test/end-to-end/fixtures/pkg_download/bad_target.toml
+++ b/test/end-to-end/fixtures/pkg_download/bad_target.toml
@@ -1,0 +1,9 @@
+format_version = 1
+file_descriptor = "fooa"
+
+# we do not support PDP 11 builds. Be thankful.
+[[pdp11-ultrix]]
+channel = "stable"
+packages = ["core/gzip", "core/grep/3.1", "core/redis/4.0.14/20190319155852"]
+
+

--- a/test/end-to-end/fixtures/pkg_download/happy_path.toml
+++ b/test/end-to-end/fixtures/pkg_download/happy_path.toml
@@ -1,0 +1,17 @@
+format_version = 1
+file_descriptor = "fooa"
+
+# option 1,
+# complex, target first
+[[x86_64-linux]]
+channel = "stable"
+packages = ["core/gzip", "core/grep/3.1", "core/redis/4.0.14/20190319155852"]
+
+[[x86_64-linux]]
+channel = "unstable"
+packages = ["chef/chef-client", "chef/inspec/4.18.30/20191107165916"]
+
+[[x86_64-windows]]
+channel = "stable"
+packages = ["effortless/audit-baseline"]
+

--- a/test/end-to-end/fixtures/pkg_download/no_header.toml
+++ b/test/end-to-end/fixtures/pkg_download/no_header.toml
@@ -1,0 +1,14 @@
+# option 1,
+# complex, target first
+[[x86_64-linux]]
+channel = "stable"
+packages = ["core/gzip", "core/grep/3.1", "core/redis/4.0.14/20190319155852"]
+
+[[x86_64-linux]]
+channel = "unstable"
+packages = ["chef/chef-client", "chef/inspec/4.18.30/20191107165916"]
+
+[[x86_64-windows]]
+channel = "stable"
+packages = ["effortless/audit-baseline"]
+

--- a/test/end-to-end/fixtures/pkg_download/no_target.toml
+++ b/test/end-to-end/fixtures/pkg_download/no_target.toml
@@ -1,0 +1,3 @@
+format_version = 1
+file_descriptor = "fooa"
+

--- a/test/end-to-end/test_pkg_download.sh
+++ b/test/end-to-end/test_pkg_download.sh
@@ -18,12 +18,19 @@ set -euo pipefail
 #
 # Uses the `HAB_INTERNAL_BLDR_CHANNEL` environment variable to control
 # the base packages channel for the exporter.
+#
+# Developers most likely want to run:
+# HAB_TEST_CMD=./target/debug/hab test/end-to-end/test_pkg_download.sh
+#
 HAB=${HAB_TEST_CMD:-hab}
 CACHE_DIR="test-cache"
 IDENT_FILE="ident_file"
+SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+FIXTURES="${SCRIPT_DIR}/fixtures/pkg_download"
 
 echo
 echo "--- Testing with command ${HAB}, using cache dir ${CACHE_DIR}"
+echo "--- Using fixtures from ${FIXTURES}"
 echo
 
 before_test() {
@@ -79,6 +86,20 @@ check_rust_idents() {
 	echo "FAIL $CMD"
     fi
 }
+
+check_count_idents() {
+    expected=$1
+
+    count=$(find "${CACHE_DIR}/artifacts" -type f | wc -l)
+
+    echo "found $count downloads"
+    if [ "$count" -ge "$expected" ]; then
+	echo "PASS $CMD"
+    else
+	echo "FAIL $CMD"
+    fi
+}
+
 
 # desc cmd
 test_expecting_fail() {
@@ -219,8 +240,63 @@ bad_channel() {
     test_expecting_fail "Bad channel" "$CMD"
 }
 
+# toml tests
+toml_success_happy_path() {
+    before_test
 
-# functional tests
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${FIXTURES}/happy_path.toml"
+    echo "Testing command line: ${CMD}"
+    ${CMD}
+}
+
+toml_success_no_header() {
+    before_test
+
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${FIXTURES}/no_header.toml"
+    
+    echo "Testing command line: ${CMD}"
+    ${CMD}
+}
+
+toml_bad_header() {
+    before_test
+
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${FIXTURES}/bad_header.toml"
+
+    # note the message here is a little deceptive
+    #  Failed to parse TOML: string cannot be parsed: "this_is_garbage" (Invalid package target: this_is_garbage. A valid target is in the form architecture-platform (example: x86_64-linux)) at line 13 column 1
+    # the problem isn't actually it's an invalid target, but the TOML format doesn't let us distinquish that.
+    test_expecting_fail "Failed to parse TOML:" "$CMD"
+}
+
+toml_bad_ident() {
+    before_test
+
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${FIXTURES}/bad_ident.toml"
+	  
+    test_expecting_fail "Invalid package identifier:" "$CMD"
+}
+
+toml_bad_target() {
+    before_test
+
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${FIXTURES}/bad_target.toml"
+	  
+    test_expecting_fail "Failed to parse TOML:" "$CMD"
+}
+
+toml_no_target() {
+    before_test
+
+    CMD="$HAB pkg download --download-directory=${CACHE_DIR} --file=${FIXTURES}/no_target.toml"
+	  
+    test_expecting_fail "No package identifers provided." "$CMD"
+
+}
+
+
+
+# Functional tests
 success_from_command_line
 success_from_file
 success_from_file_with_comments_and_emtpy_lines
@@ -238,3 +314,13 @@ bad_target
 bad_token
 bad_url
 bad_channel
+ 
+# toml tests
+toml_success_happy_path
+toml_success_no_header
+
+toml_bad_header
+toml_bad_ident
+toml_bad_target
+toml_no_target
+

--- a/test/end-to-end/test_pkg_download.sh
+++ b/test/end-to-end/test_pkg_download.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 HAB=${HAB_TEST_CMD:-hab}
 CACHE_DIR="test-cache"
 IDENT_FILE="ident_file"
-SCRIPT_DIR=$(dirname ${BASH_SOURCE[0]})
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 FIXTURES="${SCRIPT_DIR}/fixtures/pkg_download"
 
 echo


### PR DESCRIPTION
This is a first cut of the toml file format proposed in issue #7162

Ideally this would be implemented via TOML deserialization into a rust
data structure, but I couldn't get that to work, because of issues
with the keys being 'PackageTarget' structures. I'll make another go
at it, perhaps with an intermediate structure that matches the file
structure better, but I thought this might be worthwhile for UX review
and the like.

```
format_version = 1
file_descriptor = "user specified data"

[["x86_64-linux"]]
channel = "stable"
packages = ["core/foo", "core/bar/3.2", "core/baz/2.71/20190910181446"]

[["x86_64-linux"]]
channel = "unstable"
packages = ["core/crazypants", "core/cliffs_of_insanity/0.0.1/20191010181446"]

[["x86_64-windows"]]
channel = "stable"
packages = ["effortless/audit-baseline"]
```

Signed-off-by: Mark Anderson <mark@chef.io>