### PR TITLE
[Chore] Clean up libbuild.rs

### DIFF
--- a/components/libbuild.rs
+++ b/components/libbuild.rs
@@ -1,96 +1,37 @@
-#[allow(dead_code)]
-const VERSION_ENVVAR: &str = "PLAN_VERSION";
-
-#[allow(dead_code)]
-mod builder {
-    use std::env;
-    use std::process::Command;
-
-    use super::VERSION_ENVVAR;
-
-    pub fn common() {
-        super::version::write_file(version());
-    }
-
-    pub fn version() -> String {
-        match env::var(VERSION_ENVVAR) {
-            Ok(ver) => ver,
-            _ => read_git_version(),
-        }
-    }
-
-    fn read_git_version() -> String {
-        let child = Command::new("git")
-            .arg("rev-parse")
-            .arg("HEAD")
-            .output()
-            .expect("Failed to spawn child");
-        String::from_utf8_lossy(&child.stdout).into_owned()
-    }
-}
-
-#[allow(dead_code)]
 mod habitat {
-    use std::env;
-    use std::fs::File;
-    use std::io::{BufRead, BufReader};
-    use std::path::Path;
+    use std::{env,
+              fs::{self,
+                   File},
+              io::Write,
+              path::Path};
 
-    use super::VERSION_ENVVAR;
+    /// Writes version information to `$OUT_DIR/VERSION` during
+    /// compilation, in order to be picked up by `include!` macros
+    /// elsewhere in the compiling code.
+    pub fn common() { write_out_dir_file("VERSION", version()); }
 
-    pub fn common() {
-        super::version::write_file(version());
-    }
+    /// Reads from $PLAN_VERSION in a `hab pkg build` run, but from
+    /// the `VERSION` file in a plain `cargo build` run.
+    fn version() -> String { env::var("PLAN_VERSION").unwrap_or_else(|_| read_common_version()) }
 
-    pub fn version() -> String {
-        match env::var(VERSION_ENVVAR) {
-            Ok(ver) => ver,
-            _ => read_common_version(),
-        }
-    }
-
+    /// Reads the contents of the `VERSION` file at the repository root.
     fn read_common_version() -> String {
-        let ver_file = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap())
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("VERSION");
-        let f = File::open(ver_file).expect("Failed to open version file");
-        let mut reader = BufReader::new(f);
-        let mut ver = String::new();
-        reader
-            .read_line(&mut ver)
-            .expect("Failed to read line from version file");
-        ver
+        let version_file = Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).parent()
+                                                                              .unwrap()
+                                                                              .parent()
+                                                                              .unwrap()
+                                                                              .join("VERSION");
+        fs::read_to_string(version_file).expect("Couldn't read VERSION file!")
     }
-}
 
-#[allow(dead_code)]
-mod util {
-    use std::env;
-    use std::fs::File;
-    use std::io::Write;
-    use std::path::Path;
-
-    pub fn write_out_dir_file<P, S>(filename: P, content: S)
-    where
-        P: AsRef<Path>,
-        S: AsRef<str>,
-    {
+    /// Write the given `content` to `$OUT_DIR/filename`.
+    fn write_out_dir_file(filename: &str, content: String) {
         let mut f = File::create(
-            Path::new(&env::var("OUT_DIR").expect("Failed to read OUT_DIR environment variable"))
+            Path::new(&env::var("OUT_DIR").unwrap())
                 .join(filename),
         )
         .expect("Failed to create OUT_DIR file");
-        f.write_all(content.as_ref().trim().as_bytes())
-            .expect("Failed to write to OUT_DIR file");
-    }
-}
-
-#[allow(dead_code)]
-mod version {
-    pub fn write_file<S: AsRef<str>>(version: S) {
-        super::util::write_out_dir_file("VERSION", version);
+        f.write_all(content.trim().as_bytes())
+         .expect("Failed to write to OUT_DIR file");
     }
 }


### PR DESCRIPTION
* Remove the unused `builder` module
* Remove all `allow(dead_code)`annotations
* Consolidate all code into the `habitat` module
* Add documentation
* Simplify type signatures
* Simplify VERSION file reading
* Inline the implementation of the `write_file` function
* Don't `expect` on `OUT_DIR`; it is set by Cargo
* Remove VERSION_ENVVAR indirection

![](https://media.giphy.com/media/NXhU5xzqXmIOQ/giphy.gif)

Signed-off-by: Christopher Maier <cmaier@chef.io>