### PR TITLE
Update manual validation docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,7 +58,7 @@ curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/
     | sudo bash -s -- -c staging -t x86_64-linux-kernel2
 ```
 (Note the addition of the target option on the "curlbash" command! Without this you will end up with
-the Kernel 3 version, and things won't work properly!)
+the modern Linux version, and things won't work properly!)
 
 ```sh
 sudo hab pkg install core/hab --binlink --force --channel=staging

--- a/support/validation/x86_64-linux-kernel2/Vagrantfile
+++ b/support/validation/x86_64-linux-kernel2/Vagrantfile
@@ -22,8 +22,13 @@ Vagrant.configure("2") do |config|
     #
     # It expects you to have HAB_ORIGIN and HAB_AUTH_TOKEN set in your
     # environment when you provision the VM.
+    #
+    # Additionally, it will install from the *staging* channel unless
+    # you specifically override this with the INSTALL_CHANNEL environment
+    # variable. This is the default because this VM is mostly used for
+    # manual evaluation of release candidates from that channel.
     curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh -o install.sh
-    bash install.sh -t x86_64-linux-kernel2
+    bash install.sh -t x86_64-linux-kernel2 -c #{ENV.fetch('INSTALL_CHANNEL', 'staging')}
     sudo hab license accept
     sudo -u vagrant hab origin key download #{ENV['HAB_ORIGIN']} --secret --auth=#{ENV['HAB_AUTH_TOKEN']}
   SHELL


### PR DESCRIPTION
Also tweak the Kernel2 VM `Vagrantfile` to make it easier to evaluate
candidates from the `staging` channel.

Signed-off-by: Christopher Maier <cmaier@chef.io>