### PR TITLE
[Chore] Update CODEOWNERS for new CI infrastructure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
-.buildkite @christophermaier
-components/backline
+.expeditor @christophermaier @smacfarlane
 components/builder-api-client @chefsalim @raskchanky
 components/butterfly* @christophermaier @raskchanky
 components/core @christophermaier @chefsalim @raskchanky


### PR DESCRIPTION
`.buildkite` is gone, replaced with `.expeditor`

Also went ahead and removed the line for `components/backline`, since
a) there were no names anyway, and b) there's not really any code to
that component.

Signed-off-by: Christopher Maier <cmaier@chef.io>