### PR TITLE
Fix lock when spawning windows processes

### DIFF
--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -249,7 +249,14 @@ impl Child {
         //
         // For more information, msdn also has an article about this race:
         // http://support.microsoft.com/kb/315939
-        let _ = CREATE_PROCESS_LOCK.lock().unwrap();
+        //
+        // The Rust standard library uses a similar lock[1] when spawning a process. Race
+        // conditions can easily occur because these two implementations do not share the same
+        // lock. We should be careful that spawning processes using the standard library and our
+        // custom implementation never occur simultaneously.
+        //
+        // [1] https://github.com/rust-lang/rust/blob/1bd30ce2aac40c7698aa4a1b9520aa649ff2d1c5/src/libstd/sys/windows/process.rs#L179
+        let _lock = CREATE_PROCESS_LOCK.lock().unwrap();
 
         let mut pipes = StdioPipes { stdin:  None,
                                      stdout: None,


### PR DESCRIPTION
Resolves #7136

This is a very subtle bug where binding a variable with `_` has different semantics than with `_some_variable_name`. In fact , `_` does not actually bind the variable. This causes the lifetime of the variable to only exist for the single expression instead of the entire lexical scope. See discussion of the topic [here](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html?highlight=underscore#ignoring-an-unused-variable-by-starting-its-name-with-_). This caused the lock to effectively be nonexistent,

Having two implementations for spawning a windows' child process with two distinct locks could easily lead to future race conditions. Here is a listing of places where we spawn a process on windows using the standard library:

* [components/common/src/templating/hooks.rs #L804](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/common/src/templating/hooks.rs#L804)
* [components/common/src/ui.rs #L602](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/common/src/ui.rs#L602)
* [components/hab/src/command/studio/docker.rs #L177](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/hab/src/command/studio/docker.rs#L177)
* [components/launcher/src/server.rs #L593](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/launcher/src/server.rs#L593)
* [components/pkg-export-docker/src/docker.rs #L89](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/pkg-export-docker/src/docker.rs#L89)
* [components/pkg-export-docker/src/docker.rs #L255](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/pkg-export-docker/src/docker.rs#L255)
[components/pkg-export-docker/src/docker.rs #L273](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/pkg-export-docker/src/docker.rs#L273)
* [components/pkg-export-helm/src/deps.rs #L52](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/pkg-export-helm/src/deps.rs#L52)
* [components/pkg-export-helm/src/deps.rs #L68](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/pkg-export-helm/src/deps.rs#L68)
* [components/sup/tests/utils/test_sup.rs #L242](https://github.com/habitat-sh/habitat/blob/18c9b8f204e8537f90343cc013d5e6a9c56f776b/components/sup/tests/utils/test_sup.rs#L242)

At the very least, we should be sure none of these can occur when the main supervisor loop is running, These all looked ok to me, but reviewers corroborating that claim would be great.

More robust solutions:
1. In a windows context only use our custom spawn
2. Expose the lock publicly and lock it when spawning processes with the standard library
3. Draft and implement an RFC for the Rust standard libary adding the ability to spawn a windows process as a particular user. This would negate the need for our custom implementation. I realize this is considerable effort and is probably untenable, but it feels like the "right" solution so I thought I would add it. 

Signed-off-by: David McNeil <mcneil.david2@gmail.com>