### PR TITLE
Use HAB_BLDR_URL in hab pkg download

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -936,7 +936,7 @@ fn sub_pkg_download() -> App<'static, 'static> {
     let sub = clap_app!(@subcommand download =>
     (about: "Download Habitat artifacts (including dependencies and keys) from Builder")
     (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
-    (@arg BLDR_URL: --url -u +takes_value {valid_url} default_value(habitat_core::url::DEFAULT_BLDR_URL)
+    (@arg BLDR_URL: --url -u +takes_value {valid_url}
         "Specify an alternate Builder endpoint. If not specified, the value will \
          be taken from the HAB_BLDR_URL environment variable if defined.")
     (@arg CHANNEL: --channel -c +takes_value default_value[stable] env(ChannelIdent::ENVVAR)


### PR DESCRIPTION
Resolves #7084

[`bldr_url_from_matches`](https://github.com/habitat-sh/habitat/blob/8a8677f535daab497c1e2b8472d1f0458207cfb5/components/hab/src/main.rs#L1545) does the right thing so remove the explicit default value.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>