### PR TITLE
[CI] Sign files using `gpg --yes`

### DIFF
--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -70,10 +70,15 @@ import_gpg_keys() {
 # `*.asc` signature in the same directory as `file`.
 gpg_sign() {
     local file="${1}"
+
+    # Adding the `--yes` option here because we've seen cases where an
+    # *.asc file is already present somehow, even though that _should_
+    # be impossible.
     gpg --armor \
         --digest-algo sha256 \
         --default-key "${chef_gpg_key}" \
         --output "${file}.asc" \
+        --yes \
         --detach-sign \
         "${file}"
 }


### PR DESCRIPTION
We've seen intermittent failures to upload `manifest.json` files
because when we go to sign it, `gpg` says there's already a
`manifest.json.asc` file present, and asks whether we want to
overwrite it or not. As it's a tiny bit tricky to get STDIN in a
Buildkite stage, the stage ends up timing out.

Here, we simply add the `--yes` option, to automatically answer such
questions in the affirmative.

I'm not exactly sure how a `manifest.json.asc` could be present in a
clean runner, though.

Signed-off-by: Christopher Maier <cmaier@chef.io>