### PR TITLE
bulkupload: discover origins from signing keys

### DIFF
--- a/components/hab/src/command/origin/key.rs
+++ b/components/hab/src/command/origin/key.rs
@@ -14,8 +14,7 @@ use crate::{error::{Error,
                     Result},
             hcore};
 
-// shared between origin::key::upload and origin::key::upload_latest
-fn get_name_with_rev(keyfile: &Path, expected_vsn: &str) -> Result<String> {
+pub fn get_name_with_rev(keyfile: &Path, expected_vsn: &str) -> Result<String> {
     let f = File::open(&keyfile)?;
     let f = BufReader::new(f);
     let mut lines = f.lines();

--- a/components/hab/src/command/pkg/bulkupload.rs
+++ b/components/hab/src/command/pkg/bulkupload.rs
@@ -21,6 +21,7 @@ use crate::{api_client::{self,
             error::{Error,
                     Result},
             hcore::{crypto::{keys::parse_name_with_rev,
+                             PUBLIC_KEY_SUFFIX,
                              PUBLIC_SIG_KEY_VERSION},
                     ChannelIdent},
             PRODUCT,
@@ -49,7 +50,7 @@ pub fn start(ui: &mut UI,
              key_path: &Path)
              -> Result<()> {
     let artifact_paths = paths_with_extension(artifact_path, "hart");
-    let pub_keys_paths = paths_with_extension(key_path, "pub");
+    let pub_keys_paths = paths_with_extension(key_path, PUBLIC_KEY_SUFFIX);
 
     ui.begin(format!("Preparing to upload artifacts to the '{}' channel on {}",
                      additional_release_channel.clone()
@@ -121,16 +122,17 @@ pub fn start(ui: &mut UI,
     Ok(())
 }
 
-fn paths_with_extension<P>(path: P, pattern: &str) -> Vec<PathBuf>
+fn paths_with_extension<P>(path: P, suffix: &str) -> Vec<PathBuf>
     where P: AsRef<Path>
 {
     let options = glob::MatchOptions { case_sensitive:              true,
                                        require_literal_separator:   true,
                                        require_literal_leading_dot: true, };
-    glob_with(&path.as_ref().join(pattern).display().to_string(), options).expect("Failed to read \
-                                                                                   glob pattern")
-                                                                          .filter_map(std::result::Result::ok)
-                                                                          .collect()
+    let pattern = format!("*.{}", suffix);
+    glob_with(&path.as_ref().join(pattern).display().to_string(),
+              options).expect("Failed to read glob pattern")
+                      .filter_map(std::result::Result::ok)
+                      .collect()
 }
 
 fn ask_create_origins(ui: &mut UI) -> Result<bool> {

--- a/components/hab/src/command/pkg/bulkupload.rs
+++ b/components/hab/src/command/pkg/bulkupload.rs
@@ -129,7 +129,7 @@ fn paths_with_extension<P>(path: P, pattern: &str) -> Vec<PathBuf>
                                        require_literal_leading_dot: true, };
     glob_with(&path.as_ref().join(pattern).display().to_string(), options).expect("Failed to read \
                                                                                    glob pattern")
-                                                                          .filter_map(|x| x.ok())
+                                                                          .filter_map(std::result::Result::ok)
                                                                           .collect()
 }
 


### PR DESCRIPTION
Fixes #7275 

This PR changes the method by which `hab pkg bulkupload` builds the list of origins for the package set about to be uploaded. Previously the origin list was discovered by calling `PackageArchive::new()` on each package archive and then pulling out the ident.origin. That proved to be too expensive an operation at any sort of scale potentially due to https://github.com/habitat-sh/habitat/issues/5153

Now the origin list is discovered from the public signing keys in the upload directory. The time savings is substantial.

Before (the 1st stack is the `hab::command::pkg::bulkupload` code path, which passes the execution thread off to the 2nd stack `hab::command::pkg::upload`):
![Screen Shot 2019-12-11 at 10 42 18 AM](https://user-images.githubusercontent.com/1991696/70636111-fee2a500-1c02-11ea-925a-1e6e1f1c54cf.png)

After (notice the 1st stack is almost entirely eliminated, only the `hab::command::pkg:upload` remains with any substantive I/O cost):
![Screen Shot 2019-12-11 at 10 44 04 AM](https://user-images.githubusercontent.com/1991696/70636250-32253400-1c03-11ea-86cc-3a90125ebccd.png)

Signed-off-by: Jeremy J. Miller <jm@chef.io>