### PR TITLE
[CI] Fix failing macOS build

### DIFF
--- a/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
+++ b/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
@@ -15,10 +15,6 @@ channel=$(get_release_channel)
 
 echo "--- Channel: $channel - bldr url: $HAB_BLDR_URL"
 
-echo "--- Install openssl for the certs"
-brew install openssl
-export SSL_CERT_FILE=/usr/local/etc/openssl/cert.pem
-
 echo "--- Installing mac bootstrap package"
 # subscribe to releases: https://github.com/habitat-sh/release-engineering/issues/84
 bootstrap_package_version="$(cat MAC_BOOTSTRAPPER_VERSION)"
@@ -33,6 +29,42 @@ export PATH=/opt/mac-bootstrapper/embedded/bin:/usr/local/bin:$PATH
 declare -g hab_binary
 curlbash_hab "$BUILD_PKG_TARGET"
 import_keys
+
+########################################################################
+# BEGIN CERTIFICATE SHENANIGANS
+
+echo "--- Prepare cert file"
+# So, originally, we got this cert file from Homebrew's openssl
+# package. We currently need this because it gets baked into the
+# binaries we ship as part of how our API client library works. We may
+# be able to remove this in the near future, but for the time being,
+# we can just grab a cert file from the Linux core/cacerts Habitat
+# package.
+cacerts_scratch_dir="cacerts_scratch"
+mkdir "${cacerts_scratch_dir}"
+${hab_binary} pkg download core/cacerts \
+    --target=x86_64-linux \
+    --download-directory="${cacerts_scratch_dir}"
+cacerts_hart=$(find "${cacerts_scratch_dir}"/artifacts -type f -name 'core-cacerts-*-x86_64-linux.hart')
+
+# GNU tail, tar, from the mac-bootstrapper
+tail --lines=+6 "${cacerts_hart}" | \
+    tar --extract \
+        --verbose \
+        --xz \
+        --strip-components=8 \
+        --wildcards "hab/pkgs/core/cacerts/*/*/ssl/certs"
+
+cert_file="cacert.pem"
+if [ ! -f "${cert_file}" ]; then
+    echo "Couldn't extract ${cert_file} file from core/cacerts package!"
+    exit 1
+fi
+export SSL_CERT_FILE
+SSL_CERT_FILE="$(pwd)/${cert_file}"
+
+# END CERTIFICATE SHENANIGANS
+########################################################################
 
 # We invoke hab-plan-build.sh directly via sudo, so we don't get the key management that studio provides.
 # Copy keys from the user account Habitat cache to the system Habitat cache so that they are present for root.


### PR DESCRIPTION
`openssl` is no longer in Homebrew, and we don't need it anymore,
anyway.

Signed-off-by: Christopher Maier <cmaier@chef.io>