### PR TITLE
Unpin reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1132,7 +1132,7 @@ dependencies = [
  "pbr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1191,7 +1191,7 @@ dependencies = [
  "pbr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-transcode 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1255,7 +1255,7 @@ dependencies = [
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2091,7 +2091,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.17"
+version = "0.9.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2709,6 +2709,7 @@ dependencies = [
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4178,7 +4179,7 @@ dependencies = [
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.9.17 (registry+https://github.com/rust-lang/crates.io-index)" = "e57803405f8ea0eb041c1567dac36127e0c8caa1251c843cb03d43fd767b3d50"
+"checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum resolv-conf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b263b4aa1b5de9ffc0054a2386f96992058bb6870aab516f8cdeb8a667d56dcb"
 "checksum retry 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c8ac83b31b3831aa4b07608db4170f6555ab12942197037c38570dc4c5ba5028"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"

--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -15,10 +15,7 @@ log = "*"
 pbr = "*"
 rand = "*"
 regex = "*"
-# Locked on this version of reqwest until we can go fully async: see
-# https://github.com/seanmonstar/reqwest/commit/5096e12fa21ffdf62ce953c7514e772959d1e4e1
-# and https://github.com/habitat-sh/habitat/issues/6852
-reqwest = "=0.9.17"
+reqwest = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -32,10 +32,7 @@ parking_lot = "*"
 pbr = "*"
 petgraph = "*"
 regex = "*"
-# Locked on this version of reqwest until we can go fully async: see
-# https://github.com/seanmonstar/reqwest/commit/5096e12fa21ffdf62ce953c7514e772959d1e4e1
-# and https://github.com/habitat-sh/habitat/issues/6852
-reqwest = "=0.9.17"
+reqwest = "*"
 serde = "*"
 serde_derive = "*"
 serde_json = "*"

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -19,7 +19,7 @@ chrono = {version = "*", features = ["serde"]}
 dirs = "*"
 env_logger = "*"
 flate2 = "*"
-futures = "*"
+futures = "0.1"
 glob = "*"
 habitat_api_client = { path = "../builder-api-client" }
 habitat_common = { path = "../common" }
@@ -32,10 +32,7 @@ lazy_static = "*"
 libc = "*"
 log = "*"
 pbr = "*"
-# Locked on this version of reqwest until we can go fully async: see
-# https://github.com/seanmonstar/reqwest/commit/5096e12fa21ffdf62ce953c7514e772959d1e4e1
-# and https://github.com/habitat-sh/habitat/issues/6852
-reqwest = "=0.9.17"
+reqwest = "*"
 retry = "*"
 same-file = "*"
 serde = "*"

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -11,10 +11,7 @@ base64 = "*"
 log = "*"
 native-tls = "*"
 httparse = "*"
-# Locked on this version of reqwest until we can go fully async: see
-# https://github.com/seanmonstar/reqwest/commit/5096e12fa21ffdf62ce953c7514e772959d1e4e1
-# and https://github.com/habitat-sh/habitat/issues/6852
-reqwest = "=0.9.17"
+reqwest = "*"
 # Unlock with url here and in bulider-api-client
 env_proxy = "=0.3.1"
 serde = "*"

--- a/components/sup-client/Cargo.toml
+++ b/components/sup-client/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["The Habitat Maintainers <humans@habitat.sh>"]
 workspace = "../../"
 
 [dependencies]
-futures = "*"
+futures = "0.1"
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 habitat_common = { path = "../common" }
 log = "*"

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -9,7 +9,7 @@ workspace = "../../"
 [dependencies]
 base64 = "*"
 bytes = "*"
-futures = "*"
+futures = "0.1"
 habitat_core = { path = "../core" }
 lazy_static = "*"
 log = "*"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -20,7 +20,7 @@ actix-web = { version = "*", default-features = false, features = [ "rust-tls" ]
 byteorder = "*"
 clap = { version = "*", features = [ "suggestions", "color", "unstable" ] }
 cpu-time = "*"
-futures = "*"
+futures = "0.1"
 glob = "*"
 hab = { path = "../hab" }
 habitat_butterfly = { path = "../butterfly", default-features = false }


### PR DESCRIPTION
This unpins reqwest now that a blocking issue has been resolved in the latest version.

Note: cargo is not cooperating and the Cargo.lock has needed some hand holding.

The wierdness should be resolved by the updates planned in https://github.com/habitat-sh/habitat/pull/7256

Signed-off-by: Salim Alam <salam@chef.io>

![](https://media1.giphy.com/media/MX6f6I28EOTVZZmYvo/giphy.gif?cid=5a38a5a24954dfaa95ce20d835c3898a5fecaa2849b5dfeb&rid=giphy.gif)
