### PR TITLE
Fix setting SSL_CERT_FILE in studio when the cert isn't cached

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -504,7 +504,10 @@ function Update-SslCertFile {
   if($env:SSL_CERT_FILE) {
     try {
       $cert_filename = (Get-Item $env:SSL_CERT_FILE).Name
-      $env:SSL_CERT_FILE = Join-Path $env:HAB_CACHE_SSL_PATH $cert_filename
+      $studio_ssl_cert_file = (Join-Path $env:HAB_CACHE_SSL_PATH $cert_filename)
+      if (Test-Path (Join-Path $env:HAB_STUDIO_ROOT $studio_ssl_cert_file)) {
+        $env:SSL_CERT_FILE = $studio_ssl_cert_file
+      }
     } catch {
       Write-HabInfo "Unable to set SSL_CERT_FILE from '$env:SSL_CERT_FILE'"
     }

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -505,7 +505,7 @@ function Update-SslCertFile {
     try {
       $cert_filename = (Get-Item $env:SSL_CERT_FILE).Name
       $studio_ssl_cert_file = (Join-Path $env:HAB_CACHE_SSL_PATH $cert_filename)
-      if (Test-Path (Join-Path $env:HAB_STUDIO_ROOT $studio_ssl_cert_file)) {
+      if (Test-Path $studio_ssl_cert_file) {
         $env:SSL_CERT_FILE = $studio_ssl_cert_file
       }
     } catch {

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -883,8 +883,12 @@ chroot_env() {
 
   if [ -n "${SSL_CERT_FILE:-}" ] \
   && [ -z "${NO_MOUNT}" ] \
-  && [ -z "${NO_CERT_PATH}" ]; then 
-    env="$env SSL_CERT_FILE=${HAB_CACHE_CERT_PATH}/$($bb basename "$SSL_CERT_FILE")"
+  && [ -z "${NO_CERT_PATH}" ]; then
+    studio_ssl_cert_file="${HAB_CACHE_CERT_PATH}/$($bb basename "$SSL_CERT_FILE")"
+    # Only set SSL_CERT_FILE inside the studio if the file is present in the cache
+    if [ -f "${HAB_STUDIO_ROOT}/${studio_ssl_cert_file}" ]; then
+      env="$env SSL_CERT_FILE=${studio_ssl_cert_file}"
+    fi
   fi
 
   env="$env $(load_secrets)"
@@ -934,6 +938,9 @@ report_env_vars() {
   fi
   if [ -n "${no_proxy:-}" ]; then
     info "Exported: no_proxy=$no_proxy"
+  fi
+  if [ -n "${SSL_CERT_FILE:-}" ]; then
+    info "Exported: SSL_CERT_FILE=$SSL_CERT_FILE"
   fi
 
   for secret_name in $(load_secrets | $bb cut -d = -f 1); do

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -939,9 +939,6 @@ report_env_vars() {
   if [ -n "${no_proxy:-}" ]; then
     info "Exported: no_proxy=$no_proxy"
   fi
-  if [ -n "${SSL_CERT_FILE:-}" ]; then
-    info "Exported: SSL_CERT_FILE=$SSL_CERT_FILE"
-  fi
 
   for secret_name in $(load_secrets | $bb cut -d = -f 1); do
     info "Exported: $secret_name=[redacted]"

--- a/test/end-to-end/test_studio_when_ssl_cert_file_isnt_cached.sh
+++ b/test/end-to-end/test_studio_when_ssl_cert_file_isnt_cached.sh
@@ -19,7 +19,9 @@ rm -f ~/.hab/cache/ssl/*
 # the auto-installation of the studio on first-run triggers
 # the behavior we're attempting to test
 echo "--- Uninstalling any existing studio packages"
-hab pkg uninstall core/hab-studio || true
+while hab pkg uninstall core/hab-studio; do 
+  :; # no-op
+done
 
 echo "--- Test SSL_CERT_FILE remains unset inside the studio"
 hab studio run "echo \$SSL_CERT_FILE && test ! -v SSL_CERT_FILE"

--- a/test/end-to-end/test_studio_when_ssl_cert_file_isnt_cached.sh
+++ b/test/end-to-end/test_studio_when_ssl_cert_file_isnt_cached.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Test that when SSL_CERT_FILE isn't cached, the variable isn't 
+# set on the inside of the studio.  
+# https://github.com/habitat-sh/habitat/issues/7219
+
+set -euo pipefail
+
+source .expeditor/scripts/end_to_end/shared_end_to_end.sh
+ 
+echo "--- Generating a signing key"
+hab origin key generate "$HAB_ORIGIN"
+
+echo "--- Removing any existing cached certificates"
+rm -f /hab/cache/ssl/*
+rm -f ~/.hab/cache/ssl/*
+
+# This must be run immediatly before `studio run`, as 
+# the auto-installation of the studio on first-run triggers
+# the behavior we're attempting to test
+echo "--- Uninstalling any existing studio packages"
+hab pkg uninstall core/hab-studio || true
+
+echo "--- Test SSL_CERT_FILE remains unset inside the studio"
+hab studio run "echo \$SSL_CERT_FILE && test ! -v SSL_CERT_FILE"
+

--- a/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
+++ b/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
@@ -125,12 +125,15 @@ Context "SSL_CERT_FILE isn't set" {
         Cleanup-CachedCertificate
         # Ensure SSL_CERT_FILE isn't set
         Remove-Item Env:\SSL_CERT_FILE
-    }
-
-    Describe "SSL_CERT_FILE isn't set when studio is auto-installed on first run" {
         hab studio rm
         hab pkg uninstall core/hab-studio
-        $result = hab studio run '$env:SSL_CERT_FILE -eq $null'
-        $result[-1] | Should -be "True"
+    }
+
+    Describe "Studio is auto-installed on first run" {
+
+        It "Should not set SSL_CERT_FILE in the studio" {
+            $result = hab studio run '$env:SSL_CERT_FILE -eq $null'
+            $result[-1]| Should -be "True"
+        }
     }
 }

--- a/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
+++ b/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
@@ -117,3 +117,20 @@ Context "SSL_CERT_FILE is passed into the studio" {
         }
     }
 }
+
+Write-Host "--- Testing SSL_CERT_FILE is not set"
+
+Context "SSL_CERT_FILE isn't set" {
+    BeforeEach { 
+        Cleanup-CachedCertificate
+        # Ensure SSL_CERT_FILE isn't set
+        Remove-Item Env:\SSL_CERT_FILE
+    }
+
+    Describe "SSL_CERT_FILE isn't set when studio is auto-installed on first run" {
+        hab studio rm
+        hab pkg uninstall core/hab-studio
+        $result = hab studio run '$env:SSL_CERT_FILE -eq $null'
+        $result[-1] | Should -be "True"
+    }
+}


### PR DESCRIPTION
Closes #7219 

Thanks to @stevendanna for the extremely detailed write up in that issue.  

The original intent behind the munging and passing of `SSL_CERT_FILE` into the studio was for the self-signed-cert case, where a user may have it set in order to interact with internal services such as  vcs, or artifact repositories. The assumption being that if a user has it set external to the studio, they will likely need it set inside the studio as well.  

This change attempts to preserve that intent, by only setting `SSL_CERT_FILE` if the the file was cached.  Windows doesn't appear to have the same issue Linux does due to how the ssl-probe crate works, however it's a good check to make anyways.

Testing this is somewhat of a pain, due to the nature of how it is triggered.  I validated this by standing up a local builder instance and building and uploading a package with this change to that local instance. 