### PR TITLE
Use packages.chef.io for installation of all versions

### DIFF
--- a/components/hab/install.ps1
+++ b/components/hab/install.ps1
@@ -45,7 +45,7 @@ Function Get-WorkDir {
 }
 
 # Downloads the requested archive from packages.chef.io
-Function Get-PackagesChefioArchive($channel, $version) {
+Function Get-Archive($channel, $version) {
     $url = $packagesChefioRootUrl
     if(!$version -Or $version -eq "latest") {
         $hab_url="$url/$channel/habitat/latest/hab-x86_64-windows.zip"
@@ -176,7 +176,7 @@ Write-Host "Installing Habitat 'hab' program"
 $workdir = Get-WorkDir
 New-Item $workdir -ItemType Directory -Force | Out-Null
 try {
-    $archive = Get-PackagesChefioArchive $channel $version
+    $archive = Get-Archive $channel $version
     if($archive.shasum) {
         Assert-Shasum $archive
     }

--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -42,7 +42,7 @@ main() {
   create_workdir
   get_platform
   validate_target
-  download_packages_chef_io_archive "$version" "$channel" "$target"
+  download_archive "$version" "$channel" "$target"
   verify_archive
   extract_archive
   install_hab
@@ -163,7 +163,7 @@ validate_target() {
   fi
 }
 
-download_packages_chef_io_archive() {
+download_archive() {
   need_cmd mv
   
   local _version="${1:-latest}"

--- a/components/hab/tests/test_install_script.bats
+++ b/components/hab/tests/test_install_script.bats
@@ -43,7 +43,7 @@ installed_target() {
   [ "$(installed_target)" == "x86_64-linux" ]
 }
 
-@test "Install from bintray for x86_84-linux" {
+@test "Install legacy package for x86_84-linux" {
   linux || skip "Did not detect a Linux system"
   run components/hab/install.sh -v 0.79.1 
 
@@ -69,7 +69,7 @@ installed_target() {
   [ "$(installed_target)" == "x86_64-linux-kernel2" ]
 }
 
-@test "Install from bintray for x86_84-linux-kernel2" {
+@test "Install legacy package for x86_84-linux-kernel2" {
   linux || skip "Did not detect a Linux system"
   run components/hab/install.sh -v 0.79.1 -t "x86_64-linux-kernel2"
 
@@ -93,7 +93,7 @@ installed_target() {
   [ "$(installed_version)" == "hab 0.90.6" ]
 }
 
-@test "Install from bintray for x86_84-darwin" {
+@test "Install legacy package for x86_84-darwin" {
   darwin || skip "Did not detect a Darwin system"
   run components/hab/install.sh -v 0.79.1
 

--- a/components/hab/tests/test_install_script.ps1
+++ b/components/hab/tests/test_install_script.ps1
@@ -13,7 +13,7 @@ Describe "Install habitat using install.ps1" {
         $result | Should -Match "hab 0.90.6/*"
     }
 
-    It "can install a specific version of Habitat from Bintray" {
+    It "can install a specific version of legacy Habitat package" {
         components/hab/install.ps1 -v 0.79.1
         $LASTEXITCODE | Should -Be 0
 


### PR DESCRIPTION
Closes #7312 

All releases of legacy versions of Habitat have been migrated to packages.chef.io. This PR drops support for installation of those packages from their previous host. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>