### PR TITLE
ensure dep variables are properly scoped for scaffolding access

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -295,6 +295,18 @@ steps:
             - BUILDKITE_AGENT_ACCESS_TOKEN
             - HAB_ORIGIN
 
+  - label: "[:windows: test_studio_can_build_scaffolded_package]"
+    command:
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_can_build_scaffolded_package
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          environment:
+            - BUILD_PKG_TARGET=x86_64-windows
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+            - HAB_ORIGIN
+
   - label: "[:linux: test_studio_hab_is_expected_version]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_hab_is_expected_version

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -90,10 +90,15 @@ $script:pkg_name = ""
 $script:pkg_version = ""
 # Each release is a timestamp - `YYYYMMDDhhmmss`
 $script:pkg_release = "$(Get-Date -UFormat "%Y%m%d%H%M%S")"
+
+# pkg_deps and pkg_build_deps are given the AllScope option so that
+# they can be set in scaffolding plans without the need to specify
+# the Script scope
 # The default build deps setting - an empty array
-$script:pkg_build_deps = @()
+New-Variable pkg_build_deps -Scope Script -Option AllScope -Value @()
 # The default runtime deps setting - an empty array
-$script:pkg_deps = @()
+New-Variable pkg_deps -Scope Script -Option AllScope -Value @()
+
 # The path inside a package that contains libraries - used in `LD_RUN_PATH` and
 # `LD_FLAGS`.
 $script:pkg_lib_dirs = @()

--- a/test/end-to-end/test_studio_can_build_scaffolded_package.ps1
+++ b/test/end-to-end/test_studio_can_build_scaffolded_package.ps1
@@ -1,0 +1,24 @@
+hab origin key generate $env:HAB_ORIGIN
+
+Function Invoke-WindowsPlanBuild($package) {
+    Invoke-NativeCommand hab pkg build test/fixtures/windows_plans/$package -R | Out-Null
+    . results/last_build.ps1
+    @{ Artifact = $pkg_artifact; Ident = $pkg_ident }
+}
+
+Describe "package using scaffolding" {
+    $dummy = Invoke-WindowsPlanBuild dummy
+    $dummyHabSvcUser = Invoke-WindowsPlanBuild dummy_hab_svc_user
+    $scaffolding = Invoke-WindowsPlanBuild scaffolding
+    $consumer = Invoke-WindowsPlanBuild use_scaffolding
+    It "inherits scaffolding dependencies" {
+        hab pkg install "results/$($dummy.Artifact)"
+        hab pkg install "results/$($dummyHabSvcUser.Artifact)"
+        hab pkg install "results/$($scaffolding.Artifact)"
+        hab pkg install "results/$($consumer.Artifact)"
+        # scaffolding has dummy as runtime and dummy_hab_svc_user as build time deps
+        
+        "/hab/pkgs/$($consumer.Ident)/DEPS" | Should -FileContentMatch "habitat-testing/dummy"
+        "/hab/pkgs/$($consumer.Ident)/BUILD_DEPS" | Should -FileContentMatch "habitat-testing/dummy-hab-user"
+    }
+}

--- a/test/fixtures/windows_plans/scaffolding/lib/scaffolding.ps1
+++ b/test/fixtures/windows_plans/scaffolding/lib/scaffolding.ps1
@@ -1,0 +1,4 @@
+function Load-Scaffolding {
+    $pkg_deps += @("habitat-testing/dummy")
+    $pkg_build_deps += @("habitat-testing/dummy-hab-user")
+}

--- a/test/fixtures/windows_plans/scaffolding/plan.ps1
+++ b/test/fixtures/windows_plans/scaffolding/plan.ps1
@@ -1,0 +1,7 @@
+$pkg_name="dummy-scaffolding"
+$pkg_origin="habitat-testing"
+$pkg_version="0.1.0"
+
+function Invoke-Install {
+  Copy-Item "$PLAN_CONTEXT/lib" $pkg_prefix -Recurse -Force
+}

--- a/test/fixtures/windows_plans/use_scaffolding/plan.ps1
+++ b/test/fixtures/windows_plans/use_scaffolding/plan.ps1
@@ -1,0 +1,4 @@
+$pkg_name="use-scaffolding"
+$pkg_origin="habitat-testing"
+$pkg_version="0.1.0"
+$pkg_scaffolding="habitat-testing/dummy-scaffolding"


### PR DESCRIPTION
fixes #6671 

When setting a powershell variable, the default scope is `local`. So when `Load-Scaffolding` sets `$pkg_deps` or `$pkg_build_deps`, it us setting them scoped to that specific function. Thus an author of `Load-Scaffolding` needs to explicitly set the `script` scope by using `$script:pkg_deps = "origin/package"`. However by setting the `AllScopes` option of those variables, child scopes will reference the same variable set at a parent scope removing the need to use the `script:` qualifier.

Signed-off-by: mwrock <matt@mattwrock.com>