### PR TITLE
Put jemalloc behind a cargo feature flag

### DIFF
--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -85,8 +85,9 @@ json = "*"
 prost-build = "*"
 
 [features]
-default = []
+default = ["jemalloc"]
 apidocs = []
 ignore_integration_tests = []
+jemalloc = []
 lock_as_rwlock = ["habitat_common/lock_as_rwlock"]
 lock_as_mutex = ["habitat_common/lock_as_mutex"]

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -1,9 +1,5 @@
 extern crate clap;
 extern crate habitat_sup as sup;
-#[cfg(unix)]
-extern crate jemalloc_ctl;
-#[cfg(unix)]
-extern crate jemallocator;
 #[macro_use]
 extern crate log;
 #[cfg(test)]
@@ -75,7 +71,7 @@ use tempfile::TempDir;
 /// Our output key
 static LOGKEY: &str = "MN";
 
-#[cfg(unix)]
+#[cfg(all(feature = "jemalloc", unix))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1905,7 +1905,7 @@ fn get_fd_count() -> std::io::Result<usize> {
     Ok(fs::read_dir(FD_DIR)?.count())
 }
 
-#[cfg(unix)]
+#[cfg(all(feature = "jemalloc", unix))]
 fn track_memory_stats() {
     // We'd like to track some memory stats, but these stats are cached and only refreshed
     // when the epoch is advanced. We manually advance it here to ensure our stats are
@@ -1944,8 +1944,8 @@ fn track_memory_stats() {
                                                          .to_i64());
 }
 
-// This is a no-op on purpose because windows doesn't support jemalloc
-#[cfg(windows)]
+// This is a no-op on purpose if we do not support jemalloc
+#[cfg(not(all(feature = "jemalloc", unix)))]
 fn track_memory_stats() {}
 
 #[cfg(test)]


### PR DESCRIPTION
As the PR stands now, the `jemalloc` feature flag is enabled by default so there is no immediate change in behavior. If we decide to change our default allocator the PR will be changed accordingly. 

This is one possible option to unblock #7256. There should be more discussion to determine all the ramifications of this change.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>