### PR TITLE
Allow ad-hoc deployments of acceptance environment website changes

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -27,7 +27,12 @@ pipelines:
   - verify:
       description: Pull Request validation tests
   - website:
-      description: Deploy the website
+      description: Deploy the website to production
+  - website-acceptance:
+      # This is NOT intended for automated runs... it just
+      # encapsulates the parameters and execution environment to
+      # deploy a given branch to the acceptance environment website.
+      description: Deploy the website on-demand to the acceptance environment
   - release_habitat:
       description: Habitat release process
   - end_to_end:

--- a/.expeditor/scripts/website-deploy.sh
+++ b/.expeditor/scripts/website-deploy.sh
@@ -14,9 +14,10 @@ if [[ "$env" != "acceptance" && "$env" != "live"  ]]; then
 fi
 
 export AWS_BUCKET="habitat-www-$env"
+export AWS_DEFAULT_REGION=us-west-2
 
-# verify that all the environment variables are properly set
-vars=(AWS_BUCKET AWS_DEFAULT_REGION FASTLY_SERVICE_KEY)
+# verify that the expected environment variables are properly set
+vars=(FASTLY_SERVICE_KEY)
 for var in "${vars[@]}"
 do
   if [ -z "${!var:-}" ]; then

--- a/.expeditor/website-acceptance.pipeline.yml
+++ b/.expeditor/website-acceptance.pipeline.yml
@@ -1,0 +1,26 @@
+expeditor:
+  secrets:
+    FASTLY_API_KEY:
+      path: account/static/fastly/eng-services-ops
+      field: token
+  accounts:
+    - aws/chef-cd
+    - aws/habitat
+  defaults:
+    buildkite:
+      timeout_in_minutes: 30
+      env:
+        FASTLY_SERVICE_KEY: "14eS2oVO4ENvQXYEIp1E5M"
+        AWS_DEFAULT_REGION: "us-west-2"
+
+steps:
+  - label: "Deploy the website to Acceptance :pen:"
+    command:
+      - AWS_PROFILE=habitat .expeditor/scripts/website-deploy.sh acceptance
+    expeditor:
+      executor:
+        docker:
+    timeout_in_minutes: 10
+    retry:
+      automatic:
+        limit: 1

--- a/.expeditor/website-acceptance.pipeline.yml
+++ b/.expeditor/website-acceptance.pipeline.yml
@@ -11,7 +11,6 @@ expeditor:
       timeout_in_minutes: 30
       env:
         FASTLY_SERVICE_KEY: "14eS2oVO4ENvQXYEIp1E5M"
-        AWS_DEFAULT_REGION: "us-west-2"
 
 steps:
   - label: "Deploy the website to Acceptance :pen:"

--- a/.expeditor/website.pipeline.yml
+++ b/.expeditor/website.pipeline.yml
@@ -11,7 +11,6 @@ expeditor:
       timeout_in_minutes: 30
       env:
         FASTLY_SERVICE_KEY: "T32H9RqMWpCV9qhp3S9xq"
-        AWS_DEFAULT_REGION: "us-west-2"
 
 steps:
   - label: "Deploy the website :pen:"

--- a/www/README.md
+++ b/www/README.md
@@ -1,4 +1,3 @@
-
 # WWW
 
 Static site content for www.habitat.sh
@@ -37,8 +36,28 @@ In some cases, you may need to install `gawk` in order to obtain the `ffi` gem. 
 
 ## How-To: Deploy
 
-This happens automatically now as part of our CI pipeline.  When a PR merges
-to master, the web site will automatically be deployed to production. Deploys
-of the web site to acceptance is still a manual process, accomplished by
-running `make deploy_acceptance`. If you need to deploy the web site to
-production manually, you can run `make deploy_live`.
+This happens automatically now as part of our CI pipeline.  When a PR
+merges to master, the web site will automatically be deployed to
+production.
+
+If you would like to deploy your changes to the acceptance
+environment, you can manually invoke the [website-acceptance
+pipeline][]. Hit the "New Build" button and specify your PR
+branch. This pipeline does _not_ run automatically, and is provided as
+a way to encapsulate all that is necessary to deploy a build to
+acceptance. Alternatively, you may run `make deploy_acceptance`
+locally, provided you know the appropriate Fastly service ID and have
+an appropriate build environment set up. The pipeline is the preferred
+way, however, as all that is taken care of for you.
+
+Note that there is currently _no_ isolation provided for this
+acceptance pipeline, so you will need to coordinate with your
+teammates if more than one of you have website changes you'd like to
+see at the same time. We're all adults here, though, so make it
+happen.
+
+Once your PR merges, it would be nice for you to re-invoke the
+[website-acceptance pipeline][] again, pointed to the `master` branch,
+in order to "reset" the acceptance website to its expected state.
+
+[website-acceptance pipeline]: https://buildkite.com/chef/habitat-sh-habitat-master-website-acceptance


### PR DESCRIPTION
This simply encapsulates the process of deploying a website build to
our acceptance environment. It is not intended to be run in an
automated way, but rather on an ad-hoc basis to allow team members to
view and validate website changes in our acceptance environment.

![](https://media.giphy.com/media/P7qFEMh3TLMGY/giphy.gif)