### PR TITLE
mirror RUSTFMT_VERSION in RUST_NIGHTLY_VERSION

### DIFF
--- a/.expeditor/scripts/finish_release/bump_rustfmt.sh
+++ b/.expeditor/scripts/finish_release/bump_rustfmt.sh
@@ -4,6 +4,13 @@
 # When found, it bumps the repo rustfmt version and submits a new PR
 # with the new version pin and any code base formatting changes from the
 # new version.
+#
+# Once an rustfmt nightly toolchain version is selected, we use the same
+# toolchain version for the RUST_NIGHTLY_VERSION version pin.
+# The RUST_NIGHTLY_VERSION file defines the toolchain used for cargo test.
+# Since simply running `cargo test` does not require the installation
+# of any additional rust components, using the same toolchain selected
+# for rustfmt suffices.
 
 # Assumptions:
 # 1. This script runs on a x86_64-unknown-linux-gnu target
@@ -63,15 +70,15 @@ run_fmt_open_pr() {
   readonly branch="expeditor/rustfmt_${version_underbar}"
   maybe_run git checkout -b "${branch}"
 
-  # update the rustfmt version pin file
-  echo "${FOUND_VERSION}" > RUSTFMT_VERSION
+  # update the version pin files
+  echo "${FOUND_VERSION}" | tee RUSTFMT_VERSION RUST_NIGHTLY_VERSION
 
   # sweep the codebase
   echo "--- :rust: Running new rustfmt"
   cargo +"$(< RUSTFMT_VERSION)" fmt --all
 
   git add --update
-  maybe_run git commit --signoff --message "\"Bump rustfmt to ${FOUND_VERSION}\""
+  maybe_run git commit --signoff --message "\"Bump nightly toolchain to ${FOUND_VERSION}\""
 
   # This script runs from a pipeline step, thus we do not
   # have access to expeditor's open_pull_request bash

--- a/.expeditor/scripts/finish_release/bump_rustfmt.sh
+++ b/.expeditor/scripts/finish_release/bump_rustfmt.sh
@@ -5,12 +5,8 @@
 # with the new version pin and any code base formatting changes from the
 # new version.
 #
-# Once an rustfmt nightly toolchain version is selected, we use the same
+# Once a rustfmt nightly toolchain version is selected, we use the same
 # toolchain version for the RUST_NIGHTLY_VERSION version pin.
-# The RUST_NIGHTLY_VERSION file defines the toolchain used for cargo test.
-# Since simply running `cargo test` does not require the installation
-# of any additional rust components, using the same toolchain selected
-# for rustfmt suffices.
 
 # Assumptions:
 # 1. This script runs on a x86_64-unknown-linux-gnu target

--- a/.expeditor/scripts/finish_release/notify_rustfmt.sh
+++ b/.expeditor/scripts/finish_release/notify_rustfmt.sh
@@ -26,7 +26,7 @@ send_notification() {
   local url="${1?url argument required}"
   local message
   message=$(cat <<MSG
-Hi @habitat-team, there is a rustfmt version bump PR ready for review! :jumping-habicat:
+Hi @habitat-team, there is a nightly toolchain version bump PR ready for review! :jumping-habicat:
 
 ${url}
 

--- a/.expeditor/scripts/verify/run_cargo_test.ps1
+++ b/.expeditor/scripts/verify/run_cargo_test.ps1
@@ -28,6 +28,10 @@ If($Features) {
 
 # Set cargo test invocation
 Install-Rustup $toolchain
+# In this context we are installing a nightly toolchain and do not
+# require any additional components, we'll set a minimal profile.
+# https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles
+rustup set profile minimal
 Install-RustToolchain $toolchain
 $CargoTestCommand = "cargo +$toolchain test $FeatureString -- $TestOptions"
 

--- a/.expeditor/scripts/verify/run_cargo_test.ps1
+++ b/.expeditor/scripts/verify/run_cargo_test.ps1
@@ -28,10 +28,6 @@ If($Features) {
 
 # Set cargo test invocation
 Install-Rustup $toolchain
-# In this context we are installing a nightly toolchain and do not
-# require any additional components, we'll set a minimal profile.
-# https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles
-rustup set profile minimal
 Install-RustToolchain $toolchain
 $CargoTestCommand = "cargo +$toolchain test $FeatureString -- $TestOptions"
 

--- a/.expeditor/scripts/verify/run_cargo_test.sh
+++ b/.expeditor/scripts/verify/run_cargo_test.sh
@@ -23,6 +23,10 @@ fi
 # All the remaining args are passed to cargo test +"$toolchain"
 
 install_rustup
+# In this context we are installing a nightly toolchain and do not
+# require any additional components, we'll set a minimal profile.
+# https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles
+rustup set profile minimal
 install_rust_toolchain "$toolchain"
 
 # TODO: fix this upstream, it looks like it's not saving correctly.
@@ -62,7 +66,7 @@ TESTING_FS_ROOT=$(mktemp -d /tmp/testing-fs-root-XXXXXX)
 
 export RUST_BACKTRACE=1
 
-echo "--- Running cargo +$toolchain test with on $scope with $*"
+echo "--- Running cargo +$toolchain test with scope '$scope' and args '$*'"
 
 if [[ -n ${component:-} ]]; then
   cd "components/$component"

--- a/.expeditor/scripts/verify/run_cargo_test.sh
+++ b/.expeditor/scripts/verify/run_cargo_test.sh
@@ -23,10 +23,6 @@ fi
 # All the remaining args are passed to cargo test +"$toolchain"
 
 install_rustup
-# In this context we are installing a nightly toolchain and do not
-# require any additional components, we'll set a minimal profile.
-# https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles
-rustup set profile minimal
 install_rust_toolchain "$toolchain"
 
 # TODO: fix this upstream, it looks like it's not saving correctly.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -73,7 +73,7 @@ You would run:
 cargo +nightly-2019-05-10 fmt
 ```
 
-You may also be able to configure your editor to automatically run rustfmt every time you save. The [./support/rustfmt_nightly.sh](./support/rustfmt_nightly.sh) script may be helpful. 
+You may also be able to configure your editor to automatically run rustfmt every time you save. The [./support/rustfmt_nightly.sh](./support/rustfmt_nightly.sh) script may be helpful.
 
 # Compiling habitat binaries
 
@@ -140,6 +140,25 @@ export HAB_SUP_BINARY=/path/to/habitat/target/debug/hab-sup
 or setting the value upon execution of the `hab` binary:
 ```
 env HAB_SUP_BINARY=/path/to/habitat/target/debug/hab-sup hab sup status
+```
+
+## Running Unit Tests
+
+In order to exercise the project's unit tests you can either leverage one of the existing platform specific CI scripts or use `cargo test` on the CLI.
+
+Linux CI script
+```
+$ .expeditor/scripts/verify/run_cargo_test.sh
+```
+
+Windows CI script
+```
+$ .expeditor/scripts/verify/run_cargo_test.ps1
+```
+
+Using cargo
+```
+$ cargo +$(<RUST_NIGHTLY_VERSION) test
 ```
 
 ## Always test the habitat package


### PR DESCRIPTION
This PR leverages last week's [work](https://github.com/habitat-sh/habitat/pull/7258) which auto bumps the version in `RUSTFMT_VERSION` following a new release and mirrors the same version in `RUST_NIGHTLY_VERSION`.

For all intents and purposes, `RUST_NIGHTLY_VERSION` holds the toolchain version used by CI for running our Unit Test suites via `cargo test`.  Since our automation already selects a nightly toollchain version usable for running `rustfmt` we opt to use that same version for unit tests in order to keep complexity low.

Keeping the two files distinctly separate still allows us the flexibility to decouple the toolchain used by either `rustfmt` or `cargo test` should that need ever arise.
