### PR TITLE
hab origin invitations subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,6 +1263,7 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tabwriter 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -20,5 +20,6 @@ reqwest = { version = "*", features = ["blocking", "json"] }
 serde = "*"
 serde_derive = "*"
 serde_json = "*"
+tabwriter = "*"
 tee = "*"
 url = "*"

--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -17,8 +17,10 @@ use crate::{error::{Error,
             OriginKeyIdent,
             OriginSecret,
             Package,
+            PendingOriginInvitationsResponse,
             ReverseDependencies,
-            SchedulerResponse};
+            SchedulerResponse,
+            UserOriginInvitationsResponse};
 use broadcast::BroadcastWriter;
 use percent_encoding::{percent_encode,
                        AsciiSet,
@@ -544,6 +546,198 @@ impl BuilderAPIProvider for BuilderAPIClient {
             .bearer_auth(token)
             .send()?
             .ok_if(&[StatusCode::NO_CONTENT])
+    }
+
+    /// Accepts an origin member invitation
+    ///
+    ///  # Builder API endpiont (api.raml permalink)
+    ///    * https://github.com/habitat-sh/builder/blob/da72e9fb86e24d9076268b6b1c913b7531c83ed9/components/builder-api/doc/api.raml#L883
+    ///
+    ///  # Arguments
+    ///    * Origin: &str - origin name where membership invitation exists
+    ///    * Token: &str - bearer token for authentication/authorization
+    ///    * Invitation Id: u64 - id of invitation to accept
+    ///
+    ///  # Expected API response on success
+    ///    * HTTP 204
+    ///
+    ///  # Return
+    ///    * Result<()>
+    fn accept_origin_invitation(&self,
+                                origin: &str,
+                                token: &str,
+                                invitation_id: u64)
+                                -> Result<()> {
+        debug!("Accepting invitation id {} in origin {}",
+               invitation_id, origin);
+
+        let path = format!("depot/origins/{}/invitations/{}", origin, invitation_id);
+
+        self.0
+            .put(&path)
+            .bearer_auth(token)
+            .send()?
+            .ok_if(&[StatusCode::NO_CONTENT])
+    }
+
+    /// Marks an origin member invitation ignored
+    ///
+    ///  After ignoring, the user will no longer see the invitation
+    ///
+    ///  # Builder API endpiont (api.raml permalink)
+    ///    * https://github.com/habitat-sh/builder/blob/da72e9fb86e24d9076268b6b1c913b7531c83ed9/components/builder-api/doc/api.raml#L903
+    ///
+    ///  # Arguments
+    ///    * Origin: &str - origin name where membership invitation exists
+    ///    * Token: &str - bearer token for authentication/authorization
+    ///    * Invitation Id: u64 - id of invitation to accept
+    ///
+    ///  # Expected API response on success
+    ///    * HTTP 204
+    ///
+    ///  # Return
+    ///    * Result<()>
+    fn ignore_origin_invitation(&self,
+                                origin: &str,
+                                token: &str,
+                                invitation_id: u64)
+                                -> Result<()> {
+        debug!("Marking invitation {} in origin {} ignored",
+               invitation_id, origin);
+
+        let path = format!("depot/origins/{}/invitations/{}/ignore",
+                           origin, invitation_id);
+
+        self.0
+            .put(&path)
+            .bearer_auth(token)
+            .send()?
+            .ok_if(&[StatusCode::NO_CONTENT])
+    }
+
+    /// Retrieves origin member invitations for current user
+    ///
+    ///  The usecase is for any user to discover any origin invitations sent to their
+    ///  account without having to know the origin.
+    ///
+    ///  # Builder API endpiont (api.raml permalink)
+    ///    * https://github.com/habitat-sh/builder/blob/da72e9fb86e24d9076268b6b1c913b7531c83ed9/components/builder-api/doc/api.raml#L614
+    ///
+    ///  # Arguments
+    ///    * Token: &str - bearer token for authentication/authorization
+    ///
+    ///  # Expected API response on success
+    ///    * HTTP 200
+    ///
+    ///  # Return
+    ///    * Result<UserOriginInvitationsResponse>
+    fn list_user_invitations(&self, token: &str) -> Result<UserOriginInvitationsResponse> {
+        let path = "user/invitations";
+
+        let mut resp = self.0.get(&path).bearer_auth(token).send()?;
+        resp.ok_if(&[StatusCode::OK])?;
+
+        Ok(resp.json()?)
+    }
+
+    /// Retrieves pending origin member invitations
+    ///
+    ///  The usecase here is for an origin owner (or simply origin member) to see the outstanding
+    ///  invitations for a given origin.
+    ///
+    ///  # Builder API endpiont (api.raml permalink)
+    ///    * https://github.com/habitat-sh/builder/blob/da72e9fb86e24d9076268b6b1c913b7531c83ed9/components/builder-api/doc/api.raml#L881
+    ///
+    ///  # Arguments
+    ///    * Origin: &str - origin name where membership invitation exists
+    ///    * Token: &str - bearer token for authentication/authorization
+    ///
+    ///  # Expected API response on success
+    ///    * HTTP 200
+    ///
+    ///  # Return
+    ///    * Result<PendingOriginInvitationsResponse>
+    fn list_pending_origin_invitations(&self,
+                                       origin: &str,
+                                       token: &str)
+                                       -> Result<PendingOriginInvitationsResponse> {
+        debug!("Retrieving pending invitations in origin {}", origin);
+        let path = format!("depot/origins/{}/invitations", origin);
+
+        let mut resp = self.0.get(&path).bearer_auth(token).send()?;
+        resp.ok_if(&[StatusCode::OK])?;
+
+        Ok(resp.json()?)
+    }
+
+    /// Rescind an origin member invitation
+    ///
+    ///  Rescind an invitation that hasn't already been ignored. The invitation will be deleted.
+    ///
+    ///  # Builder API endpiont (api.raml permalink)
+    ///    * https://github.com/habitat-sh/builder/blob/da72e9fb86e24d9076268b6b1c913b7531c83ed9/components/builder-api/doc/api.raml#L893
+    ///
+    ///  # Arguments
+    ///    * Origin: &str - origin name where membership invitation exists
+    ///    * Token: &str - bearer token for authentication/authorization
+    ///    * Invitation Id: u64 - id of invitation to accept
+    ///
+    ///  # Expected API response on success
+    ///    * HTTP 204
+    ///
+    ///  # Return
+    ///    * Result<()>
+    fn rescind_origin_invitation(&self,
+                                 origin: &str,
+                                 token: &str,
+                                 invitation_id: u64)
+                                 -> Result<()> {
+        debug!("Rescinding invitation {} in origin {}",
+               invitation_id, origin);
+
+        let path = format!("depot/origins/{}/invitations/{}", origin, invitation_id);
+
+        self.0
+            .delete(&path)
+            .bearer_auth(token)
+            .send()?
+            .ok_if(&[StatusCode::NO_CONTENT])
+    }
+
+    /// Send an origin member invitation
+    ///
+    ///  Invite a user into an origin. The invite will show up under pending origin invitations
+    ///  and listed under a user's direct invitations.
+    ///
+    ///  # Builder API endpiont (api.raml permalink)
+    ///    * https://github.com/habitat-sh/builder/blob/da72e9fb86e24d9076268b6b1c913b7531c83ed9/components/builder-api/doc/api.raml#L812
+    ///
+    ///  # Arguments
+    ///    * Origin: &str - origin name where membership invitation exists
+    ///    * Token: &str - bearer token for authentication/authorization
+    ///    * Invitee Account: &str - account name to invite into the origin
+    ///
+    ///  # Expected API response on success
+    ///    * HTTP 201
+    ///
+    ///  # Return
+    ///    * Result<()>
+    fn send_origin_invitation(&self,
+                              origin: &str,
+                              token: &str,
+                              invitee_account: &str)
+                              -> Result<()> {
+        debug!("Sending an invitation to {} for origin {}",
+               invitee_account, origin);
+
+        let path = format!("depot/origins/{}/users/{}/invitations",
+                           origin, invitee_account);
+
+        self.0
+            .post(&path)
+            .bearer_auth(token)
+            .send()?
+            .ok_if(&[StatusCode::CREATED])
     }
 
     /// List all secrets keys for an origin

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -268,8 +268,8 @@ pub trait Tabular {
 impl Tabular for UserOriginInvitationsResponse {
     fn as_tabbed(&self) -> Result<String> {
         let tw = tabw().padding(2).minwidth(5);
-        let mut body = Vec::new();
         if !self.0.is_empty() {
+            let mut body = Vec::new();
             body.push(String::from("Invitation Id\tOrigin Name\tAccount Name\tCreation \
                                     Date\tIgnored"));
             for invitation in self.0.iter() {
@@ -280,16 +280,18 @@ impl Tabular for UserOriginInvitationsResponse {
                                   invitation.created_at,
                                   invitation.ignored));
             }
-        };
-        tabify(tw, &body.join("\n"))
+            tabify(tw, &body.join("\n"))
+        } else {
+            Ok(String::from(""))
+        }
     }
 }
 
 impl Tabular for PendingOriginInvitationsResponse {
     fn as_tabbed(&self) -> Result<String> {
         let tw = tabw().padding(2).minwidth(5);
-        let mut body = Vec::new();
         if !self.invitations.is_empty() {
+            let mut body = Vec::new();
             body.push(String::from("Invitation Id\tAccount Name\tCreation Date\tIgnored"));
             for invitation in self.invitations.iter() {
                 body.push(format!("{}\t{}\t{}\t{}",
@@ -298,8 +300,10 @@ impl Tabular for PendingOriginInvitationsResponse {
                                   invitation.created_at,
                                   invitation.ignored));
             }
-        };
-        tabify(tw, &body.join("\n"))
+            tabify(tw, &body.join("\n"))
+        } else {
+            Ok(String::from(""))
+        }
     }
 }
 

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -24,8 +24,11 @@ use std::{fmt,
           path::{Path,
                  PathBuf}};
 
-use chrono::DateTime;
+use chrono::{DateTime,
+             Utc};
 use reqwest::IntoUrl;
+
+use tabwriter::TabWriter;
 
 pub use crate::error::{Error,
                        Result};
@@ -198,6 +201,109 @@ pub struct OriginChannelIdent {
 }
 
 #[derive(Clone, Deserialize)]
+pub struct OriginInvitation {
+    #[serde(with = "json_u64")]
+    pub id: u64,
+    #[serde(with = "json_u64")]
+    pub account_id: u64,
+    pub account_name: String,
+    #[serde(with = "json_date_format")]
+    pub created_at: DateTime<Utc>,
+    pub ignored: bool,
+    pub origin: String,
+    #[serde(with = "json_u64")]
+    pub owner_id: u64,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct UserOriginInvitationsResponse(pub Vec<OriginInvitation>);
+
+#[derive(Clone, Deserialize)]
+pub struct PendingOriginInvitationsResponse {
+    pub origin:      String,
+    pub invitations: Vec<OriginInvitation>,
+}
+
+// Custom conversion logic to allow `serde` to successfully
+// deserialize `DateTime<Utc>` datatypes.
+//
+// To use it, add `#[serde(with = "json_date_format")]` to any
+// `DateTime<Utc>`-typed struct fields.
+mod json_date_format {
+    use chrono::{DateTime,
+                 TimeZone,
+                 Utc};
+    use serde::{self,
+                Deserialize,
+                Deserializer};
+    const DATE_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.f";
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+        where D: Deserializer<'de>
+    {
+        let s = String::deserialize(deserializer)?;
+        Utc.datetime_from_str(&s, DATE_FORMAT)
+           .map_err(serde::de::Error::custom)
+    }
+}
+
+// Returns a library object that implements elastic tabstops
+fn tabw() -> TabWriter<Vec<u8>> { TabWriter::new(Vec::new()) }
+
+// Given a TabWriter object and a str slice, return a Result
+// where the Ok() variant comprises a String with nicely tab aligned columns
+fn tabify(mut tw: TabWriter<Vec<u8>>, s: &str) -> Result<String> {
+    write!(&mut tw, "{}", s)?;
+    tw.flush()?;
+    String::from_utf8(tw.into_inner().expect("TABWRITER into_inner")).map_err(|e| {
+        habitat_core::Error::StringFromUtf8Error(e).into()
+    })
+}
+
+pub trait Tabular {
+    fn as_tabbed(&self) -> Result<String>;
+}
+
+impl Tabular for UserOriginInvitationsResponse {
+    fn as_tabbed(&self) -> Result<String> {
+        let tw = tabw().padding(2).minwidth(5);
+        let mut body = Vec::new();
+        if !self.0.is_empty() {
+            body.push(String::from("Invitation Id\tOrigin Name\tAccount Name\tCreation \
+                                    Date\tIgnored"));
+            for invitation in self.0.iter() {
+                body.push(format!("{}\t{}\t{}\t{}\t{}",
+                                  invitation.id,
+                                  invitation.origin,
+                                  invitation.account_name,
+                                  invitation.created_at,
+                                  invitation.ignored));
+            }
+        };
+        tabify(tw, &body.join("\n"))
+    }
+}
+
+impl Tabular for PendingOriginInvitationsResponse {
+    fn as_tabbed(&self) -> Result<String> {
+        let tw = tabw().padding(2).minwidth(5);
+        let mut body = Vec::new();
+        if !self.invitations.is_empty() {
+            body.push(String::from("Invitation Id\tAccount Name\tCreation Date\tIgnored"));
+            for invitation in self.invitations.iter() {
+                body.push(format!("{}\t{}\t{}\t{}",
+                                  invitation.id,
+                                  invitation.account_name,
+                                  invitation.created_at,
+                                  invitation.ignored));
+            }
+        };
+        tabify(tw, &body.join("\n"))
+    }
+}
+
+#[derive(Clone, Deserialize)]
 pub struct OriginSecret {
     pub id:        String,
     pub origin_id: String,
@@ -291,6 +397,31 @@ pub trait BuilderAPIProvider: Sync + Send {
     fn delete_origin(&self, origin: &str, token: &str) -> Result<()>;
 
     fn transfer_origin_ownership(&self, origin: &str, token: &str, account: &str) -> Result<()>;
+
+    fn accept_origin_invitation(&self, origin: &str, token: &str, invitation_id: u64)
+                                -> Result<()>;
+
+    fn ignore_origin_invitation(&self, origin: &str, token: &str, invitation_id: u64)
+                                -> Result<()>;
+
+    fn list_user_invitations(&self, token: &str) -> Result<UserOriginInvitationsResponse>;
+
+    fn list_pending_origin_invitations(&self,
+                                       origin: &str,
+                                       token: &str)
+                                       -> Result<PendingOriginInvitationsResponse>;
+
+    fn rescind_origin_invitation(&self,
+                                 origin: &str,
+                                 token: &str,
+                                 invitation_id: u64)
+                                 -> Result<()>;
+
+    fn send_origin_invitation(&self,
+                              origin: &str,
+                              token: &str,
+                              invitee_account: &str)
+                              -> Result<()>;
 
     fn list_origin_secrets(&self, origin: &str, token: &str) -> Result<Vec<String>>;
 

--- a/components/common/src/ui.rs
+++ b/components/common/src/ui.rs
@@ -189,6 +189,8 @@ impl Glyph {
 }
 
 pub enum Status {
+    Accepted,
+    Accepting,
     Applying,
     Added,
     Adding,
@@ -211,10 +213,16 @@ pub enum Status {
     Found,
     Generated,
     Generating,
+    Ignored,
+    Ignoring,
     Installed,
     Missing,
     Promoted,
     Promoting,
+    Rescinded,
+    Rescinding,
+    Sending,
+    Sent,
     Signed,
     Signing,
     Skipping,
@@ -231,6 +239,8 @@ pub enum Status {
 impl Status {
     pub fn parts(&self) -> (Glyph, String, Color) {
         match *self {
+            Status::Accepting => (Glyph::UpArrow, "Accepting".into(), Color::Info),
+            Status::Accepted => (Glyph::CheckMark, "Accepted".into(), Color::Info),
             Status::Applying => (Glyph::UpArrow, "Applying".into(), Color::Info),
             Status::Added => (Glyph::UpArrow, "Added".into(), Color::Info),
             Status::Adding => (Glyph::FingerPoint, "Adding".into(), Color::Info),
@@ -255,10 +265,16 @@ impl Status {
             Status::Found => (Glyph::RightArrow, "Found".into(), Color::Important),
             Status::Generated => (Glyph::RightArrow, "Generated".into(), Color::Important),
             Status::Generating => (Glyph::FingerPoint, "Generating".into(), Color::Info),
+            Status::Ignored => (Glyph::CheckMark, "Ignored".into(), Color::Info),
+            Status::Ignoring => (Glyph::BoxedX, "Ignoring".into(), Color::Info),
             Status::Installed => (Glyph::CheckMark, "Installed".into(), Color::Info),
             Status::Missing => (Glyph::Because, "Missing".into(), Color::Critical),
             Status::Promoted => (Glyph::CheckMark, "Promoted".into(), Color::Info),
             Status::Promoting => (Glyph::RightArrow, "Promoting".into(), Color::Info),
+            Status::Rescinded => (Glyph::CheckMark, "Rescinded".into(), Color::Info),
+            Status::Rescinding => (Glyph::BoxedX, "Rescinding".into(), Color::Info),
+            Status::Sending => (Glyph::UpArrow, "Sending".into(), Color::Info),
+            Status::Sent => (Glyph::CheckMark, "Sent".into(), Color::Info),
             Status::Signed => (Glyph::CheckMark, "Signed".into(), Color::Important),
             Status::Signing => (Glyph::FingerPoint, "Signing".into(), Color::Important),
             Status::Skipping => (Glyph::Elipses, "Skipping".into(), Color::Info),

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -287,7 +287,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                 (@arg ORIGIN: +required {valid_origin} "The origin to be created")
                 (@arg BLDR_URL: -u --url +takes_value {valid_url}
                      "Specify an alternate Builder endpoint. If not specified, the value will \
-                     be taken from the `HAB_BLDR_URL environment variable if defined. (default: \
+                     be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
                      https://bldr.habitat.sh)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
             )
@@ -297,7 +297,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                 (@arg ORIGIN: +required {valid_origin} "The origin name")
                 (@arg BLDR_URL: -u --url +takes_value {valid_url}
                      "Specify an alternate Builder endpoint. If not specified, the value will \
-                     be taken from the `HAB_BLDR_URL environment variable if defined. (default: \
+                     be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
                      https://bldr.habitat.sh)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
             )
@@ -310,6 +310,66 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                      https://bldr.habitat.sh)")
                 (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
                 (@arg NEW_OWNER_ACCOUNT: +required +takes_value {non_empty} "The account name of the new origin owner")
+            )
+            (@subcommand invitations =>
+                (about: "Manage origin member invitations")
+                (@subcommand accept =>
+                     (about: "Accept an origin member invitation")
+                     (@arg ORIGIN: +required {valid_origin} "The origin name the invitation applies to")
+                     (@arg INVITATION_ID: +required +takes_value {valid_numeric::<u64>} "The id of the invitation to accept")
+                     (@arg BLDR_URL: -u --url +takes_value {valid_url}
+                          "Specify an alternate Builder endpoint. If not specified, the value will \
+                          be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
+                          https://bldr.habitat.sh)")
+                     (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
+                )
+                (@subcommand ignore =>
+                     (about: "Ignore an origin member invitation")
+                     (@arg ORIGIN: +required {valid_origin} "The origin name the invitation applies to")
+                     (@arg INVITATION_ID: +required +takes_value {valid_numeric::<u64>} "The id of the invitation to ignore")
+                     (@arg BLDR_URL: -u --url +takes_value {valid_url}
+                          "Specify an alternate Builder endpoint. If not specified, the value will \
+                          be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
+                          https://bldr.habitat.sh)")
+                     (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
+                )
+                (@subcommand list =>
+                     (about: "List origin invitations sent to your account")
+                     (@arg BLDR_URL: -u --url +takes_value {valid_url}
+                          "Specify an alternate Builder endpoint. If not specified, the value will \
+                          be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
+                          https://bldr.habitat.sh)")
+                     (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
+                )
+                (@subcommand pending =>
+                     (about: "List pending invitations for a particular origin. Requires that you are the origin owner.")
+                     (@arg ORIGIN: +required {valid_origin} "The name of the origin you wish to list invitations for ")
+                     (@arg BLDR_URL: -u --url +takes_value {valid_url}
+                          "Specify an alternate Builder endpoint. If not specified, the value will \
+                          be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
+                          https://bldr.habitat.sh)")
+                     (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
+                )
+                (@subcommand rescind =>
+                    (about: "Rescind an existing origin member invitation")
+                    (@arg ORIGIN: +required {valid_origin} "The origin name the invitation applies to")
+                     (@arg INVITATION_ID: +required +takes_value {valid_numeric::<u64>} "The id of the invitation to rescind")
+                    (@arg BLDR_URL: -u --url +takes_value {valid_url}
+                          "Specify an alternate Builder endpoint. If not specified, the value will \
+                          be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
+                          https://bldr.habitat.sh)")
+                    (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
+                )
+                (@subcommand send =>
+                     (about: "Send an origin member invitation")
+                     (@arg ORIGIN: +required {valid_origin} "The origin name the invitation applies to")
+                     (@arg INVITEE_ACCOUNT: +required +takes_value {non_empty} "The account name to invite into the origin")
+                     (@arg BLDR_URL: -u --url +takes_value {valid_url}
+                          "Specify an alternate Builder endpoint. If not specified, the value will \
+                          be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
+                          https://bldr.habitat.sh)")
+                     (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
+                )
             )
             (@subcommand key =>
                 (about: "Commands relating to Habitat origin key maintenance")

--- a/components/hab/src/command/origin.rs
+++ b/components/hab/src/command/origin.rs
@@ -1,5 +1,6 @@
 pub mod create;
 pub mod delete;
+pub mod invitations;
 pub mod key;
 pub mod secret;
 pub mod transfer;

--- a/components/hab/src/command/origin/invitations.rs
+++ b/components/hab/src/command/origin/invitations.rs
@@ -1,0 +1,6 @@
+pub mod accept;
+pub mod ignore;
+pub mod list_pending_origin;
+pub mod list_user;
+pub mod rescind;
+pub mod send;

--- a/components/hab/src/command/origin/invitations/accept.rs
+++ b/components/hab/src/command/origin/invitations/accept.rs
@@ -1,0 +1,32 @@
+use crate::{api_client::Client,
+            common::ui::{Status,
+                         UIWriter,
+                         UI},
+            error::{Error,
+                    Result},
+            PRODUCT,
+            VERSION};
+
+pub fn start(ui: &mut UI,
+             bldr_url: &str,
+             origin: &str,
+             token: &str,
+             invitation_id: u64)
+             -> Result<()> {
+    let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
+
+    ui.status(Status::Accepting,
+              format!("invitation id {} in origin {}", invitation_id, origin))?;
+
+    match api_client.accept_origin_invitation(origin, token, invitation_id) {
+        Ok(_) => {
+            ui.status(Status::Accepted, "the invitation successfully!".to_string())
+              .or(Ok(()))
+        }
+        Err(e) => {
+            ui.fatal(format!("Failed to accept invitation {} in origin {}, {:?}",
+                             invitation_id, origin, e))?;
+            Err(Error::from(e))
+        }
+    }
+}

--- a/components/hab/src/command/origin/invitations/ignore.rs
+++ b/components/hab/src/command/origin/invitations/ignore.rs
@@ -1,0 +1,32 @@
+use crate::{api_client::Client,
+            common::ui::{Status,
+                         UIWriter,
+                         UI},
+            error::{Error,
+                    Result},
+            PRODUCT,
+            VERSION};
+
+pub fn start(ui: &mut UI,
+             bldr_url: &str,
+             origin: &str,
+             token: &str,
+             invitation_id: u64)
+             -> Result<()> {
+    let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
+
+    ui.status(Status::Ignoring,
+              format!("invitation id {} in origin {}", invitation_id, origin))?;
+
+    match api_client.ignore_origin_invitation(origin, token, invitation_id) {
+        Ok(_) => {
+            ui.status(Status::Ignored, "the invitation successfully!".to_string())
+              .or(Ok(()))
+        }
+        Err(e) => {
+            ui.fatal(format!("Failed to ignore invitation {} in origin {}, {:?}",
+                             invitation_id, origin, e))?;
+            Err(Error::from(e))
+        }
+    }
+}

--- a/components/hab/src/command/origin/invitations/list_pending_origin.rs
+++ b/components/hab/src/command/origin/invitations/list_pending_origin.rs
@@ -24,9 +24,7 @@ pub fn start(ui: &mut UI, bldr_url: &str, origin: &str, token: &str) -> Result<(
                      resp.invitations.len());
             match resp.as_tabbed() {
                 Ok(body) => {
-                    if !body.is_empty() {
-                        println!("{}", body);
-                    }
+                    println!("{}", body);
                     Ok(())
                 }
                 Err(e) => {

--- a/components/hab/src/command/origin/invitations/list_pending_origin.rs
+++ b/components/hab/src/command/origin/invitations/list_pending_origin.rs
@@ -1,0 +1,49 @@
+use crate::{api_client::{self,
+                         Client,
+                         Tabular},
+            common::ui::{Status,
+                         UIWriter,
+                         UI},
+            error::{Error,
+                    Result},
+            PRODUCT,
+            VERSION};
+use reqwest::StatusCode;
+
+pub fn start(ui: &mut UI, bldr_url: &str, origin: &str, token: &str) -> Result<()> {
+    let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
+
+    ui.status(Status::Discovering,
+              format!("pending member invitations in origin {}", origin))?;
+
+    // given an origin, list its pending invitations
+    match api_client.list_pending_origin_invitations(origin, token) {
+        Ok(resp) => {
+            println!("Pending Origin ({}) Member Invitations [{}]:",
+                     origin,
+                     resp.invitations.len());
+            match resp.as_tabbed() {
+                Ok(body) => {
+                    if !body.is_empty() {
+                        println!("{}", body);
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    ui.fatal(format!("Failed to format pending origin invitations! {:?}.", e))?;
+                    Err(Error::from(e))
+                }
+            }
+        }
+        Err(err @ api_client::Error::APIError(StatusCode::FORBIDDEN, _)) => {
+            ui.fatal("Failed to list pending invitations!")?;
+            ui.fatal("This situation could arise, if for example, you are not the owner of the \
+                      origin.")?;
+            Err(Error::APIClient(err))
+        }
+        Err(e) => {
+            ui.fatal(format!("Failed to retrieve pending origin invitations! {:?}.", e))?;
+            Err(Error::from(e))
+        }
+    }
+}

--- a/components/hab/src/command/origin/invitations/list_user.rs
+++ b/components/hab/src/command/origin/invitations/list_user.rs
@@ -1,0 +1,42 @@
+use crate::{api_client::{Client,
+                         Tabular},
+            common::ui::{Status,
+                         UIWriter,
+                         UI},
+            error::{Error,
+                    Result},
+            PRODUCT,
+            VERSION};
+
+pub fn start(ui: &mut UI, bldr_url: &str, token: &str) -> Result<()> {
+    let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
+
+    ui.status(Status::Discovering,
+              "member invitations sent to your account".to_string())?;
+
+    // given a token, fetch any invitations for this user
+    match api_client.list_user_invitations(token) {
+        Ok(resp) => {
+            println!("Your Origin Invitations Inbox [{}]:", resp.0.len());
+            match resp.as_tabbed() {
+                Ok(body) => {
+                    if !body.is_empty() {
+                        println!("{}", body);
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    ui.fatal(format!("Failed to format origin invitations under your account! \
+                                      {:?}.",
+                                     e))?;
+                    Err(Error::from(e))
+                }
+            }
+        }
+        Err(e) => {
+            ui.fatal(format!("Failed to retrieve origin invitations under your account! {:?}.",
+                             e))?;
+            Err(Error::from(e))
+        }
+    }
+}

--- a/components/hab/src/command/origin/invitations/list_user.rs
+++ b/components/hab/src/command/origin/invitations/list_user.rs
@@ -20,9 +20,7 @@ pub fn start(ui: &mut UI, bldr_url: &str, token: &str) -> Result<()> {
             println!("Your Origin Invitations Inbox [{}]:", resp.0.len());
             match resp.as_tabbed() {
                 Ok(body) => {
-                    if !body.is_empty() {
-                        println!("{}", body);
-                    }
+                    println!("{}", body);
                     Ok(())
                 }
                 Err(e) => {

--- a/components/hab/src/command/origin/invitations/rescind.rs
+++ b/components/hab/src/command/origin/invitations/rescind.rs
@@ -1,0 +1,50 @@
+use crate::{api_client::{self,
+                         Client},
+            common::ui::{Status,
+                         UIWriter,
+                         UI},
+            error::{Error,
+                    Result},
+            PRODUCT,
+            VERSION};
+use reqwest::StatusCode;
+
+pub fn start(ui: &mut UI,
+             bldr_url: &str,
+             origin: &str,
+             token: &str,
+             invitation_id: u64)
+             -> Result<()> {
+    let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
+
+    ui.status(Status::Rescinding,
+              format!("invitation id {} for origin {}", invitation_id, origin))?;
+
+    match api_client.rescind_origin_invitation(origin, token, invitation_id) {
+        Ok(_) => {
+            ui.status(Status::Rescinded,
+                      "the invitation successfully!".to_string())
+              .or(Ok(()))
+        }
+        Err(err @ api_client::Error::APIError(StatusCode::FORBIDDEN, _)) => {
+            ui.fatal("Failed to rescind the invitation!")?;
+            ui.fatal("This situation could arise, if for example, you are not a member of the \
+                      origin.")?;
+            Err(Error::APIClient(err))
+        }
+        Err(err @ api_client::Error::APIError(StatusCode::UNAUTHORIZED, _)) => {
+            ui.fatal("Failed to rescind the invitation!")?;
+            Err(Error::APIClient(err))
+        }
+        Err(err @ api_client::Error::APIError(StatusCode::NOT_FOUND, _)) => {
+            ui.fatal("Failed to rescind the invitation!")?;
+            ui.fatal("The origin or invitation id does not exist.")?;
+            Err(Error::APIClient(err))
+        }
+        Err(e) => {
+            ui.fatal(format!("Failed to rescind the invitation id {} in the {} origin, {:?}",
+                             invitation_id, origin, e))?;
+            Err(Error::from(e))
+        }
+    }
+}

--- a/components/hab/src/command/origin/invitations/send.rs
+++ b/components/hab/src/command/origin/invitations/send.rs
@@ -1,0 +1,41 @@
+use crate::{api_client::{self,
+                         Client},
+            common::ui::{Status,
+                         UIWriter,
+                         UI},
+            error::{Error,
+                    Result},
+            PRODUCT,
+            VERSION};
+use reqwest::StatusCode;
+
+pub fn start(ui: &mut UI,
+             bldr_url: &str,
+             origin: &str,
+             token: &str,
+             invitation_account: &str)
+             -> Result<()> {
+    let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
+
+    ui.status(Status::Sending,
+              format!("invitation to user {} for origin {}",
+                      invitation_account, origin))?;
+
+    match api_client.send_origin_invitation(origin, token, invitation_account) {
+        Ok(_) => {
+            ui.status(Status::Sent, "the invitation successfully!".to_string())
+              .or(Ok(()))
+        }
+        Err(err @ api_client::Error::APIError(StatusCode::FORBIDDEN, _)) => {
+            ui.fatal("Failed to send the invitation!")?;
+            ui.fatal("This situation could arise, if for example, you are not a member of the \
+                      origin.")?;
+            Err(Error::APIClient(err))
+        }
+        Err(e) => {
+            ui.fatal(format!("Failed to send invitation to {} in the {} origin, {:?}",
+                             invitation_account, origin, e))?;
+            Err(Error::from(e))
+        }
+    }
+}

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -192,6 +192,17 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
         ("install", Some(m)) => sub_pkg_install(ui, m, feature_flags)?,
         ("origin", Some(matches)) => {
             match matches.subcommand() {
+                ("invitations", Some(m)) => {
+                    match m.subcommand() {
+                        ("accept", Some(sc)) => sub_accept_origin_invitation(ui, sc)?,
+                        ("ignore", Some(sc)) => sub_ignore_origin_invitation(ui, sc)?,
+                        ("list", Some(sc)) => sub_list_user_invitations(ui, sc)?,
+                        ("pending", Some(sc)) => sub_list_pending_origin_invitations(ui, sc)?,
+                        ("send", Some(sc)) => sub_send_origin_invitation(ui, sc)?,
+                        ("rescind", Some(sc)) => sub_rescind_origin_invitation(ui, sc)?,
+                        _ => unreachable!(),
+                    }
+                }
                 ("key", Some(m)) => {
                     match m.subcommand() {
                         ("download", Some(sc)) => sub_origin_key_download(ui, sc)?,
@@ -484,6 +495,61 @@ fn sub_origin_transfer_ownership(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> 
     let url = bldr_url_from_matches(&m)?;
     let token = auth_token_param_or_env(&m)?;
     command::origin::transfer::start(ui, &url, &token, &origin, &account)
+}
+
+fn sub_accept_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
+    let origin = m.value_of("ORIGIN").expect("required ORIGIN");
+    let invitation_id: u64 = m.value_of("INVITATION_ID")
+                              .expect("required INVITATION_ID")
+                              .parse()
+                              .expect("INVITATION_ID should be valid at this point");
+    let url = bldr_url_from_matches(&m)?;
+    let token = auth_token_param_or_env(&m)?;
+    command::origin::invitations::accept::start(ui, &url, &origin, &token, invitation_id)
+}
+
+fn sub_ignore_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
+    let origin = m.value_of("ORIGIN").expect("required ORIGIN");
+    let invitation_id: u64 = m.value_of("INVITATION_ID")
+                              .expect("required INVITATION_ID")
+                              .parse()
+                              .expect("INVITATION_ID should be valid at this point");
+    let url = bldr_url_from_matches(&m)?;
+    let token = auth_token_param_or_env(&m)?;
+    command::origin::invitations::ignore::start(ui, &url, &origin, &token, invitation_id)
+}
+
+fn sub_list_user_invitations(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
+    let url = bldr_url_from_matches(&m)?;
+    let token = auth_token_param_or_env(&m)?;
+    command::origin::invitations::list_user::start(ui, &url, &token)
+}
+
+fn sub_list_pending_origin_invitations(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
+    let origin = m.value_of("ORIGIN").expect("required ORIGIN");
+    let url = bldr_url_from_matches(&m)?;
+    let token = auth_token_param_or_env(&m)?;
+    command::origin::invitations::list_pending_origin::start(ui, &url, &origin, &token)
+}
+
+fn sub_rescind_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
+    let origin = m.value_of("ORIGIN").expect("required ORIGIN");
+    let invitation_id: u64 = m.value_of("INVITATION_ID")
+                              .expect("required INVITATION_ID")
+                              .parse()
+                              .expect("INVITATION_ID should be valid at this point");
+    let url = bldr_url_from_matches(&m)?;
+    let token = auth_token_param_or_env(&m)?;
+    command::origin::invitations::rescind::start(ui, &url, &origin, &token, invitation_id)
+}
+
+fn sub_send_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
+    let origin = m.value_of("ORIGIN").expect("required ORIGIN");
+    let invitee_account = m.value_of("INVITEE_ACCOUNT")
+                           .expect("required INVITEE_ACCOUNT");
+    let url = bldr_url_from_matches(&m)?;
+    let token = auth_token_param_or_env(&m)?;
+    command::origin::invitations::send::start(ui, &url, &origin, &token, &invitee_account)
 }
 
 fn sub_pkg_binlink(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {


### PR DESCRIPTION
This implements Habitat Builder origin invitation management via the hab CLI

Signed-off-by: Jeremy J. Miller <jm@chef.io>