### PR TITLE
Add PIDS_FROM_LAUNCHER feature to eliminate service PID files

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -435,6 +435,33 @@ steps:
             - BUILD_PKG_TARGET=x86_64-windows
             - BUILDKITE_AGENT_ACCESS_TOKEN
 
+  - label: "[:linux: test PIDS_FROM_LAUNCHER feature]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh dev
+      - test/end-to-end/test_PIDS_FROM_LAUNCHER_feature.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+
+  - label: "[:linux: test PIDS_FROM_LAUNCHER feature with old Launcher]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh dev
+      - test/end-to-end/test_PIDS_FROM_LAUNCHER_feature_old_launcher.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+
+  - label: "[:linux: test PIDS_FROM_LAUNCHER disabled]"
+    command:
+      - .expeditor/scripts/end_to_end/setup_environment.sh dev
+      - test/end-to-end/test_PIDS_FROM_LAUNCHER_feature_old_launcher_disabled.sh
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+
   - wait
 
   - label: "[:habicat: Promote to Acceptance]"

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -77,14 +77,18 @@ bitflags::bitflags! {
     /// environment variable to which it corresponds in the `ENV_VARS`
     /// map below.
     pub struct FeatureFlag: u32 {
-        const LIST               = 0b0000_0000_0001;
-        const TEST_EXIT          = 0b0000_0000_0010;
-        const TEST_BOOT_FAIL     = 0b0000_0000_0100;
-        const REDACT_HTTP        = 0b0000_0000_1000;
-        const OFFLINE_INSTALL    = 0b0000_0100_0000;
-        const IGNORE_LOCAL       = 0b0000_1000_0000;
-        const EVENT_STREAM       = 0b0001_0000_0000;
-        const TRIGGER_ELECTION   = 0b0010_0000_0000;
+        const LIST                 = 0b0000_0000_0001;
+        const TEST_EXIT            = 0b0000_0000_0010;
+        const TEST_BOOT_FAIL       = 0b0000_0000_0100;
+        const REDACT_HTTP          = 0b0000_0000_1000;
+        const OFFLINE_INSTALL      = 0b0000_0100_0000;
+        const IGNORE_LOCAL         = 0b0000_1000_0000;
+        const EVENT_STREAM         = 0b0001_0000_0000;
+        const TRIGGER_ELECTION     = 0b0010_0000_0000;
+        /// Ask the Launcher for the PID of supervised services,
+        /// rather than reading it from a file on disk. It's easy for
+        /// file contents to become out-of-sync with reality.
+        const PIDS_FROM_LAUNCHER = 0b0100_0000_0000;
     }
 }
 
@@ -97,7 +101,8 @@ lazy_static! {
                            (FeatureFlag::OFFLINE_INSTALL, "HAB_FEAT_OFFLINE_INSTALL"),
                            (FeatureFlag::IGNORE_LOCAL, "HAB_FEAT_IGNORE_LOCAL"),
                            (FeatureFlag::EVENT_STREAM, "HAB_FEAT_EVENT_STREAM"),
-                           (FeatureFlag::TRIGGER_ELECTION, "HAB_FEAT_TRIGGER_ELECTION")];
+                           (FeatureFlag::TRIGGER_ELECTION, "HAB_FEAT_TRIGGER_ELECTION"),
+                           (FeatureFlag::PIDS_FROM_LAUNCHER, "HAB_FEAT_PIDS_FROM_LAUNCHER"),];
         HashMap::from_iter(mapping)
     };
 }

--- a/components/launcher-client/src/client.rs
+++ b/components/launcher-client/src/client.rs
@@ -155,6 +155,18 @@ impl LauncherCli {
         Ok(reply.pid as Pid)
     }
 
+    /// Query the launcher for the PID of the named service. If the
+    /// Launcher is aware of it, you'll get `Ok(Some(Pid))`
+    pub fn pid_of(&self, service_name: &str) -> Result<Option<Pid>> {
+        let msg = protocol::PidOf { service_name: service_name.to_string(), };
+        Self::send(&self.tx, &msg)?;
+        let reply = Self::recv::<protocol::PidIs>(&self.rx)?;
+        match reply.pid {
+            Some(pid) => Ok(Some(pid as Pid)),
+            None => Ok(None),
+        }
+    }
+
     pub fn terminate(&self, pid: Pid) -> Result<i32> {
         let msg = protocol::Terminate { pid: pid.into() };
         Self::send(&self.tx, &msg)?;

--- a/components/launcher-client/src/client.rs
+++ b/components/launcher-client/src/client.rs
@@ -9,11 +9,24 @@ use ipc_channel::ipc::{IpcOneShotServer,
                        IpcSender};
 use std::{collections::BTreeMap,
           io,
-          path::Path};
+          path::Path,
+          thread,
+          time::{Duration,
+                 Instant}};
 
 type Env = BTreeMap<String, String>;
 type IpcServer = IpcOneShotServer<Vec<u8>>;
 
+// Defines how long to wait to receive a reply from the Launcher.
+//
+// Initially used for calls to get the PID from a service as a way to
+// deal with older Launchers that don't know about that protocol
+// message, and don't reply back on unknown messages.
+//
+// Don't override this value unless you know what you're doing.
+habitat_core::env_config_duration!(LauncherInteractionTimeout,
+                                   HAB_LAUNCHER_INTERACTION_TIMEOUT_MS => from_millis,
+                                   Duration::from_millis(1000));
 pub struct LauncherCli {
     tx: IpcSender<Vec<u8>>,
     rx: IpcReceiver<Vec<u8>>,
@@ -23,6 +36,9 @@ pub struct LauncherCli {
     // wraps the pipe in a WinHandle whose drop impl calls CloseHandle.
     #[cfg(not(windows))]
     pipe: String,
+
+    /// Maximum wait time for interactions that can timeout.
+    timeout: Duration,
 }
 
 #[cfg(not(windows))]
@@ -46,10 +62,14 @@ impl LauncherCli {
         Self::send(&tx, &cmd)?;
         let (rx, raw) = ipc_srv.accept().map_err(|_| Error::AcceptConn)?;
         Self::read::<protocol::NetOk>(&raw)?;
+
+        let timeout = LauncherInteractionTimeout::configured_value().into();
+
         Ok(LauncherCli { tx,
                          rx,
                          #[cfg(not(windows))]
-                         pipe: pipe_to_sup })
+                         pipe: pipe_to_sup,
+                         timeout })
     }
 
     /// Read a launcher protocol message from a byte array
@@ -72,6 +92,46 @@ impl LauncherCli {
         match rx.recv() {
             Ok(bytes) => Self::read(&bytes),
             Err(err) => Err(Error::from(*err)),
+        }
+    }
+
+    /// EXPERIMENTAL! BEWARE! EXPERIMENTAL!
+    ///
+    /// When this was added, we needed a way for a Supervisor to be
+    /// able to recover from sending a message to an older version of
+    /// the Launcher that didn't know how to process that message. At
+    /// the time, the Launcher would just ignore the message, but we
+    /// always use a `recv` to wait for the response, so the
+    /// Supervisor would hang.
+    ///
+    /// This function is an attempt to get around this situation, but
+    /// ONLY for the specific scenarios where it is appropriate. I am
+    /// hesitant to introduce a global timeout at this point, because
+    /// it's difficult to know how that will affect the overall
+    /// interactions between the Supervisor and the Launcher (it
+    /// *should* be fine, but I can't guarantee that right now).
+    ///
+    /// As such, use this with caution and intention.
+    fn recv_timeout<T>(rx: &IpcReceiver<Vec<u8>>, timeout: Duration) -> Result<T>
+        where T: protocol::LauncherMessage
+    {
+        // If ipc_channel implemented this directly, we wouldn't have
+        // to do this :(
+        let timeout = Instant::now() + timeout;
+        loop {
+            match rx.try_recv().map_err(|e| Error::from(*e)) {
+                Ok(bytes) => return Self::read(&bytes),
+                Err(Error::IPCIO(io::ErrorKind::WouldBlock)) => {
+                    trace!("try_recv would block; waiting 5ms");
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Err(err) => {
+                    return Err(err);
+                }
+            }
+            if Instant::now() > timeout {
+                return Err(Error::Timeout);
+            }
         }
     }
 
@@ -160,7 +220,14 @@ impl LauncherCli {
     pub fn pid_of(&self, service_name: &str) -> Result<Option<Pid>> {
         let msg = protocol::PidOf { service_name: service_name.to_string(), };
         Self::send(&self.tx, &msg)?;
-        let reply = Self::recv::<protocol::PidIs>(&self.rx)?;
+        // This should be a recv_timeout until pidfile-less
+        // supervisors are the norm. We only expect to not receive a
+        // response when dealing with older Launchers that didn't know
+        // how to return PIDs.
+        let reply = Self::recv_timeout::<protocol::PidIs>(&self.rx, self.timeout)?;
+        // TODO (CM): really, we need to have all our protocol types
+        // that use pids actually use a Pid type that's nonzero, with
+        // lots of descriptive errors for failures.
         match reply.pid {
             Some(pid) => Ok(Some(pid as Pid)),
             None => Ok(None),

--- a/components/launcher-client/src/error.rs
+++ b/components/launcher-client/src/error.rs
@@ -14,6 +14,7 @@ pub enum Error {
     IPCIO(io::ErrorKind),
     Protocol(protocol::Error),
     Send(ipc_channel::Error),
+    Timeout,
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -30,6 +31,7 @@ impl fmt::Display for Error {
             Error::IPCIO(ref e) => format!("Unable to receive message from Launcher, {:?}", e),
             Error::Protocol(ref e) => format!("{}", e),
             Error::Send(ref e) => format!("Unable to send to Launcher's pipe, {}", e),
+            Error::Timeout => "Launcher interaction timed out".to_string(),
         };
         write!(f, "{}", msg)
     }

--- a/components/launcher-protocol/protocols/error.proto
+++ b/components/launcher-protocol/protocols/error.proto
@@ -8,6 +8,11 @@ enum ErrCode {
   UserNotFound = 2;
   ExecWait = 3;
   NoPID = 4;
+  // Returned when the Launcher receives a protocol message that it
+  // does not know how to handle. This could happen if a newer
+  // Supervisor was trying to communicate with an older Launcher that
+  // didn't understand a newer message, for instance.
+  UnknownMessage = 5;
 }
 
 message NetErr {

--- a/components/launcher-protocol/protocols/launcher.proto
+++ b/components/launcher-protocol/protocols/launcher.proto
@@ -11,6 +11,7 @@ message Restart {
 }
 
 message Spawn {
+  // The name of the service group we're spawning, e.g. "redis.default".
   optional string id = 1;
   optional string binary = 2;
   optional string svc_user = 3;
@@ -38,4 +39,23 @@ enum ShutdownMethod {
   AlreadyExited = 0;
   GracefulTermination = 1;
   Killed = 2;
+}
+
+// Query the Launcher to find the current PID of the named
+// service.
+//
+// Note: this is the entire service group name, like
+// "redis.default". It really needs to be whatever Spawn#id is.
+message PidOf {
+  optional string service_name = 1;
+}
+
+// The response that corresponds to `PidOf`. If the service is known
+// to the Launcher, the PID will be present. If not, the PID will be
+// absent.
+message PidIs {
+  // TODO: the launcher really only deals with u32, but should this be
+  // int64 for consistency? Should we make a new type? What's the best
+  // way to evolve that?
+  optional uint32 pid = 1;
 }

--- a/components/launcher-protocol/src/types.rs
+++ b/components/launcher-protocol/src/types.rs
@@ -276,3 +276,47 @@ impl LauncherMessage for Shutdown {
 impl From<Shutdown> for generated::Shutdown {
     fn from(_value: Shutdown) -> Self { generated::Shutdown {} }
 }
+
+#[derive(Clone, Debug)]
+pub struct PidOf {
+    pub service_name: String,
+}
+
+impl LauncherMessage for PidOf {
+    type Generated = generated::PidOf;
+
+    const MESSAGE_ID: &'static str = "PidOf";
+
+    fn from_proto(proto: generated::PidOf) -> Result<Self> {
+        Ok(PidOf { service_name: proto.service_name
+                                      .ok_or(Error::ProtocolMismatch("service_name"))?, })
+    }
+}
+
+impl From<PidOf> for generated::PidOf {
+    fn from(value: PidOf) -> Self { generated::PidOf { service_name: Some(value.service_name), } }
+}
+
+#[derive(Clone, Debug)]
+pub struct PidIs {
+    pub pid: Option<u32>,
+}
+
+impl LauncherMessage for PidIs {
+    type Generated = generated::PidIs;
+
+    const MESSAGE_ID: &'static str = "PidIs";
+
+    fn from_proto(proto: generated::PidIs) -> Result<Self> {
+        // TODO (CM): ensure that the Pid is never Some(0)
+        Ok(PidIs { pid: proto.pid })
+    }
+}
+
+impl From<PidIs> for generated::PidIs {
+    // TODO (CM): I would need to ensure that PidIs can never contain
+    // a non-zero u32
+    //
+    // Perhaps we truly do need a NonZero Pid type here
+    fn from(value: PidIs) -> Self { generated::PidIs { pid: value.pid } }
+}

--- a/components/launcher/src/server.rs
+++ b/components/launcher/src/server.rs
@@ -217,6 +217,11 @@ impl Server {
         // for a possible future where this isn't needed, and reaping
         // could theoretically just take place at the very end of this
         // shutdown process, rather than repeatedly.
+        //
+        // TODO (CM): need some kind of timeout here... if the
+        // Supervisor didn't get the signal, then we're just going to
+        // hang here forever. We should have a (customizable) timeout
+        // here, after which we kill *everything*.
         while let Ok(None) = self.supervisor.try_wait() {
             self.services.reap_services();
             thread::sleep(Duration::from_millis(5));

--- a/components/launcher/src/server/handlers.rs
+++ b/components/launcher/src/server/handlers.rs
@@ -1,8 +1,10 @@
+mod pid;
 mod restart;
 mod spawn;
 mod terminate;
 
-pub use self::{restart::*,
+pub use self::{pid::*,
+               restart::*,
                spawn::*,
                terminate::*};
 

--- a/components/launcher/src/server/handlers/pid.rs
+++ b/components/launcher/src/server/handlers/pid.rs
@@ -1,0 +1,18 @@
+use super::{HandleResult,
+            Handler};
+use crate::{protocol,
+            server::ServiceTable};
+
+pub struct PidHandler;
+
+impl Handler for PidHandler {
+    type Message = protocol::PidOf;
+    type Reply = protocol::PidIs;
+
+    fn handle(msg: Self::Message, services: &mut ServiceTable) -> HandleResult<Self::Reply> {
+        let service_name = msg.service_name;
+        let pid = services.pid_of(&service_name);
+        let reply = protocol::PidIs { pid };
+        Ok(reply)
+    }
+}

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -35,8 +35,8 @@ static LOGKEY: &str = "SV";
 
 #[derive(Debug)]
 pub struct Supervisor {
-    preamble:          String,
-    state:             ProcessState,
+    group_name: String,
+    state:      ProcessState,
     pub state_entered: Timespec,
     pid:               Option<Pid>,
     pid_file:          PathBuf,
@@ -44,7 +44,7 @@ pub struct Supervisor {
 
 impl Supervisor {
     pub fn new(service_group: &ServiceGroup) -> Supervisor {
-        Supervisor { preamble:      service_group.to_string(),
+        Supervisor { group_name:    service_group.to_string(),
                      state:         ProcessState::Down,
                      state_entered: time::get_time(),
                      pid:           None,
@@ -75,7 +75,7 @@ impl Supervisor {
     }
 
     // NOTE: the &self argument is only used to get access to
-    // self.preamble, and even then only for Linux :/
+    // self.group_name, and even then only for Linux :/
     #[cfg(unix)]
     fn user_info(&self, pkg: &Pkg) -> Result<UserInfo> {
         if users::can_run_services_as_svc_user() {
@@ -105,7 +105,7 @@ impl Supervisor {
 
             let name_for_logging = username.clone()
                                            .unwrap_or_else(|| format!("anonymous [UID={}]", uid));
-            outputln!(preamble self.preamble, "Current user ({}) lacks sufficient capabilites to \
+            outputln!(preamble self.group_name, "Current user ({}) lacks sufficient capabilites to \
                 run services as a different user; running as self!", name_for_logging);
 
             Ok(UserInfo { username,
@@ -134,7 +134,7 @@ impl Supervisor {
                  svc_password: Option<&str>)
                  -> Result<()> {
         let user_info = self.user_info(&pkg)?;
-        outputln!(preamble self.preamble,
+        outputln!(preamble self.group_name,
                   "Starting service as user={}, group={}",
                   user_info.username.as_ref().map_or("<anonymous>", String::as_str),
                   user_info.groupname.as_ref().map_or("<anonymous>", String::as_str)
@@ -174,7 +174,7 @@ impl Supervisor {
 
     pub fn status(&self) -> (bool, String) {
         let status = format!("{}: {} for {}",
-                             self.preamble,
+                             self.group_name,
                              self.state,
                              time::get_time() - self.state_entered);
         let healthy = match self.state {
@@ -188,17 +188,17 @@ impl Supervisor {
     pub fn stop(&self, shutdown_config: ShutdownConfig) -> impl Future<Item = (), Error = Error> {
         // TODO (CM): we should really just keep the service
         // group around AS a service group
-        let service_group = self.preamble.clone();
+        let group_name = self.group_name.clone();
 
         if let Some(pid) = self.pid {
             let pid_file = self.pid_file.clone();
             if pid == 0 {
                 warn!(target: "pidfile_tracing", "Cowardly refusing to stop {}, because we think it has a PID of 0, which makes no sense",
-                      service_group);
+                      group_name);
                 return future::Either::B(future::ok(()));
             }
 
-            future::Either::A(terminator::terminate_service(pid, service_group, shutdown_config).and_then(
+            future::Either::A(terminator::terminate_service(pid, group_name, shutdown_config).and_then(
                 |_shutdown_method| {
                     Supervisor::cleanup_pidfile_future(pid_file);
                     Ok(())
@@ -211,7 +211,7 @@ impl Supervisor {
             // cleared up, remove this logging target; it was added
             // just to help with debugging. The overall logging
             // message can stay, however.
-            warn!(target: "pidfile_tracing", "Cowardly refusing to stop {}, because we mysteriously have no PID!", service_group);
+            warn!(target: "pidfile_tracing", "Cowardly refusing to stop {}, because we mysteriously have no PID!", group_name);
             future::Either::B(future::ok(()))
         }
     }

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -35,8 +35,8 @@ static LOGKEY: &str = "SV";
 
 #[derive(Debug)]
 pub struct Supervisor {
-    pub preamble:      String,
-    pub state:         ProcessState,
+    preamble:          String,
+    state:             ProcessState,
     pub state_entered: Timespec,
     pid:               Option<Pid>,
     pid_file:          PathBuf,

--- a/components/sup/src/manager/service/terminator.rs
+++ b/components/sup/src/manager/service/terminator.rs
@@ -4,7 +4,8 @@ use crate::{manager::ShutdownConfig,
                   ShutdownMethod}};
 use futures::sync::oneshot;
 use habitat_common::outputln;
-use habitat_core::os::process::Pid;
+use habitat_core::{os::process::Pid,
+                   service::ServiceGroup};
 use std::thread;
 
 static LOGKEY: &str = "ST"; // "Service Terminator"
@@ -14,7 +15,7 @@ static LOGKEY: &str = "ST"; // "Service Terminator"
 /// This is performed in a separate thread in order to prevent
 /// blocking the rest of the Supervisor.
 pub fn terminate_service(pid: Pid,
-                         service_group: String,
+                         service_group: ServiceGroup,
                          shutdown_config: ShutdownConfig)
                          -> SpawnedFuture<ShutdownMethod> {
     let (tx, rx) = oneshot::channel();

--- a/test/end-to-end/shared.sh
+++ b/test/end-to-end/shared.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# These are some handy-dandy functions that can be shared across
+# end-to-end tests to make it easier to write tests.
+
+# Waits for `timeout_sec` seconds for a process named `process_name`
+# to be found.
+#
+# Exits with code 1 if the process is not found in the allotted time.
+wait_for_process() {
+    local process_name="${1}"
+    local timeout_sec="${2}"
+
+    for i in $(seq "${timeout_sec}"); do
+        if pgrep "${process_name}" &>/dev/null; then
+            echo
+            return
+        else
+            echo -n .
+            sleep 1
+        fi
+    done
+    echo "${process_name} did not start after ${timeout_sec} seconds!"
+    exit 1
+}
+
+# Log the arguments to standard error with a helpful line header.
+log() {
+    echo "TEST_LOG>>> $*" >&2
+}
+
+# Helper to log the PID of a named process.
+log_pid() {
+    local process_name="${1}"
+    local pid
+    pid="$(pgrep "${process_name}")"
+    log "Process '${process_name}' has PID ${pid}"
+}
+
+# Restarts the Supervisor by sending a SIGHUP, and then waits for it
+# to restart.
+restart_supervisor() {
+    log "HUPping Supervisor"
+    log_pid "hab-sup"
+    pkill --signal=HUP hab-launch
+    sleep 3 # wait for the signal to be processed
+    wait_for_process hab-sup 5 # 5 seconds should be plenty of time
+    log "New Supervisor started"
+    log_pid "hab-sup"
+}
+
+# Load a given service and then wait for it to come up.
+load_service() {
+    local service="${1}"
+    local binary="${2}"
+
+    # We do this install first so we don't have to wait so long for
+    # the service to start (we've got to download packages, and that
+    # takes an indeterminate amount of time). If we had synchronous
+    # loading, this wouldn't be an issue.
+    hab pkg install "${service}" --channel=stable
+    hab svc load "${service}"
+    wait_for_process "${binary}" 5
+
+    log_pid "redis"
+}
+
+readonly sup_log_file="sup.log"
+
+# Starts up a Supervisor in the background and waits for it to
+# start. Also wires up a trap function to shut it down at the end of
+# the test.
+start_supervisor() {
+    hab sup run &> "${sup_log_file}" &
+    trap cleanup_supervisor INT TERM EXIT
+    wait_for_process "hab-sup" 10
+}
+
+# Trap function to shut down the Supervisor and also emit all the
+# Supervisor's captured log output.
+cleanup_supervisor() {
+    hab sup term
+    sed -e 's/^/TEST_SUP_LOG>>> /' "${sup_log_file}" >&2
+}

--- a/test/end-to-end/test_PIDS_FROM_LAUNCHER_feature.sh
+++ b/test/end-to-end/test_PIDS_FROM_LAUNCHER_feature.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# When using a current Launcher and enabling the PIDS_FROM_LAUNCHER
+# feature, the Supervisor should not create PID files for the services
+# it manages.
+
+source test/end-to-end/shared.sh
+
+export HAB_FEAT_PIDS_FROM_LAUNCHER=1
+
+start_supervisor
+
+load_service "core/redis" "redis"
+
+# This is the main assertion of this test
+if [ -f "/hab/svc/redis/PID" ]; then
+    echo "Should not have a PID file!"
+    exit 1
+fi
+
+redis_pid="$(pgrep redis)"
+sup_pid="$(pgrep hab-sup)"
+
+restart_supervisor
+
+new_redis_pid="$(pgrep redis)"
+new_sup_pid="$(pgrep hab-sup)"
+
+if [[ "${sup_pid}" == "${new_sup_pid}" ]]; then
+    echo "Supervisor PID should have changed across restart, but it didn't!"
+    exit 1
+fi
+
+if [[ "${redis_pid}" != "${new_redis_pid}" ]]; then
+    echo "Service PID should have remained the same across restart, but it didn't!"
+    echo "  Expected ${redis_pid}; was ${new_redis_pid}"
+    exit 1
+fi

--- a/test/end-to-end/test_PIDS_FROM_LAUNCHER_feature_disabled.sh
+++ b/test/end-to-end/test_PIDS_FROM_LAUNCHER_feature_disabled.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# When the PIDS_FROM_LAUNCHER feature is not enabled, we should still
+# be using PID files for services.
+
+source test/end-to-end/shared.sh
+
+unset HAB_FEAT_PIDS_FROM_LAUNCHER
+
+start_supervisor
+
+load_service "core/redis" "redis"
+
+# This is the main assertion of this test
+if [ ! -f "/hab/svc/redis/PID" ]; then
+    echo "Service PID file should exist because we're NOT using the PIDS_FROM_LAUNCHER feature!"
+    exit 1
+fi
+
+redis_pid="$(pgrep redis)"
+sup_pid="$(pgrep hab-sup)"
+
+restart_supervisor
+
+new_redis_pid="$(pgrep redis)"
+new_sup_pid="$(pgrep hab-sup)"
+
+if [[ "${sup_pid}" == "${new_sup_pid}" ]]; then
+    echo "Supervisor PID should have changed across restart, but it didn't!"
+    exit 1
+fi
+
+if [[ "${redis_pid}" != "${new_redis_pid}" ]]; then
+    echo "Service PID should have remained the same across restart, but it didn't!"
+    echo "  Expected ${redis_pid}; was ${new_redis_pid}"
+    exit 1
+fi

--- a/test/end-to-end/test_PIDS_FROM_LAUNCHER_feature_old_launcher.sh
+++ b/test/end-to-end/test_PIDS_FROM_LAUNCHER_feature_old_launcher.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# When using a Launcher from before the PIDS_FROM_LAUNCHER feature was
+# created, we should still be using PID files for individual services,
+# even if we've enabled the feature.
+
+source test/end-to-end/shared.sh
+
+export HAB_FEAT_PIDS_FROM_LAUNCHER=1
+
+# This was the last stable Linux launcher prior to the
+# PIDS_FROM_LAUNCHER feature.
+hab pkg install core/hab-launcher/12605/20191112144831
+
+start_supervisor
+
+load_service "core/redis" "redis"
+
+# This is the main assertion of this test
+if [ ! -f "/hab/svc/redis/PID" ]; then
+    echo "Service PID file should exist because we're using an older Launcher!"
+    exit 1
+fi
+
+redis_pid="$(pgrep redis)"
+sup_pid="$(pgrep hab-sup)"
+
+restart_supervisor
+
+new_redis_pid="$(pgrep redis)"
+new_sup_pid="$(pgrep hab-sup)"
+
+if [[ "${sup_pid}" == "${new_sup_pid}" ]]; then
+    echo "Supervisor PID should have changed across restart, but it didn't!"
+    exit 1
+fi
+
+if [[ "${redis_pid}" != "${new_redis_pid}" ]]; then
+    echo "Service PID should have remained the same across restart, but it didn't!"
+    echo "  Expected ${redis_pid}; was ${new_redis_pid}"
+    exit 1
+fi


### PR DESCRIPTION
By setting `HAB_FEAT_PIDS_FROM_LAUNCHER=1` in the environment, _and_ using a Launcher built from this code or later, the Supervisor will now ask the Launcher for the PIDs of services it is supervising, rather than relying on reading that information from files on disk.

Eventually, this will be the default behavior, but it is feature-flagged at the moment as we begin rolling it out.

If users are using an older Launcher, the Supervisor will continue to use PID files, regardless of whether the feature is enabled or not.

Read individual commit messages for further details.

Fixes #7021 