### PR TITLE
[CI] Remove changelog rollover automation

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -22,7 +22,6 @@ changelog:
     - "X-change": "Behavioral Changes"
     - "X-feature": "New Features & Enhancements"
     - "X-fix": "Bug Fixes"
-  rollup_header: Changes not yet released to stable
 
 pipelines:
   - verify:
@@ -117,7 +116,6 @@ subscriptions:
 
   - workload: project_promoted:{{agent_id}}:current:*
     actions:
-      - built_in:rollover_changelog
       - bash:.expeditor/scripts/expeditor_promote.sh
       # This purges the cache on promotion to stable, so our
       # "curlbash" installers get the right packages. This isn't


### PR DESCRIPTION
It turns out that we can't use Expeditor's built-in changelog rollover
logic right now.

As a workaround, we'll remove the automation hooks and manually
perform the rollover after a release.

Signed-off-by: Christopher Maier <cmaier@chef.io>