### PR TITLE
[CI] Don't install `core/rust` in Windows test steps

### DIFF
--- a/.expeditor/scripts/verify/shared.ps1
+++ b/.expeditor/scripts/verify/shared.ps1
@@ -28,8 +28,6 @@ function Setup-Environment {
       "core/zeromq",
       "core/zlib"
   )
-  # we always want the latest rust
-  hab pkg install core/rust
 
   # Set up some path variables for ease of use later
   $cacertsDir     = & hab pkg path core/cacerts


### PR DESCRIPTION
We're using `rustup`, not `core/rust`.

Signed-off-by: Christopher Maier <cmaier@chef.io>