### PR TITLE
Add token and warning to rdeps usage

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -332,7 +332,10 @@ impl BuilderAPIProvider for BuilderAPIClient {
     /// # Failures
     ///
     /// * Remote API Server is not available
-    fn fetch_rdeps(&self, (ident, target): (&PackageIdent, PackageTarget)) -> Result<Vec<String>> {
+    fn fetch_rdeps(&self,
+                   (ident, target): (&PackageIdent, PackageTarget),
+                   token: &str)
+                   -> Result<Vec<String>> {
         debug!("Fetching the reverse dependencies for {}", ident);
 
         let url = format!("rdeps/{}", ident);
@@ -341,6 +344,7 @@ impl BuilderAPIProvider for BuilderAPIClient {
                            .get_with_custom_url(&url, |u| {
                                u.set_query(Some(&format!("target={}", &target.to_string())))
                            })
+                           .bearer_auth(token)
                            .send()?;
         resp.ok_if(&[StatusCode::OK])?;
 

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -256,7 +256,10 @@ pub trait BuilderAPIProvider: Sync + Send {
                     token: &str)
                     -> Result<String>;
 
-    fn fetch_rdeps(&self, ident_and_target: (&PackageIdent, PackageTarget)) -> Result<Vec<String>>;
+    fn fetch_rdeps(&self,
+                   ident_and_target: (&PackageIdent, PackageTarget),
+                   token: &str)
+                   -> Result<Vec<String>>;
 
     fn job_group_promote_or_demote(&self,
                                    group_id: u64,

--- a/components/hab/src/command/bldr/job/start.rs
+++ b/components/hab/src/command/bldr/job/start.rs
@@ -20,7 +20,7 @@ pub fn start(ui: &mut UI,
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
 
     if group {
-        let rdeps = api_client.fetch_rdeps((ident, target))
+        let rdeps = api_client.fetch_rdeps((ident, target), token)
                               .map_err(Error::APIClient)?;
         if !rdeps.is_empty() {
             ui.warn("Found the following reverse dependencies:")?;
@@ -29,8 +29,10 @@ pub fn start(ui: &mut UI,
                 ui.warn(rdep.to_string())?;
             }
 
-            let question = "If you choose to start a group build for this package, all of the \
-                            above will be built as well. Is this what you want?";
+            ui.warn("Note: dependencies from private origins are omitted for non-members.");
+
+            let question = "Starting a group build for this package will also build all of the \
+                            reverse dependencies listed above. Is this what you want?";
 
             if !ui.prompt_yes_no(question, Some(true))? {
                 ui.fatal("Aborted")?;


### PR DESCRIPTION
Related to https://github.com/habitat-sh/builder/pull/1278/files

This change adds the auth token to the rdeps call made during `hab bldr job start`

Signed-off-by: Salim Alam <salam@chef.io>

![](https://media3.giphy.com/media/zQc8STzaOlJ3q/giphy.gif?cid=5a38a5a245fdf6329029b9d7b47ecd3dc21f68d20f25cd30&rid=giphy.gif)
