### PR TITLE
auto bump rustfmt version post release

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -112,6 +112,15 @@ subscriptions:
       - trigger_pipeline:finish_release:
           post_commit: true
 
+  # Post release notification workloads
+  #
+  # Do not change the branch name here without also changing
+  # it in .expeditor/scripts/finish_release/bump_rustfmt.sh
+  # pull_request_<ACTION>:<REPO>:<BRANCH>:<NUMBER>:<GITHUB_DELIVERY_UUID>
+  - workload: pull_request_opened:{{github_repo}}:expeditor/rustfmt_*:*
+    actions:
+      - bash:.expeditor/scripts/finish_release/notify_rustfmt.sh
+
 promote:
   channels:
     # e2e pipeline tests from here

--- a/.expeditor/finish_release.pipeline.yml
+++ b/.expeditor/finish_release.pipeline.yml
@@ -32,3 +32,16 @@ steps:
         docker:
           host_os: windows
           environment:
+
+  - label: ":rust: Check for new nightly rustfmt version"
+    command:
+      - .expeditor/scripts/finish_release/bump_rustfmt.sh
+    expeditor:
+      secrets:
+        GITHUB_TOKEN:
+          account: github
+          field: token
+      executor:
+        linux:
+          privileged: true
+    soft_fail: true

--- a/.expeditor/scripts/finish_release/bump_rustfmt.sh
+++ b/.expeditor/scripts/finish_release/bump_rustfmt.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# This script attempts to find the latest installable nightly rustfmt.
+# When found, it bumps the repo rustfmt version and submits a new PR
+# with the new version pin and any code base formatting changes from the
+# new version.
+
+# Assumptions:
+# 1. This script runs on a x86_64-unknown-linux-gnu target
+# 2. If rustfmt is installable on x86_64-unknown-linux-gnu, the other Tier1
+#    platforms are assumed to also have a working version.
+
+set -Eeuo pipefail
+
+# shellcheck source=.expeditor/scripts/shared.sh
+source .expeditor/scripts/shared.sh
+
+TODAY=$(date '+%Y-%m-%d')
+# pick out the date from a string like: nightly-2019-12-04
+CURRENT_RUSTFMT_DATE=$(awk -F- '{print $2"-"$3"-"$4}' RUSTFMT_VERSION)
+# convert to seconds for easier date comparison later
+CURRENT_RUSTFMT_DATE_S=$(date '+%s' --date "${CURRENT_RUSTFMT_DATE}")
+CHANNEL=nightly
+# a maximum iterator value for searching elligible nightlies
+MAX_ATTEMPTS=90
+
+# if set, this will be the next version
+export FOUND_VERSION
+
+find_nightly_rustfmt() {
+  # set minimal profile so only rustc, rust-std, and cargo components
+  # are installed in addition to rustfmt
+  echo "--- :habicat: Setting minimal profile"
+  rustup set profile minimal
+
+  for ((i=0; i<MAX_ATTEMPTS; i++)); do
+    # begin searching nightly date versions using current date
+    # as a starting point
+    attempt_date=$(date '+%Y-%m-%d' --date "${TODAY} -${i} day")
+    # use the conversion to seconds for easy date comparison
+    attempt_date_s=$(date '+%s' --date "${attempt_date}")
+    attempt_version="${CHANNEL}-${attempt_date}"
+    echo "--- Trying Nightly Date Version: ${attempt_version}"
+    if rustup toolchain install "${attempt_version}" --component rustfmt; then
+      FOUND_VERSION=${attempt_version}
+      break
+    fi
+    if [ "${attempt_date_s}" -le "${CURRENT_RUSTFMT_DATE_S}" ]; then
+      # Exit early since there is no newer version available than what is
+      # currently pinned in RUSTFMT_VERSION file.
+      echo "--- No newer ${CHANNEL} versions found. Nothing to do."
+      exit 0
+    fi
+  done
+}
+
+run_fmt_open_pr() {
+  local version_underbar="${FOUND_VERSION//-/_}"
+
+  # Do not change the branch name here without also changing
+  # it in .expeditor/config.yml where a workload
+  # subscription references the same name.
+  readonly branch="expeditor/rustfmt_${version_underbar}"
+  maybe_run git checkout -b "${branch}"
+
+  # update the rustfmt version pin file
+  echo "${FOUND_VERSION}" > RUSTFMT_VERSION
+
+  # sweep the codebase
+  echo "--- :rust: Running new rustfmt"
+  cargo +"$(< RUSTFMT_VERSION)" fmt --all
+
+  git add --update
+  maybe_run git commit --signoff --message "\"Bump rustfmt to ${FOUND_VERSION}\""
+
+  # This script runs from a pipeline step, thus we do not
+  # have access to expeditor's open_pull_request bash
+  # action helper function.
+  install_hub
+
+  echo "--- :github: Creating PR"
+  maybe_run hub pull-request --push --no-edit
+}
+
+install_rustup
+find_nightly_rustfmt
+
+if [ -z "${FOUND_VERSION}" ]; then
+  # Something is likely wrong if we did not find an installable nightly version.
+  echo "--- :thumbsdown: No candidate versions found within ${MAX_ATTEMPTS}!"
+  exit 1
+fi
+
+echo "--- :thumbsup: New installable version of rustfmt found: ${FOUND_VERSION}"
+
+run_fmt_open_pr

--- a/.expeditor/scripts/finish_release/notify_rustfmt.sh
+++ b/.expeditor/scripts/finish_release/notify_rustfmt.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+# Assumptions:
+# 1. This script runs from a bash action triggered from a workload subscription.
+#    Therefore it assumes EXPEDITOR_SCM_SETTINGS_BRANCH ENV var exists.
+
+# shellcheck source=.expeditor/scripts/shared.sh
+source .expeditor/scripts/shared.sh
+
+# https://expeditor.chef.io/docs/reference/workloads/#environment-variables
+BRANCH=${EXPEDITOR_SCM_SETTINGS_BRANCH?required EXPEDITOR_SCM_SETTINGS_BRANCH ENV var not set}
+
+export GITHUB_TOKEN
+GITHUB_TOKEN="${GITHUB_TOKEN:-$(chef_ci_github_token)}"
+
+pr_url_from_branch() {
+  # assumes hub is being executed from git cloned repo workspace
+  local branch="${1?branch argument required}"
+  url=$(hub pr list --head "${branch}" --format %U)
+  echo "${url}"
+}
+
+send_notification() {
+  local url="${1?url argument required}"
+  local message
+  message=$(cat <<MSG
+Hi @habitat-team, there is a rustfmt version bump PR ready for review! :jumping-habicat:
+
+${url}
+
+MSG
+)
+
+  echo "--- :slack: Notifying hab-team"
+  # https://expeditor.chef.io/docs/reference/script/#post-slack-message
+  maybe_run post_slack_message "hab-team" "\"${message}\""
+}
+
+# expeditor has no built-in way to fetch a PR URL, so we use hub
+install_hub
+
+echo "--- :github: Fetching PR URL of ${BRANCH} branch"
+PR_URL=$(pr_url_from_branch "${BRANCH}")
+
+# Even in the event that PR_URL is empty, we'll still send a notification.
+send_notification "${PR_URL}"

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -288,6 +288,7 @@ latest_release_tag() {
 
 install_hub() {
   # TODO: Create a Hab core plans pkg for this.
+  # see https://github.com/habitat-sh/habitat/issues/7267
   local tag
   tag=$(latest_release_tag github/hub)
   tag_sans_v="${tag//v/}"

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -239,6 +239,13 @@ hab_auth_token() {
           account/static/habitat/chef-ci
 }
 
+# Retrieve a suitable GITHUB_TOKEN value from Vault.
+chef_ci_github_token() {
+    vault kv get \
+          -field=token \
+          account/static/github/chef-ci
+}
+
 # Our pipelines can define this value as a top-level environment
 # variable, but we don't have that ability with scripts executed
 # directly by Expeditor. Those scripts use this (similar to
@@ -271,4 +278,24 @@ fastly_token() {
     vault kv get \
           -field=token \
           account/static/fastly/eng-services-ops
+}
+
+latest_release_tag() {
+  local repo="${1?repo argument required}"
+  tag=$(curl --silent "https://api.github.com/repos/${repo}/releases/latest" | jq -r .tag_name)
+  echo "${tag}"
+}
+
+install_hub() {
+  # TODO: Create a Hab core plans pkg for this.
+  local tag
+  tag=$(latest_release_tag github/hub)
+  tag_sans_v="${tag//v/}"
+  url="https://github.com/github/hub/releases/download/${tag}/hub-linux-amd64-${tag_sans_v}.tgz"
+  echo "--- :github: Installing hub version ${tag} to /bin/hub from ${url}"
+  curl -L -O "${url}"
+  tar xfz hub-linux-amd64-*.tgz
+  cp -f hub-linux-amd64-*/bin/hub /bin
+  chmod a+x /bin/hub
+  rm -rf hub-linux-amd64*
 }

--- a/.expeditor/scripts/verify/shared.sh
+++ b/.expeditor/scripts/verify/shared.sh
@@ -26,8 +26,17 @@ get_rustfmt_toolchain() {
 
 install_rustfmt() {
   local toolchain="${1?toolchain argument required}"
+  # Only include rustc, rust-std, and cargo components
+  # as the base default. This ensures that when we install the
+  # rustfmt component, we don't try to bring in anything else
+  # like clippy that might not be available in the toolchain
+  # for a given target.
+  # https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles
+  rustup set profile minimal
   install_rust_toolchain "$toolchain"
   rustup component add --toolchain "$toolchain" rustfmt
+  # set profile back to default
+  rustup set profile default
 }
 
 install_rust_toolchain() {

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,9 @@
+# Due to our desire to enable certain
+# rustfmt features that are only available
+# in nightly builds of rustfmt, we set
+# this flag to true.
+unstable_features = true
+
 # stable options
 edition = "2018"
 fn_args_layout = "Tall"

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -47,7 +47,7 @@ cargo --version
 
 Next, use our installation script to install rustfmt
 ```
-./.expeditor/scripts/verify/rustfmt.sh
+./support/rustfmt_nightly.sh
 ```
 
 At any time, you can find the version of rustfmt we are using by running this command at the root level

--- a/support/rustfmt_nightly.sh
+++ b/support/rustfmt_nightly.sh
@@ -9,9 +9,11 @@ fi
 
 {
     if ! rustup run "$toolchain" rustfmt --version; then
+        rustup set profile minimal
         rustup toolchain install "$toolchain"
         rustup component add --toolchain "$toolchain" rustfmt
+        rustup set profile default
     fi
 } &> /dev/null
 
-rustup run "$toolchain" rustfmt "$@"
+cargo +"${toolchain}" fmt -- "$@"


### PR DESCRIPTION
Closes https://github.com/habitat-sh/habitat/issues/7197

An important nuance of this PR is that due to changes in `rustup`, we can now set a minimal profile when installing `rustfmt`. See this [blog post](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles) for details.

Minimal profile means that only rustc, rust-std, and cargo will be installed by default. Then we tell `rustup` to add the `rustfmt` component. The outcome from that is a greatly simplified process for selecting a nightly version when installing `rustfmt`. We no longer have to consult the [nightly component matrix](https://rust-lang.github.io/rustup-components-history/) to select a nightly that includes `rustfmt`, `clippy`, etc.  Judging by my testing, and looking at the components table, the _latest_ nightly usually seems to fit that bill. This is different from before, where we typically selected a nightly that had _all_ components available in the toolchain. 

The _latest_ nightly eligible for `rustfmt` no longer has to include those extra components as well, just core (default) + `rustfmt`. 

CI and users/developers can have as many toolchains installed as they wish, the one they use for running `rustfmt` will from now on, only include `rustc`, `rust-std`, `cargo` and `rustfmt` due to the minimal profile.

The assumption made here though, is that the nightly selected will have `default` + `rustfmt` available for **_all_** Tier1 targets. Our `rustfmt` for CI only runs on Linux, but developers obviously require various targets.

Signed-off-by: Jeremy J. Miller <jm@chef.io>