### PR TITLE
make: fix fmt target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,9 +213,10 @@ clean-$1: image ## cleans the $1 component's project tree
 endef
 $(foreach component,$(ALL),$(eval $(call CLEAN,$(component))))
 
+RUSTFMT_TOOLCHAIN := $(shell cat RUSTFMT_VERSION)
 define FMT
 fmt-$1: image ## formats the $1 component
-	$(run) sh -c 'cd components/$1 && cargo fmt'
+	$(run) sh -c 'cd components/$1 && cargo +$(RUSTFMT_TOOLCHAIN) fmt'
 .PHONY: fmt-$1
 
 endef


### PR DESCRIPTION
Without this the `fmt` target uses whatever toolchain happens to be
active, which might yield substantially different formatting.

Signed-off-by: Steven Danna <steve@chef.io>