### PR TITLE
Fix broken studio e2e tests

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -507,9 +507,12 @@ function Update-SslCertFile {
       $studio_ssl_cert_file = (Join-Path $env:HAB_CACHE_SSL_PATH $cert_filename)
       if (Test-Path $studio_ssl_cert_file) {
         $env:SSL_CERT_FILE = $studio_ssl_cert_file
+      } else {
+        $env:SSL_CERT_FILE = $null
       }
     } catch {
       Write-HabInfo "Unable to set SSL_CERT_FILE from '$env:SSL_CERT_FILE'"
+      $env:SSL_CERT_FILE = $null
     }
   }
 }

--- a/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
+++ b/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
@@ -23,7 +23,7 @@ if($IsLinux) {
     $sslCertFileCheck = "exit (!(Test-Path `$env:SSL_CERT_FILE))"
     $sslCertFilePrint = "`$env:SSL_CERT_FILE.Replace('\','/')"
     $sslCacheCertFileCheck = "exit (!(Test-Path '/hab/cache/ssl/$e2e_certname'))"
-    $sslCertFileNotSetCheck = "exit (`$env:SSL_CERT_FILE -eq `$null)"
+    $sslCertFileNotSetCheck = "exit (Test-Path `$env:SSL_CERT_FILE)"
 }
 
 Context "SSL_CERT_FILE is passed into the studio" {

--- a/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
+++ b/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
@@ -23,7 +23,6 @@ if($IsLinux) {
     $sslCertFileCheck = "exit (!(Test-Path `$env:SSL_CERT_FILE))"
     $sslCertFilePrint = "`$env:SSL_CERT_FILE.Replace('\','/')"
     $sslCacheCertFileCheck = "exit (!(Test-Path '/hab/cache/ssl/$e2e_certname'))"
-    # $sslCertFileNotSetCheck = "exit `$(If(`$env:SSL_CERT_FILE -eq `$null) { 0 } else { 1 })"
     $sslCertFIleNotSetCheck = "exit `$(!!(`$env:SSL_CERT_FILE))"
 }
 

--- a/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
+++ b/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
@@ -23,7 +23,7 @@ if($IsLinux) {
     $sslCertFileCheck = "exit (!(Test-Path `$env:SSL_CERT_FILE))"
     $sslCertFilePrint = "`$env:SSL_CERT_FILE.Replace('\','/')"
     $sslCacheCertFileCheck = "exit (!(Test-Path '/hab/cache/ssl/$e2e_certname'))"
-    $sslCertFileNotSetCheck = "exit (Test-Path `$env:SSL_CERT_FILE)"
+    $sslCertFileNotSetCheck = "exit `$(If(`$env:SSL_CERT_FILE -eq `$null) { 0 } else { 1 })"
 }
 
 Context "SSL_CERT_FILE is passed into the studio" {
@@ -90,7 +90,7 @@ Context "SSL_CERT_FILE is passed into the studio" {
     Describe "SSL_CERT_FILE is a directory" {
         $env:SSL_CERT_FILE = (Join-Path $tempdir "cert-as-directory")
         New-Item -ItemType Directory -Force -Path $env:SSL_CERT_FILE
-
+        
         It "Should not set SSL_CERT_FILE" {
             Invoke-StudioRun $sslCertFileNotSetCheck
             $LASTEXITCODE | Should -Be 0
@@ -102,7 +102,7 @@ Context "SSL_CERT_FILE is passed into the studio" {
             } else { 
               Invoke-StudioRun $sslCertFileCheck
             }
-
+            
             $LASTEXITCODE | Should -Be 1
         }
 

--- a/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
+++ b/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
@@ -23,7 +23,8 @@ if($IsLinux) {
     $sslCertFileCheck = "exit (!(Test-Path `$env:SSL_CERT_FILE))"
     $sslCertFilePrint = "`$env:SSL_CERT_FILE.Replace('\','/')"
     $sslCacheCertFileCheck = "exit (!(Test-Path '/hab/cache/ssl/$e2e_certname'))"
-    $sslCertFileNotSetCheck = "exit `$(If(`$env:SSL_CERT_FILE -eq `$null) { 0 } else { 1 })"
+    # $sslCertFileNotSetCheck = "exit `$(If(`$env:SSL_CERT_FILE -eq `$null) { 0 } else { 1 })"
+    $sslCertFIleNotSetCheck = "exit `$(!!(`$env:SSL_CERT_FILE))"
 }
 
 Context "SSL_CERT_FILE is passed into the studio" {


### PR DESCRIPTION
This PR corrects some tests I missed in #7259 after rebasing against the powershell e2e tests. 

It also corrects the windows studio behavior when `$env:SSL_CERT_FILE` is invalid, to ensure that the variable does not get set on the inside of the studio. 