### PR TITLE
Disable brew cleanup for mac builds

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -56,6 +56,7 @@ steps:
       - .expeditor/scripts/release_habitat/build_mac_hab_binary.sh
     env:
       BUILD_PKG_TARGET: "x86_64-darwin"
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     expeditor:
       executor:
         macos:


### PR DESCRIPTION
Disable automatic brew cleanup, to prevent failures during installation of `bash`. 
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>