### PR TITLE
fix erroneous client output when API response is HTTP 200

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -463,12 +463,14 @@ impl BuilderAPIProvider for BuilderAPIClient {
 
         let path = format!("depot/origins/{}/secret/{}", origin, key_name);
 
-        // We expect NO_CONTENT, because the origin must be empty to delete
+        // Originally, we only returned an Ok result if the response was StatusCode::NO_CONTENT
+        // (HTTP 204). However the Bldr API appears to always have returned HTTP 200. We'll accept
+        // either as indicators of a successful operation moving forward.
         self.0
             .delete(&path)
             .bearer_auth(token)
             .send()?
-            .ok_if(&[StatusCode::OK])
+            .ok_if(&[StatusCode::NO_CONTENT, StatusCode::OK])
     }
 
     /// Check an origin exists

--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -468,7 +468,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .delete(&path)
             .bearer_auth(token)
             .send()?
-            .ok_if(&[StatusCode::NO_CONTENT])
+            .ok_if(&[StatusCode::OK])
     }
 
     /// Check an origin exists


### PR DESCRIPTION
This change corrects misleading hab client output on a successful deletion of an origin secret.

```
$ hab origin secret delete -o jmtest foo
☒ Deleting secret foo.
✗✗✗
✗✗✗ [200 OK]
✗✗✗
```