### PR TITLE
Add some additional logging around update elections

### DIFF
--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -240,8 +240,17 @@ impl ServiceUpdater {
                                 *st = RollingState::Follower(FollowerState::Waiting);
                             }
                         }
-                        (Some(_), None) => return None,
-                        _ => return None,
+                        (Some(_), None) => {
+                            debug!("No update leader for {} present yet",
+                                   &service.service_group);
+                            return None;
+                        }
+                        (None, _) => {
+                            error!("Supervisor does not know its own identity; rolling update of \
+                                    {} cannot proceed! Please notify the Habitat core team!",
+                                   service.service_group);
+                            return None;
+                        }
                     }
                 }
             }

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -203,7 +203,7 @@ impl ServiceUpdater {
                                        &service.service_group);
                                 return None;
                             }
-                            (..) => {
+                            (None, _) => {
                                 // It looks like a Supervisor finds
                                 // out "who it is" by being told by
                                 // the rest of the network. While this

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -197,7 +197,26 @@ impl ServiceUpdater {
                                                                        0);
                                 *st = RollingState::InElection
                             }
-                            _ => return None,
+                            (Some(_), None) => {
+                                debug!("No leader present; rolling Update cannot proceed until \
+                                        the {} group election finishes",
+                                       &service.service_group);
+                                return None;
+                            }
+                            (..) => {
+                                // It looks like a Supervisor finds
+                                // out "who it is" by being told by
+                                // the rest of the network. While this
+                                // does have the advantage of unifying
+                                // code paths, it could result in some
+                                // counter-intuitive situations (like
+                                // census_group.me() returning None!)
+                                error!("Supervisor does not know its own identity; rolling \
+                                        update of {} cannot proceed! Please notify the Habitat \
+                                        core team!",
+                                       service.service_group);
+                                return None;
+                            }
                         }
                     } else {
                         debug!("Rolling update, using default suitability");


### PR DESCRIPTION
We have observed rolling updates in leader topology groups stalling
due to the inability to determine who the leader of the service group
is (we need to know who the "real" leader is in order to determine who
should *not* win the update election).

This PR adds some logging output to help illustrate when this happens,
which will hopefully make this situation easier to troubleshoot in the
future.

Signed-off-by: Christopher Maier <cmaier@chef.io>