### PR TITLE
Retry installation of rustup in CI for Windows

### DIFF
--- a/.expeditor/scripts/shared.ps1
+++ b/.expeditor/scripts/shared.ps1
@@ -90,8 +90,8 @@ function Install-Rustup($Toolchain) {
         Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
       }
 
-#./rustup-init.exe -y --default-toolchain $toolchain-x86_64-pc-windows-msvc --no-modify-path --profile=minimal
-#$env:path += ";$env:USERPROFILE\.cargo\bin"
+  ./rustup-init.exe -y --default-toolchain $toolchain-x86_64-pc-windows-msvc --no-modify-path --profile=minimal
+  $env:path += ";$env:USERPROFILE\.cargo\bin"
   }
 }
 

--- a/.expeditor/scripts/shared.ps1
+++ b/.expeditor/scripts/shared.ps1
@@ -85,11 +85,11 @@ function Install-Rustup($Toolchain) {
       $RetryCount = 0
       while( $RetryCount -lt 5 ) {
         try { 
-          Invoke-RestMethod -UseBasicParsing 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe' `
-                            -OutFile 'rustup-init.exe'
-
-        } catch {
           $RetryCount += 1
+          Invoke-RestMethod -UseBasicParsing 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe' `
+                            -OutFile 'rustup-init.exe' 
+          break
+        } catch {
           Write-Host "--- (Tries: $RetryCount) Unable to install rustup"
           # Dig into the exception to get the Response details.
           Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__ 

--- a/.expeditor/scripts/shared.ps1
+++ b/.expeditor/scripts/shared.ps1
@@ -78,9 +78,20 @@ function Install-Rustup($Toolchain) {
   } else {
       Write-Host "Installing rustup and $toolchain-x86_64-pc-windows-msvc Rust."
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-      invoke-restmethod -usebasicparsing 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe' -outfile 'rustup-init.exe'
-      ./rustup-init.exe -y --default-toolchain $toolchain-x86_64-pc-windows-msvc --no-modify-path --profile=minimal
-      $env:path += ";$env:USERPROFILE\.cargo\bin"
+      try { 
+        Invoke-RestMethod -UseBasicParsing 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe' `
+                          -OutFile 'rustup-init.exe' `
+                          -MaximumRetryCount 5 `
+                          -RetryIntervalSec 5 
+      } catch {
+        Write-Host "Unable to install rustup"
+        # Dig into the exception to get the Response details.
+        Write-Host "StatusCode:" $_.Exception.Response.StatusCode.value__ 
+        Write-Host "StatusDescription:" $_.Exception.Response.StatusDescription
+      }
+
+#./rustup-init.exe -y --default-toolchain $toolchain-x86_64-pc-windows-msvc --no-modify-path --profile=minimal
+#$env:path += ";$env:USERPROFILE\.cargo\bin"
   }
 }
 


### PR DESCRIPTION
Partially addresses #7231 

While I still don't have an explanation as to why this action fails in CI on Windows intermittently, this should provides some relief by retrying a few times with a short wait between retries.  It may also give us some additional information if the retries aren't sufficient, by printing information about the exception raised. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>