### PR TITLE
[CI] Remove `ignore_labels` from Expeditor config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -53,9 +53,7 @@ subscriptions:
 
   - workload: staged_workload_released:{{agent_id}}:release_staging:*
     actions:
-      - built_in:bump_version:
-          ignore_labels:
-            - "Expeditor: Skip Version Bump"
+      - built_in:bump_version
       - built_in:update_changelog
       - trigger_pipeline:release_habitat:
           only_if: built_in:bump_version


### PR DESCRIPTION
Due to internal implementation details, the use of `ignore_labels` is
not supported with the composite workloads that can be generated while
waiting for a staging environment to be unlocked.

As a result, we should just remove this configuration altogether.

Signed-off-by: Christopher Maier <cmaier@chef.io>