### PR TITLE
Smaller  margins on code element

### DIFF
--- a/www/source/stylesheets/_global.scss
+++ b/www/source/stylesheets/_global.scss
@@ -300,12 +300,14 @@ code {
   font-size: $code-font-size;
   margin: rem-calc(10 0 30);
 
+  h2 &,
+  h3 &,
   p &,
   li &,
   td &,
   dd & {
     border-radius: $global-radius;
-    padding: rem-calc(0 5 1);
+    padding: rem-calc(0 1);
     margin: 0 rem-calc(1);
   }
 }


### PR DESCRIPTION
The code element margins are too big, particularly  in h2 & h3

Current:
![Screen Shot 2019-11-20 at 1 34 33 PM](https://user-images.githubusercontent.com/4400151/69280113-8c018380-0b9a-11ea-8d9f-3475fd7e488b.png)

Change:
![Screen Shot 2019-11-20 at 1 33 51 PM](https://user-images.githubusercontent.com/4400151/69280165-a0458080-0b9a-11ea-83d1-43d12931272b.png)


But maybe a bit more padding in h1 & h2 would be nice?

Signed-off-by: kagarmoe <kgarmoe@chef.io>