### PR TITLE
Run cargo-update as part of post-release activities

### DIFF
--- a/.expeditor/finish_release.pipeline.yml
+++ b/.expeditor/finish_release.pipeline.yml
@@ -45,3 +45,19 @@ steps:
         linux:
           privileged: true
     soft_fail: true
+  
+  - label: ":rust: Cargo update"
+    skip: "Unable to open PRs with the expeditor provided GITHUB_TOKEN currently"
+    command:
+      - .expeditor/scripts/finish_release/cargo_update.sh
+    expeditor:
+      account:
+        - github
+      secrets:
+        GITHUB_TOKEN:
+          account: github
+          field: token
+      executor:
+        docker:
+          environment:
+    soft_fail: true

--- a/.expeditor/scripts/finish_release/cargo_update.sh
+++ b/.expeditor/scripts/finish_release/cargo_update.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail 
+ 
+# shellcheck source=.expeditor/scripts/shared.sh 
+source .expeditor/scripts/shared.sh 
+
+branch="ci/cargo-update-$(date +"%Y%m%d%H%M%S")"
+git checkout -b "$branch"
+
+toolchain="$(get_toolchain)"
+
+install_rustup
+rustup install "$toolchain"
+
+install_hub
+
+echo "--- :habicat: Installing and configuring build dependencies"
+hab pkg install core/libsodium core/libarchive core/openssl core/zeromq
+
+PKG_CONFIG_PATH="$(< "$(hab pkg path core/libarchive)"/PKG_CONFIG_PATH)"
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(< "$(hab pkg path core/libsodium)"/PKG_CONFIG_PATH)"
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(< "$(hab pkg path core/openssl)"/PKG_CONFIG_PATH)"
+PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(< "$(hab pkg path core/zeromq)"/PKG_CONFIG_PATH)"
+export PKG_CONFIG_PATH 
+
+# The library detection for the zeromq crate needs this additional hint. 
+LD_RUN_PATH="$(hab pkg path core/zeromq)/lib"
+export LD_RUN_PATH
+
+echo "--- :rust: Cargo Update"
+cargo clean
+cargo +"$toolchain" update
+
+echo "--- :rust: Cargo Check"
+cargo +"$toolchain" check --all --tests && update_status=$? || update_status=$?
+
+echo "--- :git: Publishing updated Cargo.lock"
+git add Cargo.lock
+
+git commit -s -m "Update Cargo.lock"
+
+pr_labels=""
+pr_message=""
+if [ "$update_status" -ne 0 ]; then 
+  pr_labels="T-DO-NOT-MERGE"
+
+  # read will exit 1 if it can't find a delimeter.
+  # -d '' will always trigger this case as there is no delimeter to find, 
+  # but this is required in order to write the entire message into a single PR 
+  # preserving newlines.
+   read -r -d '' pr_message <<EOM || true
+Unable to update Cargo.lock!
+
+For details on the failure, please visit ${BUILDKITE_BUILD_URL:-No Buildkite url}#${BUILDKITE_JOB_ID:-No Buildkite job id}
+EOM
+fi
+
+# Use shell to push the current branch so we can authenticate without scribbling secrets to disk
+#   or being prompted by git.
+# Hub provides better mechanisms than curl for opening a pr with a message and setting labels,
+# the latter requires multiple curl commands and parsing json responses and error handling at each step.
+push_current_branch
+
+# We have to use --force to open the PR. We're specifying where to push, rather than using a remote, in 
+# the previous command to avoid writing secrets to disk, so hub isn't able to read that information from
+# the git configuration
+hub pull-request --force --no-edit --draft --labels "$pr_labels" --file - <<EOF
+Cargo Update
+
+$pr_message
+EOF
+
+exit "$update_status"

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -324,3 +324,18 @@ install_hub() {
   chmod a+x /bin/hub
   rm -rf hub-linux-amd64*
 }
+
+# Push the current branch to the project origin
+push_current_branch() {
+  repo=$(git remote get-url origin | sed -rn  's/.+github\.com[\/\:](.*)\.git/\1/p')
+  head=$(git rev-parse --abbrev-ref HEAD)
+
+  if [ "$head" == "master" ]; then 
+    echo "Error: Attempting to push to master!"
+    exit 1
+  fi
+
+  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${repo}.git" "$head"
+}
+
+


### PR DESCRIPTION
This adds a step to run cargo update after the release is finished.  It will result in a PR with the updated Cargo.lock or, in the case of failure, a PR with a link back to the buildkite job for inspection.  This is intended to give us something to track on our board so it doesn't get lost in a buildkite job. 

This step is currently set to skip, as the GITHUB_TOKEN provided by expeditor currently doesn't have permissions to open a PR on non-chef organization repositories.  I've tested the code locally by generating  a personal access token and using that in a local `chefes/buildkite` container: https://github.com/habitat-sh/habitat/pull/7286
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>