### PR TITLE
some minor windows service improvements

### DIFF
--- a/components/windows-service/App.config
+++ b/components/windows-service/App.config
@@ -4,6 +4,10 @@
     <!--
     The 'debug' setting is deprecated and may not work as desired in a future release
     of the windows-service. Use the 'ENV_RUST_LOG' setting instead and set it to 'debug'.
+
+    Note that any setting key beginning with 'ENV_' will be set in the supervisor's
+    environment. For example, setting 'ENV_RUST_LOG' to 'debug' will set the 'RUST_LOG'
+    environment variable to the value 'debug'.
     -->
     <add key="debug" value="false" />
     <add key="launcherArgs" value="--no-color" />

--- a/components/windows-service/hooks/install
+++ b/components/windows-service/hooks/install
@@ -4,4 +4,14 @@ if((Get-Service Habitat -ErrorAction SilentlyContinue) -ne $null) {
     UnInstall-HabService
 }
 
+$configPath = Join-Path $env:SystemDrive "hab\svc\windows-service\HabService.dll.config"
+$configPathBU = "${configPath}_backup"
+if(Test-Path $configPath) {
+    Copy-Item $configPath $configPathBU
+}
+
 Install-HabService
+
+if(Test-Path $configPathBU) {
+    Move-Item $configPathBU $configPath -Force
+}


### PR DESCRIPTION
This clarifies the use of environment vars in the config files by explaining the details in the config file comments. This also ensures that any pre-existing config file is not overwritten.