### PR TITLE
Ignore 'release' component of version if downloading from packages.chef.io

### DIFF
--- a/components/hab/install.ps1
+++ b/components/hab/install.ps1
@@ -91,6 +91,11 @@ Function Get-PackagesChefioArchive($channel, $version) {
     if(!$version -Or $version -eq "latest") {
       $hab_url="$url/$channel/habitat/latest/hab-x86_64-windows.zip"
     } else {
+      $version,$_release = $version -split "/",2,"SimpleMatch"
+      if($_release -ne $null) {
+        Write-Warning "packages.chef.io does not support 'version/release' format. Using $version for the version"
+      }
+
       $hab_url="$url/habitat/${version}/hab-x86_64-windows.zip"
     }
     $sha_url="$hab_url.sha256sum"

--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -231,7 +231,7 @@ validate_target() {
 download_packages_chef_io_archive() {
   need_cmd mv
   
-  local -r _version="${1:-latest}"
+  local _version="${1:-latest}"
   local -r _channel="${2:?}"
   local -r _target="${3:?}"
   local url
@@ -239,6 +239,11 @@ download_packages_chef_io_archive() {
   if [ "$_version" == "latest" ]; then
     url="${pcio_root}/${_channel}/habitat/latest/hab-${_target}.${ext}"
   else 
+    local -r _release="$(echo "${_version}" |cut -d'/' -f2)"
+    if [ "${_release:+release}" == "release" ]; then
+      _version="$(echo "${_version}" |cut -d'/' -f1)"
+      info "packages.chef.io does not support 'version/release' format. Using $_version for the version"
+    fi
     url="${pcio_root}/habitat/${_version}/hab-${_target}.${ext}"
   fi
   

--- a/components/hab/tests/test_install_script.bats
+++ b/components/hab/tests/test_install_script.bats
@@ -101,8 +101,8 @@ installed_target() {
   [ "$(installed_version)" == "hab 0.79.1" ]
 }
 
-@test "Install ignores release" {
+@test "Install ignores release when installing from packages.chef.io" {
   run components/hab/install.sh -v "0.90.6/20191112141314"
   [ "$status" -eq 0 ]
-  [ "$(installed_version)" == "hab 0.90.6"]
+  [ "$(installed_version)" == "hab 0.90.6" ]
 }

--- a/components/hab/tests/test_install_script.bats
+++ b/components/hab/tests/test_install_script.bats
@@ -101,4 +101,8 @@ installed_target() {
   [ "$(installed_version)" == "hab 0.79.1" ]
 }
 
-
+@test "Install ignores release" {
+  run components/hab/install.sh -v "0.90.6/20191112141314"
+  [ "$status" -eq 0 ]
+  [ "$(installed_version)" == "hab 0.90.6"]
+}

--- a/components/hab/tests/test_install_script.ps1
+++ b/components/hab/tests/test_install_script.ps1
@@ -20,4 +20,12 @@ Describe "Install habitat using install.ps1" {
         $result = hab --version
         $result | Should -Match "hab 0.79.1/*"
     }
+
+    It "ignores release when installing from packages.chef.io" {
+        components/hab/install.ps1 -v "0.90.6/20191112141314"
+        $LASTEXITCODE | Should -Be 0
+
+        $result = hab --version
+        $result | Should -Match "hab 0.90.6/*"
+    }
 }


### PR DESCRIPTION
Closes #7253 

For install `.tar.gz/.zip` files hosted on packages.chef.io, we no longer use the `release` portion of our fully qualified identifier in the filename or path. Since there is only ever one `version` as part of our new release process, we can safely ignore the release portion if the user specifies `-v` in the format of  `version/release`.   

For Linux, if a release is specified it must still be valid, due to how we how we only use the packages.chef.io download to bootstrap and fetch the appropriate `.hart` from Builder to install. 

`version/release` is still supported by our packages hosted in Bintray, so this change preserves the behavior for versions <= 0.88.0

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>