### PR TITLE
Ensure that signal handlers are installed first

### DIFF
--- a/components/launcher/src/main.rs
+++ b/components/launcher/src/main.rs
@@ -11,10 +11,13 @@ use std::{env,
           process};
 
 fn main() {
+    // Set up signal handlers before anything else happens to ensure
+    // that all threads spawned thereafter behave properly.
+    signals::init();
     env_logger::init();
     let args: Vec<String> = env::args().skip(1).collect();
     set_global_logging_options(&args);
-    signals::init();
+
     match server::run(args) {
         Err(err) => {
             error!("Launcher exiting with 1 due to err: {}", err);

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -80,10 +80,12 @@ static LOGKEY: &str = "MN";
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() {
+    // Set up signal handlers before anything else happens to ensure
+    // that all threads spawned thereafter behave properly.
+    signals::init();
     logger::init();
     let mut ui = UI::default_with_env();
     let flags = FeatureFlag::from_env(&mut ui);
-    signals::init();
 
     let result = start_rsr_imlw_mlw_gsw_smw_rhw_msw(flags);
     let exit_code = match result {


### PR DESCRIPTION
Here, we ensure that our signal handlers are installed before we do
anything else.

Before, when running the Supervisor using a logging configuration file
with a refresh rate in it, our underlying logging library will start
up a refresh monitoring thread. This happened *before* we installed
our signal handlers, meaning that this refresh thread didn't get them.

As a result, when we try to restart the Supervisor by sending it a
`SIGHUP`, this refresh thread would cause the Supervisor and all its
services to completely shut down.

Though not strictly necessary at this point (because the Launcher
doesn't yet use `log4rs`), I've moved the signal handler
initialization in the Launcher up to the first instruction, as well.

Thanks to @stevendanna for the debugging assistance!

Signed-off-by: Christopher Maier <cmaier@chef.io>