### PR TITLE
avoid ctl_gateway panic on peer_addr().expect()

### DIFF
--- a/components/sup/src/ctl_gateway/server.rs
+++ b/components/sup/src/ctl_gateway/server.rs
@@ -486,8 +486,7 @@ pub fn run(listen_addr: SocketAddr, secret_key: String, mgr_sender: MgrSender) {
                                              // disregards the protocol such as from a `netcat -z`
                                              // connection.
                                              .filter_map(|tcp_stream| {
-                                                 if tcp_stream.peer_addr().is_ok() {
-                                                     let addr = tcp_stream.peer_addr().unwrap();
+                                                 if let Ok(addr) = tcp_stream.peer_addr() {
                                                      let io = SrvCodec::new().framed(tcp_stream);
                                                      let client = Client { handle: handle.clone(),
                                                                            state:  state.clone(), };

--- a/components/sup/src/ctl_gateway/server.rs
+++ b/components/sup/src/ctl_gateway/server.rs
@@ -492,6 +492,7 @@ pub fn run(listen_addr: SocketAddr, secret_key: String, mgr_sender: MgrSender) {
                                                                            state:  state.clone(), };
                                                      Some((client.serve(io), addr))
                                                  } else {
+                                                     debug!("Client peer address not available from socket!");
                                                      None
                                                  }
                                              })

--- a/test/end-to-end/shared.sh
+++ b/test/end-to-end/shared.sh
@@ -81,11 +81,6 @@ cleanup_supervisor() {
 # NOTE: This currently assumes the test is the only thing running a
 # Supervisor.
 wait_for_control_gateway() {
-    # TODO (CM): Ideally would use -z, but that appears to cause
-    # issues with the control gateway in our Docker-based testing
-    # pipeline... something about the peer address of the connection
-    # not being available.
-    #
-    # Also, this assumes GNU netcat, installed via Habitat.
-    timeout --foreground 10 sh -c 'until netcat -vv --close localhost 9632; do sleep 1; done'
+    # This assumes GNU netcat, installed via Habitat.
+    timeout --foreground 10 sh -c 'until netcat -vv -z localhost 9632; do sleep 1; done'
 }


### PR DESCRIPTION
This change introduces a filter_map allowing for removal of the
`peer_addr().expect()` which could result in panics and the ctl_gateway thread dying. 

Now, we filter out instances where there is no peer address on the socket. The peer
address could be non-existant when a client disregards the protocol
such as when a half opened connection exists from `netcat -z`.

Fixes: #7230

- [x] Verify that change avoids the ctl_gateway panic from this [context](https://github.com/habitat-sh/habitat/pull/7220#discussion_r349196781)

Signed-off-by: Jeremy J. Miller <jm@chef.io>
