### PR TITLE
hab: only print header once in hab svc status

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1198,7 +1198,7 @@ async fn sub_svc_status(m: &ArgMatches<'_>) -> Result<()> {
     }
     while let Some(message_result) = response.next().await {
         let reply = message_result?;
-        print_svc_status(&mut out, &reply, true)?;
+        print_svc_status(&mut out, &reply, false)?;
     }
     out.flush()?;
     Ok(())


### PR DESCRIPTION
The boolean controls whether to print the header. During a refactor,
this code was changed to accidentally always print the header.

Before:

```
package                               type        desired  state  elapsed (s)  pid   group
core/redis/4.0.14/20190319155852      standalone  up       up     8263         1023  redis.default
package                               type        desired  state  elapsed (s)  pid   group
core/memcached/1.5.19/20191008015847  standalone  up       up     8262         1010  memcached.default
```

after:

```
package                               type        desired  state  elapsed (s)  pid   group
core/redis/4.0.14/20190319155852      standalone  up       up     8291         1023  redis.default
core/memcached/1.5.19/20191008015847  standalone  up       up     8290         1010  memcached.default
```

Signed-off-by: Steven Danna <steve@chef.io>