### PR TITLE
Fix e2e_local scripts

### DIFF
--- a/e2e_local.ps1
+++ b/e2e_local.ps1
@@ -1,6 +1,7 @@
 Param(
    [Parameter(Mandatory=$true)]
-   [string[]]$TestName
+   [string]$TestName,
+   [string]$Channel="dev"
 )
 
 $ErrorActionPreference="stop" 
@@ -12,4 +13,4 @@ docker run `
        --env-file="$(pwd)/e2e_env" `
        --volume="$(pwd):c:\workdir" `
        --workdir=/workdir `
-       chefes/buildkite-windows powershell.exe .\.expeditor\scripts\end_to_end\run_e2e_test.ps1 dev $TestName
+       chefes/buildkite-windows powershell.exe .\.expeditor\scripts\end_to_end\run_e2e_test.ps1 $Channel $TestName

--- a/e2e_local.sh
+++ b/e2e_local.sh
@@ -2,32 +2,9 @@
 
 set -euo pipefail
 
-if [[ ${#} == 0 ]]; then
-    cat <<EOF
-    You must supply arguments! For example:
+test_name=${1:?You must specify a test name}
+channel=${2:-dev}
 
-        ${0} test/end-to-end/my_test.sh
-
-EOF
-    exit 1
-fi
-
-# These are the commands that will be sequentially run in the
-# container. The final one will be the test itself, which is supplied
-# as the arguments of the script.
-#
-# Not every test requires `expect`, but it's not hurting anything to
-# install it for everything.
-#
-# Note that the `ci-studio-common.sh` file is baked into the image we
-# use.
-commands=(". /opt/ci-studio-common/buildkite-agent-hooks/ci-studio-common.sh"
-          ".expeditor/scripts/end_to_end/setup_environment.sh dev"
-          "hab pkg install --binlink --channel=stable core/expect"
-          "${*}")
-
-# Add a `;` after every command, for feeding into the container. This
-# allows them to run in sequence.
 docker run \
        --rm \
        --interactive \
@@ -36,4 +13,4 @@ docker run \
        --env-file="$(pwd)/e2e_env" \
        --volume="$(pwd):/workdir" \
        --workdir=/workdir \
-       chefes/buildkite /bin/bash -e -c "${commands[*]/%/;}"
+       chefes/buildkite bash .expeditor/scripts/end_to_end/run_e2e_test.sh "$channel" "$test_name"

--- a/e2e_local_raw_command.sh
+++ b/e2e_local_raw_command.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ ${#} == 0 ]]; then
+    cat <<EOF
+    You must supply arguments! For example:
+
+        ${0} test/end-to-end/my_test.sh
+
+EOF
+    exit 1
+fi
+
+# These are the commands that will be sequentially run in the
+# container. The final one will be the test itself, which is supplied
+# as the arguments of the script.
+#
+# Not every test requires `expect`, but it's not hurting anything to
+# install it for everything.
+#
+# Note that the `ci-studio-common.sh` file is baked into the image we
+# use.
+commands=(". /opt/ci-studio-common/buildkite-agent-hooks/ci-studio-common.sh"
+          ".expeditor/scripts/end_to_end/setup_environment.sh dev"
+          "hab pkg install --binlink --channel=stable core/expect"
+          "${*}")
+
+# Add a `;` after every command, for feeding into the container. This
+# allows them to run in sequence.
+docker run \
+       --rm \
+       --interactive \
+       --tty \
+       --privileged \
+       --env-file="$(pwd)/e2e_env" \
+       --volume="$(pwd):/workdir" \
+       --workdir=/workdir \
+       chefes/buildkite /bin/bash -e -c "${commands[*]/%/;}"


### PR DESCRIPTION
Now that we have a unified way to run e2e tests with powershell core, this PR updates the `e2e_local.sh` to behave more like `e2e_local.ps1`. It moves the old script to `e2e_local_raw_command.sh` to allow running tests that have not yet been converted to powershell core.

e2e tests can be run with `./e2e_local.(sh|ps1) <test-name>`. So for example on linux:
`./e2e_local.sh test_simple_hooks`

The PR also adds an optional second argument to specify the channel to use when pulling the `hab` packages. It defaults to `dev`.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>