### PR TITLE
Add a "test-probe" service

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -92,3 +92,6 @@ plan_path = "components/pkg-mesosize"
 
 [simple-hooks]
 plan_path = "test/fixtures/plans/simple-hooks"
+
+[test-probe]
+plan_path = "test-services/test-probe"

--- a/.expeditor/scripts/verify/build_package.ps1
+++ b/.expeditor/scripts/verify/build_package.ps1
@@ -3,8 +3,8 @@
 #Requires -Version 5
 
 param (
-    # The name of the component to be built. Defaults to none
-    [string]$Component
+    # The path to the package to be built. Defaults to none
+    [string]$PackagePath
 )
 
 . $PSScriptRoot\shared.ps1
@@ -19,8 +19,8 @@ $env:HAB_CACHE_KEY_PATH="$job_temp_root/keys"
 
 Write-Host "--- :key: Generating fake origin key"
 hab origin key generate
-Write-Host "--- :hab: Running hab pkg build for $Component"
+Write-Host "--- :hab: Running hab pkg build for $PackagePath"
 
-hab studio build components/$Component -R
+hab studio build $PackagePath -R
 
 exit $LASTEXITCODE

--- a/.expeditor/scripts/verify/build_package.sh
+++ b/.expeditor/scripts/verify/build_package.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-component=${1?component argument required}
+package_path=${1?package_path argument required}
 
 # Since we are only verifying we don't have build failures, make everything
 # temp!
@@ -16,5 +16,5 @@ HAB_CACHE_KEY_PATH="$JOB_TEMP_ROOT/keys"
 
 echo "--- :key: Generating fake origin key"
 hab origin key generate
-echo "--- :hab: Running hab pkg build for $component"
-hab pkg build -D components/"$component"
+echo "--- :hab: Running hab pkg build for $package_path"
+hab pkg build -D "$package_path"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -573,6 +573,19 @@ steps:
 # still build. - Linux
 #######################################################################
 
+  - label: "[build] :linux: test-probe"
+    env:
+      HAB_LICENSE: "accept-no-persist"
+    command:
+      - hab pkg build test-services/test-probe
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+    retry:
+      automatic:
+        limit: 1
+
   - label: "[build] :linux: backline"
     env:
       HAB_LICENSE: "accept-no-persist"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -577,10 +577,10 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - hab pkg build test-services/test-probe
+      - .expeditor/scripts/verify/build_package.sh test-services/test-probe
     expeditor:
       executor:
-        docker:
+        linux:
           privileged: true
     retry:
       automatic:
@@ -590,7 +590,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh backline
+      - .expeditor/scripts/verify/build_package.sh components/backline
     expeditor:
       executor:
         linux:
@@ -603,7 +603,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh hab
+      - .expeditor/scripts/verify/build_package.sh components/hab
     expeditor:
       executor:
         linux:
@@ -616,7 +616,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh launcher
+      - .expeditor/scripts/verify/build_package.sh components/launcher
     expeditor:
       executor:
         linux:
@@ -629,7 +629,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh pkg-aci
+      - .expeditor/scripts/verify/build_package.sh components/pkg-aci
     expeditor:
       executor:
         linux:
@@ -642,7 +642,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh pkg-cfize
+      - .expeditor/scripts/verify/build_package.sh components/pkg-cfize
     expeditor:
       executor:
         linux:
@@ -655,7 +655,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh pkg-dockerize
+      - .expeditor/scripts/verify/build_package.sh components/pkg-dockerize
     expeditor:
       executor:
         linux:
@@ -668,7 +668,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh pkg-export-docker
+      - .expeditor/scripts/verify/build_package.sh components/pkg-export-docker
     expeditor:
       executor:
         linux:
@@ -681,7 +681,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh pkg-export-helm
+      - .expeditor/scripts/verify/build_package.sh components/pkg-export-helm
     expeditor:
       executor:
         linux:
@@ -694,7 +694,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh pkg-export-kubernetes
+      - .expeditor/scripts/verify/build_package.sh components/pkg-export-kubernetes
     expeditor:
       executor:
         linux:
@@ -707,7 +707,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh pkg-export-tar
+      - .expeditor/scripts/verify/build_package.sh components/pkg-export-tar
     expeditor:
       executor:
         linux:
@@ -720,7 +720,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh pkg-mesosize
+      - .expeditor/scripts/verify/build_package.sh components/pkg-mesosize
     expeditor:
       executor:
         linux:
@@ -733,7 +733,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh plan-build
+      - .expeditor/scripts/verify/build_package.sh components/plan-build
     expeditor:
       executor:
         linux:
@@ -746,7 +746,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh studio
+      - .expeditor/scripts/verify/build_package.sh components/studio
     expeditor:
       executor:
         linux:
@@ -759,7 +759,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.sh sup
+      - .expeditor/scripts/verify/build_package.sh components/sup
     expeditor:
       executor:
         linux:
@@ -778,7 +778,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.ps1 hab
+      - .expeditor/scripts/verify/build_package.ps1 components/hab
     expeditor:
       executor:
         docker:
@@ -793,7 +793,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.ps1 launcher
+      - .expeditor/scripts/verify/build_package.ps1 components/launcher
     expeditor:
       executor:
         docker:
@@ -807,7 +807,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.ps1 pkg-export-docker
+      - .expeditor/scripts/verify/build_package.ps1 components/pkg-export-docker
     expeditor:
       executor:
         docker:
@@ -821,7 +821,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.ps1 pkg-export-tar
+      - .expeditor/scripts/verify/build_package.ps1 components/pkg-export-tar
     expeditor:
       executor:
         docker:
@@ -836,7 +836,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.ps1 plan-build-ps1
+      - .expeditor/scripts/verify/build_package.ps1 components/plan-build-ps1
     expeditor:
       executor:
         docker:
@@ -850,7 +850,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.ps1 studio
+      - .expeditor/scripts/verify/build_package.ps1 components/studio
     expeditor:
       executor:
         docker:
@@ -864,7 +864,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.ps1 sup
+      - .expeditor/scripts/verify/build_package.ps1 components/sup
     expeditor:
       executor:
         docker:
@@ -878,7 +878,7 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
     command:
-      - .expeditor/scripts/verify/build_component.ps1 windows-service
+      - .expeditor/scripts/verify/build_package.ps1 components/windows-service
     expeditor:
       executor:
         docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,6 +3516,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-probe"
+version = "0.1.0"
+dependencies = [
+ "actix-web 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ members = [
   "components/sup-protocol",
   "components/win-users",
   "tools/one-off-release",
+  "test-services/test-probe",
 ]

--- a/test-services/test-probe/Cargo.toml
+++ b/test-services/test-probe/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "test-probe"
+version = "0.1.0"
+edition = "2018"
+authors = ["The Habitat Maintainers <humans@habitat.sh>"]
+workspace = "../../"
+
+[dependencies]
+actix-web = { version = "*", default-features = false, features = [ "rust-tls" ] }
+clap = "*"
+serde = "*"
+serde_derive = "*"
+serde_json = "*"
+toml = "*"

--- a/test-services/test-probe/README.md
+++ b/test-services/test-probe/README.md
@@ -1,0 +1,81 @@
+# Habitat package: test-probe
+
+## Description
+
+A small [actix-web](https://github.com/actix/actix-web)-powered API
+service used to introspect the operation of the
+[Habitat](https://habitat.sh) Supervisor.
+
+## Usage
+
+Deploy to your Habitat Supervisor:
+
+```
+hab svc load habitat-testing/test-probe
+```
+Introspect the service's view of things by querying what would be its
+[template data](https://www.habitat.sh/docs/reference/#template-data)
+over its HTTP API. Simply provide the path through the data you would
+like to inspect, and it will be returned to you as JSON. This approach
+allows you to actively verifiy Habitat _behaviors_, as opposed to
+relying on implementation details, such as knowing where a Supervisor
+may write data files out to disk.
+
+```
+$ curl http://localhost:8000/context/svc/me
+{
+  "alive": true,
+  "application": null,
+  "cfg": {},
+  "confirmed": false,
+  "departed": false,
+  "election_is_finished": false,
+  "election_is_no_quorum": false,
+  "election_is_running": false,
+  "environment": null,
+  "follower": false,
+  "group": "default",
+  "leader": false,
+  "member_id": "af3906a38dd8450e80c313a421967669",
+  "org": null,
+  "persistent": true,
+  "pkg": {
+    "name": "test-probe",
+    "origin": "habitat-testing",
+    "release": "20180416163256",
+    "version": "0.1.0"
+  },
+  "service": "test-probe",
+  "suspect": false,
+  "sys": {
+    "ctl_gateway_ip": "127.0.0.1",
+    "ctl_gateway_port": 9632,
+    "gossip_ip": "127.0.0.1",
+    "gossip_port": 20000,
+    "hostname": "yokai",
+    "http_gateway_ip": "0.0.0.0",
+    "http_gateway_port": 20001,
+    "ip": "192.168.67.162"
+  },
+  "update_election_is_finished": false,
+  "update_election_is_no_quorum": false,
+  "update_election_is_running": false,
+  "update_follower": false,
+  "update_leader": false
+}
+
+$ curl http://localhost:8000/context/svc/me/sys/ip
+"192.168.67.162"
+```
+
+## Local Development
+
+```
+cargo build
+```
+
+Build a standard Habitat package
+
+```
+hab pkg build <REPO>/test-services/test-probe
+```

--- a/test-services/test-probe/habitat/config/config.toml
+++ b/test-services/test-probe/habitat/config/config.toml
@@ -1,0 +1,3 @@
+host = "{{cfg.host}}"
+port = {{cfg.port}}
+render_context_file = "{{cfg.render_context_file}}"

--- a/test-services/test-probe/habitat/config/render_context.json
+++ b/test-services/test-probe/habitat/config/render_context.json
@@ -1,0 +1,7 @@
+{
+    "sys": {{toJson sys}},
+    "pkg": {{toJson pkg}},
+    "cfg": {{toJson cfg}},
+    "svc": {{toJson svc}},
+    "bind": {{toJson bind}}
+}

--- a/test-services/test-probe/habitat/default.toml
+++ b/test-services/test-probe/habitat/default.toml
@@ -1,0 +1,3 @@
+host = "0.0.0.0"
+port = 8000
+render_context_file = "/hab/svc/test-probe/config/render_context.json"

--- a/test-services/test-probe/habitat/hooks/health-check
+++ b/test-services/test-probe/habitat/hooks/health-check
@@ -1,0 +1,5 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+echo "Running health_check hook: {{pkg.ident}} (PID: $$, PPID: $PPID, PGID: $(ps h -o pgid -p $$))"
+sleep 2
+echo "health_check finished!"

--- a/test-services/test-probe/habitat/hooks/init
+++ b/test-services/test-probe/habitat/hooks/init
@@ -1,0 +1,15 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+echo "Initializing package {{pkg.ident}} (PID: $$, PPID: $PPID, PGID: $(ps h -o pgid -p $$))"
+sleep 1
+echo "... reticulating splines ..."
+echo "... integrating curves ..."
+echo "... relaxing splines ..."
+echo "... calculating inverse probability matrices ..."
+sleep 1
+echo "Deliberately taking a long time in the init hook"
+for i in {1..10}; do
+      sleep 1
+      echo "Sleeping ($i)/10..."
+done
+echo "init hook DONE"

--- a/test-services/test-probe/habitat/hooks/post-run
+++ b/test-services/test-probe/habitat/hooks/post-run
@@ -1,0 +1,4 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+echo "Running post-run script: {{pkg.ident}} (PID: $$, PPID: $PPID, PGID: $(ps h -o pgid -p $$))"
+echo "Done"

--- a/test-services/test-probe/habitat/hooks/post-stop
+++ b/test-services/test-probe/habitat/hooks/post-stop
@@ -1,0 +1,14 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+byebye(){
+    echo "Got a signal!"
+}
+trap byebye INT TERM
+
+
+echo "Deliberately long post-stop hook executing: {{pkg.ident}} (PID: $$, PPID: $PPID, PGID: $(ps h -o pgid -p $$))"
+for i in {1..15}; do
+      sleep 1
+      echo "Sleeping ($i)/15..."
+done
+echo "post-stop hook DONE"

--- a/test-services/test-probe/habitat/hooks/run
+++ b/test-services/test-probe/habitat/hooks/run
@@ -1,0 +1,20 @@
+#!{{pkgPathFor "core/bash"}}/bin/bash
+
+
+exec 2>&1
+
+echo "Running {{pkg.ident}}" # (PID: $$, PPID: $PPID, PGID: $(ps h -o pgid -p $$))"
+{{ #if bind.thing_with_a_port }}
+echo "*************************************************************"
+echo "Running with a bound service group for 'thing_with_a_port'"
+{{ #each bind.thing_with_a_port.members as |m| ~}}
+echo "- {{m.sys.hostname}}"
+{{/each ~}}
+echo "*************************************************************"
+{{ else }}
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+echo "Running WITHOUT a bound service group for 'thing_with_a_port'"
+echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+{{ /if }}
+
+exec test-probe -c "{{pkg.svc_config_path}}/config.toml"

--- a/test-services/test-probe/habitat/plan.sh
+++ b/test-services/test-probe/habitat/plan.sh
@@ -1,0 +1,47 @@
+# shellcheck disable=2034,2154
+pkg_name=test-probe
+pkg_origin=habitat-testing
+pkg_version="0.1.0"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=("Apache-2.0")
+pkg_bin_dirs=(bin)
+pkg_deps=(core/glibc
+          core/openssl
+          core/gcc-libs
+          core/procps-ng
+          core/bash)
+pkg_build_deps=(core/coreutils
+                core/rust
+                core/gcc
+                core/git
+                core/make)
+pkg_binds_optional=(
+    [thing_with_a_port]="port"
+)
+
+bin="test-probe"
+
+do_prepare() {
+  export rustc_target="x86_64-unknown-linux-gnu"
+  build_line "Setting rustc_target=$rustc_target"
+
+  # Used by Cargo to use a pristine, isolated directory for all compilation
+  export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
+  build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
+}
+
+do_build() {
+    (
+        cd "$PLAN_CONTEXT"/.. || exit
+        cargo build --target="$rustc_target" --verbose
+    )
+}
+
+do_install() {
+  install -v -D "$CARGO_TARGET_DIR/$rustc_target/debug/$bin" \
+    "$pkg_prefix/bin/$bin"
+}
+
+do_strip() {
+    return 0
+}

--- a/test-services/test-probe/src/config.rs
+++ b/test-services/test-probe/src/config.rs
@@ -1,0 +1,34 @@
+use crate::error::{Error,
+                   Result};
+use clap::ArgMatches;
+use std::{fs,
+          path::PathBuf};
+use toml;
+
+pub const DEFAULT_JSON_SOURCE: &str = "/hab/svc/test-probe/config/render_context_file.json";
+pub const DEFAULT_HOST: &str = "0.0.0.0";
+pub const DEFAULT_PORT: u16 = 8000;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Config {
+    pub host:                String,
+    pub port:                u16,
+    pub render_context_file: PathBuf,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config { host:                DEFAULT_HOST.to_string(),
+                 port:                DEFAULT_PORT,
+                 render_context_file: PathBuf::from(DEFAULT_JSON_SOURCE), }
+    }
+}
+
+pub fn from_matches(args: &ArgMatches) -> Result<Config> {
+    if let Some(path) = args.value_of("config") {
+        let contents = fs::read_to_string(path)?;
+        toml::from_str(&contents).map_err(Error::Toml)
+    } else {
+        Ok(Config::default())
+    }
+}

--- a/test-services/test-probe/src/context.rs
+++ b/test-services/test-probe/src/context.rs
@@ -7,25 +7,26 @@ use actix_web::{web,
                 HttpRequest,
                 HttpResponse};
 use serde_json;
-use std::{fs,
-          path::{Components,
-                 Path,
-                 PathBuf}};
+use std::{borrow::Cow,
+          fs,
+          path::Path};
 
 /// Show render context rooted at `path`
 #[allow(clippy::needless_pass_by_value)] // Required by actix-web API
 pub fn show(config: web::Data<config::Config>,
             req: HttpRequest)
             -> actix_web::Result<HttpResponse> {
-    let path = req.match_info()
-                  .get("path")
-                  .map(PathBuf::from)
-                  .unwrap_or_default();
-    let json =
-        extract_data(&config.render_context_file, &path).map_err(actix_web::error::ErrorBadRequest)?;
-
-    if let Some(json) = json {
-        Ok(HttpResponse::Ok().json(json))
+    // A JSON pointer of "" means "everything". Pointers starting with
+    // "/" describe paths into the structure. We'll chop off any
+    // trailing "/" since that will end up looking for an item with a
+    // key of "", which we're just not going to deal with.
+    let pointer = match req.match_info().get("path") {
+        None | Some("") => Cow::Borrowed(""),
+        Some(path) => Cow::Owned(format!("/{}", path.trim_end_matches('/'))),
+    };
+    let json = read_json(&config.render_context_file).map_err(actix_web::error::ErrorBadRequest)?;
+    if let Some(value) = json.pointer(&pointer) {
+        Ok(HttpResponse::Ok().json(value))
     } else {
         Ok(HttpResponse::NotFound().finish())
     }
@@ -33,41 +34,10 @@ pub fn show(config: web::Data<config::Config>,
 
 ////////////////////////////////////////////////////////////////////////
 
-fn extract_data<P>(render_context_file: P, path: P) -> Result<Option<serde_json::Value>>
-    where P: AsRef<Path>
-{
-    let data = read_json(render_context_file)?;
-    lookup(data, path.as_ref().components())
-}
-
 /// Read a file into a JSON value
 fn read_json<P>(path: P) -> Result<serde_json::Value>
     where P: AsRef<Path>
 {
     let contents = fs::read_to_string(path)?;
     serde_json::from_str(&contents).map_err(|e| e.into())
-}
-
-/// Recursively descend through a JSON structure, based on the path
-/// provided in `keys`
-fn lookup(data: serde_json::Value, keys: Components) -> Result<Option<serde_json::Value>> {
-    let mut result = data;
-    for component in keys {
-        let key: &str = &component.as_os_str().to_string_lossy();
-
-        // For arrays, try to coerce key to an integer and do a lookup
-        // that way
-        let lookup_result = if result.is_array() {
-            result.get(key.parse::<usize>()?)
-        } else {
-            result.get(key)
-        };
-
-        if let Some(stuff) = lookup_result {
-            result = stuff.clone(); // eww
-        } else {
-            return Ok(None);
-        }
-    }
-    Ok(Some(result))
 }

--- a/test-services/test-probe/src/context.rs
+++ b/test-services/test-probe/src/context.rs
@@ -1,0 +1,73 @@
+//! Define routes for exposing the contents of the application's
+//! rendering context.
+
+use crate::{config,
+            error::Result};
+use actix_web::{web,
+                HttpRequest,
+                HttpResponse};
+use serde_json;
+use std::{fs,
+          path::{Components,
+                 Path,
+                 PathBuf}};
+
+/// Show render context rooted at `path`
+#[allow(clippy::needless_pass_by_value)] // Required by actix-web API
+pub fn show(config: web::Data<config::Config>,
+            req: HttpRequest)
+            -> actix_web::Result<HttpResponse> {
+    let path = req.match_info()
+                  .get("path")
+                  .map(PathBuf::from)
+                  .unwrap_or_default();
+    let json =
+        extract_data(&config.render_context_file, &path).map_err(actix_web::error::ErrorBadRequest)?;
+
+    if let Some(json) = json {
+        Ok(HttpResponse::Ok().json(json))
+    } else {
+        Ok(HttpResponse::NotFound().finish())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////
+
+fn extract_data<P>(render_context_file: P, path: P) -> Result<Option<serde_json::Value>>
+    where P: AsRef<Path>
+{
+    let data = read_json(render_context_file)?;
+    lookup(data, path.as_ref().components())
+}
+
+/// Read a file into a JSON value
+fn read_json<P>(path: P) -> Result<serde_json::Value>
+    where P: AsRef<Path>
+{
+    let contents = fs::read_to_string(path)?;
+    serde_json::from_str(&contents).map_err(|e| e.into())
+}
+
+/// Recursively descend through a JSON structure, based on the path
+/// provided in `keys`
+fn lookup(data: serde_json::Value, keys: Components) -> Result<Option<serde_json::Value>> {
+    let mut result = data;
+    for component in keys {
+        let key: &str = &component.as_os_str().to_string_lossy();
+
+        // For arrays, try to coerce key to an integer and do a lookup
+        // that way
+        let lookup_result = if result.is_array() {
+            result.get(key.parse::<usize>()?)
+        } else {
+            result.get(key)
+        };
+
+        if let Some(stuff) = lookup_result {
+            result = stuff.clone(); // eww
+        } else {
+            return Ok(None);
+        }
+    }
+    Ok(Some(result))
+}

--- a/test-services/test-probe/src/error.rs
+++ b/test-services/test-probe/src/error.rs
@@ -1,0 +1,41 @@
+use serde_json;
+use std::{error::Error as StdError,
+          fmt,
+          io,
+          num,
+          result};
+use toml;
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    Json(serde_json::Error),
+    Parse(num::ParseIntError),
+    Toml(toml::de::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Io(e) => e.fmt(f),
+            Error::Json(e) => e.fmt(f),
+            Error::Parse(e) => e.fmt(f),
+            Error::Toml(e) => e.fmt(f),
+        }
+    }
+}
+
+impl StdError for Error {}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error { Error::Io(err) }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Error { Error::Json(err) }
+}
+
+impl From<num::ParseIntError> for Error {
+    fn from(err: num::ParseIntError) -> Error { Error::Parse(err) }
+}

--- a/test-services/test-probe/src/main.rs
+++ b/test-services/test-probe/src/main.rs
@@ -1,0 +1,34 @@
+#[macro_use]
+extern crate serde_derive;
+use actix_web::{web,
+                App as ActixApp,
+                HttpServer};
+use clap::{App,
+           Arg};
+
+mod config;
+mod context;
+mod error;
+
+fn app<'a, 'b>() -> App<'a, 'b> {
+    App::new("test-probe").arg(Arg::with_name("config").short("c")
+                                                       .long("config")
+                                                       .value_name("CONFIG")
+                                                       .help("Sets a custom config file")
+                                                       .takes_value(true))
+}
+
+fn main() -> std::io::Result<()> {
+    let matches = app().get_matches();
+    let config = config::from_matches(&matches).expect("Could not create application");
+    let bind_addr = format!("{}:{}", config.host, config.port);
+    let server = HttpServer::new(move || {
+                     ActixApp::new().data(config.clone())
+                                    .route("context", web::get().to(context::show))
+                                    .route("context/{path:.*}", web::get().to(context::show))
+                 }).workers(1)
+                   .bind(&bind_addr)?;
+
+    println!("Starting test-probe on {}", bind_addr);
+    server.run()
+}

--- a/test-services/test-probe/tests/fixtures/sample_render_context.json
+++ b/test-services/test-probe/tests/fixtures/sample_render_context.json
@@ -1,0 +1,438 @@
+{
+  "sys": {
+    "gossip_ip": "0.0.0.0",
+    "gossip_port": 9638,
+    "hostname": "yokai",
+    "http_gateway_ip": "0.0.0.0",
+    "http_gateway_port": 9631,
+    "ctl_gateway_ip": "127.0.0.1",
+    "ctl_gateway_port": 9632,
+    "ip": "192.168.67.207",
+    "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+    "permanent": false,
+    "version": "0.54.0/20180221023448"
+  },
+  "pkg": {
+    "deps": [
+      {
+        "name": "acl",
+        "origin": "core",
+        "release": "20170513213108",
+        "version": "2.2.52"
+      },
+      {
+        "name": "attr",
+        "origin": "core",
+        "release": "20170513213059",
+        "version": "2.4.47"
+      },
+      {
+        "name": "bzip2",
+        "origin": "core",
+        "release": "20170513212938",
+        "version": "1.0.6"
+      },
+      {
+        "name": "cacerts",
+        "origin": "core",
+        "release": "20171014212239",
+        "version": "2017.09.20"
+      },
+      {
+        "name": "coreutils",
+        "origin": "core",
+        "release": "20170513213226",
+        "version": "8.25"
+      },
+      {
+        "name": "curl",
+        "origin": "core",
+        "release": "20171014214153",
+        "version": "7.54.1"
+      },
+      {
+        "name": "db",
+        "origin": "core",
+        "release": "20170513213734",
+        "version": "5.3.28"
+      },
+      {
+        "name": "expat",
+        "origin": "core",
+        "release": "20171015103808",
+        "version": "2.2.2"
+      },
+      {
+        "name": "gcc-libs",
+        "origin": "core",
+        "release": "20170513212920",
+        "version": "5.2.0"
+      },
+      {
+        "name": "gdbm",
+        "origin": "core",
+        "release": "20170513213716",
+        "version": "1.11"
+      },
+      {
+        "name": "gettext",
+        "origin": "core",
+        "release": "20170513214354",
+        "version": "0.19.6"
+      },
+      {
+        "name": "git",
+        "origin": "core",
+        "release": "20171016215544",
+        "version": "2.14.2"
+      },
+      {
+        "name": "glibc",
+        "origin": "core",
+        "release": "20170513201042",
+        "version": "2.22"
+      },
+      {
+        "name": "gmp",
+        "origin": "core",
+        "release": "20170513202112",
+        "version": "6.1.0"
+      },
+      {
+        "name": "less",
+        "origin": "core",
+        "release": "20170513213936",
+        "version": "481"
+      },
+      {
+        "name": "libcap",
+        "origin": "core",
+        "release": "20170513213120",
+        "version": "2.24"
+      },
+      {
+        "name": "linux-headers",
+        "origin": "core",
+        "release": "20170513200956",
+        "version": "4.3"
+      },
+      {
+        "name": "ncurses",
+        "origin": "core",
+        "release": "20170513213009",
+        "version": "6.0"
+      },
+      {
+        "name": "nghttp2",
+        "origin": "core",
+        "release": "20170830163632",
+        "version": "1.24.0"
+      },
+      {
+        "name": "openssh",
+        "origin": "core",
+        "release": "20171014214153",
+        "version": "7.5p1"
+      },
+      {
+        "name": "openssl",
+        "origin": "core",
+        "release": "20171014213633",
+        "version": "1.0.2l"
+      },
+      {
+        "name": "pcre",
+        "origin": "core",
+        "release": "20170513213423",
+        "version": "8.38"
+      },
+      {
+        "name": "perl",
+        "origin": "core",
+        "release": "20170513213942",
+        "version": "5.22.1"
+      },
+      {
+        "name": "xz",
+        "origin": "core",
+        "release": "20170513214327",
+        "version": "5.2.2"
+      },
+      {
+        "name": "zlib",
+        "origin": "core",
+        "release": "20170513201911",
+        "version": "1.2.8"
+      }
+    ],
+    "env": {
+      "BAZ": "QUUX",
+      "FOO": "BAR",
+      "PATH": "/hab/pkgs/core/git/2.14.2/20171016215544/bin:/hab/pkgs/core/xz/5.2.2/20170513214327/bin:/hab/pkgs/core/perl/5.22.1/20170513213942/bin:/hab/pkgs/core/pcre/8.38/20170513213423/bin:/hab/pkgs/core/openssl/1.0.2l/20171014213633/bin:/hab/pkgs/core/openssh/7.5p1/20171014214153/bin:/hab/pkgs/core/openssh/7.5p1/20171014214153/sbin:/hab/pkgs/core/openssh/7.5p1/20171014214153/libexec:/hab/pkgs/core/ncurses/6.0/20170513213009/bin:/hab/pkgs/core/libcap/2.24/20170513213120/bin:/hab/pkgs/core/less/481/20170513213936/bin:/hab/pkgs/core/glibc/2.22/20170513201042/bin:/hab/pkgs/core/gettext/0.19.6/20170513214354/bin:/hab/pkgs/core/gdbm/1.11/20170513213716/bin:/hab/pkgs/core/expat/2.2.2/20171015103808/bin:/hab/pkgs/core/db/5.3.28/20170513213734/bin:/hab/pkgs/core/curl/7.54.1/20171014214153/bin:/hab/pkgs/core/coreutils/8.25/20170513213226/bin:/hab/pkgs/core/bzip2/1.0.6/20170513212938/bin:/hab/pkgs/core/attr/2.4.47/20170513213059/bin:/hab/pkgs/core/acl/2.2.52/20170513213108/bin:/hab/pkgs/core/busybox-static/1.24.2/20170513215502/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+    },
+    "exports": {
+      "blah": "stuff.thing",
+      "port": "test_port"
+    },
+    "exposes": [
+      "2112"
+    ],
+    "ident": "core/template-probe/0.1.0/20180315155739",
+    "name": "template-probe",
+    "origin": "core",
+    "path": "/hab/pkgs/core/template-probe/0.1.0/20180315155739",
+    "release": "20180315155739",
+    "svc_config_path": "/hab/svc/template-probe/config",
+    "svc_data_path": "/hab/svc/template-probe/data",
+    "svc_files_path": "/hab/svc/template-probe/files",
+    "svc_group": "hab",
+    "svc_path": "/hab/svc/template-probe",
+    "svc_pid_file": "/hab/svc/template-probe/PID",
+    "svc_run": "/hab/svc/template-probe/run",
+    "svc_static_path": "/hab/svc/template-probe/static",
+    "svc_user": "hab",
+    "svc_var_path": "/hab/svc/template-probe/var",
+    "version": "0.1.0"
+  },
+  "cfg": {
+    "stuff": {
+      "thing": "foo"
+    },
+    "test_port": 2112
+  },
+  "svc": {
+    "election_is_finished": false,
+    "election_is_no_quorum": false,
+    "election_is_running": false,
+    "first": {
+      "alive": true,
+      "application": null,
+      "cfg": {
+        "blah": "foo",
+        "port": 2112
+      },
+      "confirmed": false,
+      "departed": false,
+      "election_is_finished": false,
+      "election_is_no_quorum": false,
+      "election_is_running": false,
+      "environment": null,
+      "follower": false,
+      "group": "default",
+      "leader": false,
+      "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+      "org": null,
+      "persistent": false,
+      "pkg": {
+        "name": "template-probe",
+        "origin": "core",
+        "release": "20180315155739",
+        "version": "0.1.0"
+      },
+      "service": "template-probe",
+      "suspect": false,
+      "sys": {
+        "gossip_ip": "0.0.0.0",
+        "gossip_port": 9638,
+        "hostname": "yokai",
+        "http_gateway_ip": "0.0.0.0",
+        "http_gateway_port": 9631,
+        "ctl_gateway_ip": "127.0.0.1",
+        "ctl_gateway_port": 9632,
+        "ip": "192.168.67.207"
+      },
+      "update_election_is_finished": false,
+      "update_election_is_no_quorum": false,
+      "update_election_is_running": false,
+      "update_follower": false,
+      "update_leader": false
+    },
+    "group": "default",
+    "leader": null,
+    "me": {
+      "alive": true,
+      "application": null,
+      "cfg": {
+        "blah": "foo",
+        "port": 2112
+      },
+      "confirmed": false,
+      "departed": false,
+      "election_is_finished": false,
+      "election_is_no_quorum": false,
+      "election_is_running": false,
+      "environment": null,
+      "follower": false,
+      "group": "default",
+      "leader": false,
+      "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+      "org": null,
+      "persistent": false,
+      "pkg": {
+        "name": "template-probe",
+        "origin": "core",
+        "release": "20180315155739",
+        "version": "0.1.0"
+      },
+      "service": "template-probe",
+      "suspect": false,
+      "sys": {
+        "gossip_ip": "0.0.0.0",
+        "gossip_port": 9638,
+        "hostname": "yokai",
+        "http_gateway_ip": "0.0.0.0",
+        "http_gateway_port": 9631,
+        "ctl_gateway_ip": "127.0.0.1",
+        "ctl_gateway_port": 9632,
+        "ip": "192.168.67.207"
+      },
+      "update_election_is_finished": false,
+      "update_election_is_no_quorum": false,
+      "update_election_is_running": false,
+      "update_follower": false,
+      "update_leader": false
+    },
+    "members": [
+      {
+        "alive": true,
+        "application": null,
+        "cfg": {
+          "blah": "foo",
+          "port": 2112
+        },
+        "confirmed": false,
+        "departed": false,
+        "election_is_finished": false,
+        "election_is_no_quorum": false,
+        "election_is_running": false,
+        "environment": null,
+        "follower": false,
+        "group": "default",
+        "leader": false,
+        "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+        "org": null,
+        "persistent": false,
+        "pkg": {
+          "name": "template-probe",
+          "origin": "core",
+          "release": "20180315155739",
+          "version": "0.1.0"
+        },
+        "service": "template-probe",
+        "suspect": false,
+        "sys": {
+          "gossip_ip": "0.0.0.0",
+          "gossip_port": 9638,
+          "hostname": "yokai",
+          "http_gateway_ip": "0.0.0.0",
+          "http_gateway_port": 9631,
+          "ctl_gateway_ip": "127.0.0.1",
+          "ctl_gateway_port": 9632,
+          "ip": "192.168.67.207"
+        },
+        "update_election_is_finished": false,
+        "update_election_is_no_quorum": false,
+        "update_election_is_running": false,
+        "update_follower": false,
+        "update_leader": false
+      }
+    ],
+    "org": null,
+    "service": "template-probe",
+    "update_election_is_finished": false,
+    "update_election_is_no_quorum": false,
+    "update_election_is_running": false,
+    "update_leader": null
+  },
+  "bind": {
+    "router": {
+      "first": {
+        "alive": true,
+        "application": null,
+        "cfg": {
+          "port": 5562
+        },
+        "confirmed": false,
+        "departed": false,
+        "election_is_finished": false,
+        "election_is_no_quorum": false,
+        "election_is_running": false,
+        "environment": null,
+        "follower": false,
+        "group": "default",
+        "leader": false,
+        "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+        "org": null,
+        "persistent": false,
+        "pkg": {
+          "name": "builder-router",
+          "origin": "habitat",
+          "release": "20180302152133",
+          "version": "7114"
+        },
+        "service": "builder-router",
+        "suspect": false,
+        "sys": {
+          "gossip_ip": "0.0.0.0",
+          "gossip_port": 9638,
+          "hostname": "yokai",
+          "http_gateway_ip": "0.0.0.0",
+          "http_gateway_port": 9631,
+          "ctl_gateway_ip": "127.0.0.1",
+          "ctl_gateway_port": 9632,
+          "ip": "192.168.67.207"
+        },
+        "update_election_is_finished": false,
+        "update_election_is_no_quorum": false,
+        "update_election_is_running": false,
+        "update_follower": false,
+        "update_leader": false
+      },
+      "leader": null,
+      "members": [
+        {
+          "alive": true,
+          "application": null,
+          "cfg": {
+            "port": 5562
+          },
+          "confirmed": false,
+          "departed": false,
+          "election_is_finished": false,
+          "election_is_no_quorum": false,
+          "election_is_running": false,
+          "environment": null,
+          "follower": false,
+          "group": "default",
+          "leader": false,
+          "member_id": "a4e47d4aece849cd948afbd9bda3a22a",
+          "org": null,
+          "persistent": false,
+          "pkg": {
+            "name": "builder-router",
+            "origin": "habitat",
+            "release": "20180302152133",
+            "version": "7114"
+          },
+          "service": "builder-router",
+          "suspect": false,
+          "sys": {
+            "gossip_ip": "0.0.0.0",
+            "gossip_port": 9638,
+            "hostname": "yokai",
+            "http_gateway_ip": "0.0.0.0",
+            "http_gateway_port": 9631,
+            "ctl_gateway_ip": "127.0.0.1",
+            "ctl_gateway_port": 9632,
+            "ip": "192.168.67.207"
+          },
+          "update_election_is_finished": false,
+          "update_election_is_no_quorum": false,
+          "update_election_is_running": false,
+          "update_follower": false,
+          "update_leader": false
+        }
+      ]
+    }
+  }
+}

--- a/test/end-to-end/multi-supervisor/testcases/new-config-is-gossiped/run_test.ps1
+++ b/test/end-to-end/multi-supervisor/testcases/new-config-is-gossiped/run_test.ps1
@@ -1,7 +1,7 @@
 Describe "gossiping new config" {
     Load-SupervisorService "core/redis" -Remote "alpha.habitat.dev"
-    Load-SupervisorService "christophermaier/test-probe" -Bind "thing_with_a_port:redis.default" -Remote "beta.habitat.dev"
-    
+    Load-SupervisorService "habitat-testing/test-probe" -Bind "thing_with_a_port:redis.default" -Remote "beta.habitat.dev"
+
     It "probe service should bind to redis 6379" {
         $current_port = (Invoke-WebRequest "http://beta.habitat.dev:8000/context" | ConvertFrom-Json).bind.thing_with_a_port.first.cfg.port
         $current_port | Should -Be 6379


### PR DESCRIPTION
This is a small webapp intended to help test the Supervisor. Right
now, it exposes the rendering context it is provided over an HTTP
endpoint, allowing a view into the Supervisor's inner workings from
outside.

It also has a handful of lifecycle hook implementations, some of which
take a long time to run. This has been handy for verifying async service
behavior.

This service could be augmented in the future to do other things, as
well.