### PR TITLE
sup: remove palaver dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,7 +1383,6 @@ dependencies = [
  "nats 0.3.2 (git+https://github.com/habitat-sh/rust-nats?rev=a4c24be66fc54c0038af383b6df18d2ed0b5f376)",
  "notify 4.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "palaver 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1843,14 +1842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,18 +2020,6 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "nix"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2054,11 +2033,6 @@ dependencies = [
 [[package]]
 name = "nodrop"
 version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "nom"
-version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2190,22 +2164,6 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "palaver"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "procinfo 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2390,17 +2348,6 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "procinfo"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4141,7 +4088,6 @@ dependencies = [
 "checksum log-mdc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 "checksum log4rs 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "100052474df98158c0738a7d3f4249c99978490178b5f9f68cd835ac57adbd1b"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-"checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum md5 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
@@ -4161,10 +4107,8 @@ dependencies = [
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum nats 0.3.2 (git+https://github.com/habitat-sh/rust-nats?rev=a4c24be66fc54c0038af383b6df18d2ed0b5f376)" = "<none>"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
-"checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
 "checksum nodrop 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-"checksum nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
 "checksum notify 4.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1191efa2b8fe041decb55c238a125b7a1aeb6fad7a525133a02be5ec949ff3cb"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
@@ -4178,7 +4122,6 @@ dependencies = [
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
 "checksum os_info 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "81a01a9164e198a0949a491ca372e512ef769887c97a8d7ae8ff4cc46db07cfe"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum palaver 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "506302e99b606a2e34473b24570e4461ade973842ffd57de665f1a9bece98510"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
@@ -4200,7 +4143,6 @@ dependencies = [
 "checksum proc-macro-hack 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "114cdf1f426eb7f550f01af5f53a33c0946156f6814aec939b3bd77e844f9a9d"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90cf5f418035b98e655e9cdb225047638296b862b42411c4e45bb88d700f7fc0"
-"checksum procinfo 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6ab1427f3d2635891f842892dda177883dca0639e05fe66796a62c9d2f23b49c"
 "checksum prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
 "checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
 "checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -31,11 +31,7 @@ habitat_http_client = { path = "../http-client" }
 habitat-launcher-client = { path = "../launcher-client" }
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 lazy_static = "*"
-# Temporarily pin libc. The palaver crate uses the shorthand for semver compatible updates,
-# but the libc crate changed the types of some of the consts and functions it provides.
-# This pin can be removed once a release with https://github.com/alecmocatta/palaver/pull/15
-# and https://github.com/alecmocatta/palaver/pull/16 merged is made.
-libc = "= 0.2.54" 
+libc = "*"
 log = "*"
 log4rs = "*"
 nats = { git = "https://github.com/habitat-sh/rust-nats", rev = "a4c24be66fc54c0038af383b6df18d2ed0b5f376" }
@@ -70,8 +66,6 @@ valico = "*"
 caps = "*"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-# palaver's default features require nightly; see https://github.com/alecmocatta/palaver/blob/master/Cargo.toml
-palaver = { version = "*", default-features = false }
 jemallocator = "*"
 jemalloc-ctl = "*"
 

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -35,8 +35,6 @@ extern crate lazy_static;
 extern crate log;
 extern crate notify;
 extern crate num_cpus;
-#[cfg(unix)]
-extern crate palaver;
 #[macro_use]
 extern crate prometheus;
 extern crate prost;

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1859,9 +1859,7 @@ const FD_DIR: &str = "/proc/self/fd";
 const FD_DIR: &str = "/dev/fd";
 
 #[cfg(unix)]
-fn get_fd_count() -> std::io::Result<usize> {
-    Ok(fs::read_dir(FD_DIR)?.count())
-}
+fn get_fd_count() -> std::io::Result<usize> { Ok(fs::read_dir(FD_DIR)?.count()) }
 
 #[cfg(unix)]
 fn track_memory_stats() {

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -78,8 +78,6 @@ use habitat_launcher_client::{LauncherCli,
                               LAUNCHER_PID_ENV};
 use habitat_sup_protocol;
 use num_cpus;
-#[cfg(unix)]
-use palaver;
 use prometheus::{HistogramVec,
                  IntGauge,
                  IntGaugeVec};
@@ -1854,9 +1852,15 @@ fn get_fd_count() -> std::io::Result<usize> {
     }
 }
 
+// Assume we have /proc/self/fd unless we know we don't
+#[cfg(not(any(target_os = "freebsd", target_os = "macos", target_os = "ios")))]
+const FD_DIR: &str = "/proc/self/fd";
+#[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
+const FD_DIR: &str = "/dev/fd";
+
 #[cfg(unix)]
 fn get_fd_count() -> std::io::Result<usize> {
-    palaver::file::FdIter::new().map(palaver::file::FdIter::count)
+    Ok(fs::read_dir(FD_DIR)?.count())
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
I noticed a comment in Cargo.toml regarding a pin on the libc
crate. When investigating whether we could fix that, I found that we
were only using this dependency to get the count of open FDs.

I've implemented get_fd_count directly and removed the dep.

Signed-off-by: Steven Danna <steve@chef.io>