### PR TITLE
Use current commit to determine launcher version for Windows

### DIFF
--- a/components/launcher/habitat/plan.ps1
+++ b/components/launcher/habitat/plan.ps1
@@ -39,7 +39,7 @@ function Invoke-Prepare {
 }
 
 function pkg_version {
-    git rev-list master --count
+    git rev-list (git rev-parse HEAD) --count
 }
 
 function Invoke-Before {


### PR DESCRIPTION
Follow on to #7234 to address Windows launcher versions

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>