### PR TITLE
[web] Update links to point to packages.chef.io instead of Bintray

### DIFF
--- a/www/source/docs/install-habitat.html.md.erb
+++ b/www/source/docs/install-habitat.html.md.erb
@@ -71,9 +71,8 @@ curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/
 
 A: Indeed they are divisive, we know, that's why we provide a few different ways for you to download. If you'd like to take a look at the script before running it, you can find it in [the core Chef Habitat repo](https://github.com/habitat-sh/habitat/blob/master/components/hab/install.sh).
 
-If you're staunchly in the anti-curl-bash camp, you can get the latest packages from the [download links](/docs/install-habitat/#install-habitat) listed previously, or via releases on our [Bintray page](https://bintray.com/habitat).
+If you're staunchly in the anti-curl-bash camp, you can get the latest packages from the [download links](/docs/install-habitat/#install-habitat) listed previously.
 
 **Q: How do I install `hab` across my server fleet?**
 
 A: For the most part, we leave that up to you. You could just use the aforementioned curl-bash with your provisioner of choice. If your app was dockerized with Chef Habitat then you won't even need to ask this question, because you'll have everything you need inside your container. We are working on first class Mesosphere DC/OS, Cloud Foundry, and Kubernetes integrations - which you can keep up to date on in [our best practices section](/docs/best-practices/) and [blog](/blog).
-

--- a/www/source/partials/global/_download-and-install.slim
+++ b/www/source/partials/global/_download-and-install.slim
@@ -8,7 +8,7 @@ hr
       h3: a name="hab-for-linux" id="hab-for-linux" data-magellan-target="hab-for-linux" Chef Habitat for Linux
       <blockquote> Chef Habitat for Linux requires a 64-bit processor with kernel 2.6.32 or later. On Linux, exporting your Chef Habitat artifact to a Docker image requires the Docker Engine supplied by Docker. Packages from distribution-specific or otherwise alternative providers are currently not supported. </blockquote>
       p Once you have downloaded the package, extract the hab binary with tar to <code>/usr/local/bin</code> or add its location to your <code>PATH</code> (e.g. <code>tar -xvzf hab.tgz -C /usr/local/bin --strip-components 1</code>).
-      = link_to 'Download Chef Habitat for Linux', 'https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz?bt_package=hab-x86_64-linux', class: 'button cta'
+      = link_to 'Download Chef Habitat for Linux', 'https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-linux.tar.gz', class: 'button cta'
 
       h4.mt-2 Install Chef Habitat from the Command Line
       p Alternatively, you can install Chef Habitat via the command line by downloading and running the installation script:
@@ -28,7 +28,7 @@ hr
       h3: a name="hab-for-mac" id="hab-for-mac" data-magellan-target="hab-for-mac" Chef Habitat for Mac
       blockquote Requires 64-bit processor running 10.9 or later
       p Once you have downloaded the <code>hab</code> CLI, unzip it onto your machine. Unzipping to <code>/usr/local/bin</code> should place it on your <code>PATH</code>. In order to use the Chef Habitat Studio, you'll also need to install Docker for Mac.
-      = link_to 'Download Chef Habitat for Mac', 'https://api.bintray.com/content/habitat/stable/darwin/x86_64/hab-%24latest-x86_64-darwin.zip?bt_package=hab-x86_64-darwin', class: 'button cta'
+      = link_to 'Download Chef Habitat for Mac', 'https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-darwin.zip', class: 'button cta'
       = link_to 'Download Docker for Mac', 'https://store.docker.com/editions/community/docker-ce-desktop-mac', class: 'button outline contrast', target: '_blank'
 
       h4.mt-2 Install Chef Habitat Using Homebrew
@@ -63,5 +63,5 @@ hr
 
       p To use a Docker Chef Habitat Studio as an isolated environment, you'll also need to install Docker for Windows.
       blockquote Docker for Windows requires 64-bit Windows 10 Pro, Enterprise, or Education editions  (1607 Anniversary Update, Build 14393 or later) with Hyper-V enabled
-      = link_to 'Download Chef Habitat for Windows', 'https://api.bintray.com/content/habitat/stable/windows/x86_64/hab-%24latest-x86_64-windows.zip?bt_package=hab-x86_64-windows', class: 'button cta'
+      = link_to 'Download Chef Habitat for Windows', 'https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-windows.zip', class: 'button cta'
       = link_to 'Download Docker for Windows', 'https://store.docker.com/editions/community/docker-ce-desktop-windows', class: 'button outline contrast', target: '_blank'


### PR DESCRIPTION
With the switch-over to the new release pipeline, Habitat CLI binaries
are no longer being uploaded to Bintray. Instead, they are available
from https://packages.chef.io, like all other binaries distributed by
Chef.

Signed-off-by: Christopher Maier <cmaier@chef.io>