### PR TITLE
[CI] Add "staging" area into our promotion scheme for manual testing

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -106,10 +106,14 @@ subscriptions:
 
   # Promotion Workloads
   ########################################################################
-  # Only allow promotion actions from acceptance (to current) and
-  # current (to stable); other promotions are handled automatically by
-  # the pipeline.
+  # Only allow promotion actions from acceptance->staging,
+  # staging->current, and current->stable; other promotions are
+  # handled automatically by the pipeline.
   - workload: project_promoted:{{agent_id}}:acceptance:*
+    actions:
+      - bash:.expeditor/scripts/expeditor_promote.sh
+
+  - workload: project_promoted:{{agent_id}}:staging:*
     actions:
       - bash:.expeditor/scripts/expeditor_promote.sh
 
@@ -138,6 +142,9 @@ promote:
     - dev
     # acceptance Builder Supervisors update from here
     - acceptance
+    # stable "holding area" for us to perform manual evaluations. This
+    # is only really until we have automated more of our testing.
+    - staging
     # prod Builder Supervisors update from here
     - current
     # Habitat packages in stable, binary packages available to the world


### PR DESCRIPTION
Currently, packages are promoted into `acceptance` automatically after
passing automated end-to-end tests. After that, they are manually
promoted to `current`, where they are consumed by our production
Builder instance.

This poses a problem for the remaining end-to-end testing we do that
is manual. Since promotion into `acceptance` is automated, there's
nothing that would stop a new set of packages from entering
`acceptance` halfway through your manual evaluation. Since there would
be no easy way to "reset" the system to continue to use the packages
you were evaluating, you'd need to start your evaluation over again
with the new packages. This could keep happening repeatedly, in
principle.

Here, we add a new `staging` channel that sits between `acceptance`
and `current`, which is gated by a manual promotion event. When we
want to perform manual evaluation of a set of packages, we manually
promote whatever is in `acceptance` and then evaluate those
packages. Since the promotion is manual, you no longer need to worry
about new packages coming in during your evaluation. Once the
evaluation is done, the packages can be promoted to `current`,
ensuring that only fully tested packages are consumed by our
production Builder instances.

As we automate more tests, this `staging` area may become less
important. For now, however, it will provide us the safety and
convenience we need.

Signed-off-by: Christopher Maier <cmaier@chef.io>