### PR TITLE
[CI] Update Github Release automation

### DIFF
--- a/.expeditor/scripts/finish_release/create_github_release.sh
+++ b/.expeditor/scripts/finish_release/create_github_release.sh
@@ -7,12 +7,15 @@ set -euo pipefail
 echo "--- :lock: Importing GPG keys"
 import_gpg_keys
 
-echo "--- :ruby: Installing 'hub' gem"
-gem install hub
+echo "--- Installing 'hub' CLI tool"
+sudo apt-get install hub
 
-echo "--- :thinking_face: Determining sha and version to release"
+echo "--- :thinking_face: Determining the version to release"
 get_manifest_for_environment "stable"
-read -r version gitsha <<< "$(jq -r '.version + " " + .sha' manifest.json)"
+version="$(jq -r '.version' manifest.json)"
+
+# It is our convention to have a tag for every version.
+tag="${version}"
 
 echo "--- :github: Creating release"
-maybe_run hub release create --message "$version" --commitish "$gitsha" "$version"
+maybe_run hub release create --message "${version}" "${tag}"

--- a/.expeditor/scripts/finish_release/create_github_release.sh
+++ b/.expeditor/scripts/finish_release/create_github_release.sh
@@ -8,7 +8,7 @@ echo "--- :lock: Importing GPG keys"
 import_gpg_keys
 
 echo "--- Installing 'hub' CLI tool"
-sudo apt-get install hub
+install_hub
 
 echo "--- :thinking_face: Determining the version to release"
 get_manifest_for_environment "stable"


### PR DESCRIPTION
Previously, we were using `hub` installed as a Ruby gem. However,
modern `hub` is written in Go, and is available through standard
package managers.

Additionally, we no longer need a `--commitish` argument, since we
know the pre-existing tag we want to use for the release.

Signed-off-by: Christopher Maier <cmaier@chef.io>