### PR TITLE
Remove a debug log message from the service updater

### DIFF
--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -158,9 +158,6 @@ impl ServiceUpdater {
                                                  // census group for our service.
                                                  census_ring: &CensusRing)
                                                  -> Option<PackageIdent> {
-        debug!("Checking {} for updated {} package in the {} channel",
-               service.bldr_url, service.spec_ident, service.channel);
-
         // TODO (CM): can we do without this?
         let mut ident = None;
 


### PR DESCRIPTION
This message was being emitted each time we checked an internal queue
for a new service, NOT each time we initiated an HTTP call to check in
Builder. The latter is the more important (and resource-intensive!)
action, and seeing the message multiple times a second could be
misleading.

![](https://media.giphy.com/media/RLUyfJnogtXK44pm9t/giphy.gif)

Signed-off-by: Christopher Maier <cmaier@chef.io>