### PR TITLE
terminate launcher on hab sup term on windows

### DIFF
--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -151,7 +151,7 @@ pub enum Error {
     /// Occurs when a `WaitForSingleObject` win32 call returns an error.
     WaitForSingleObjectFailed(String),
     /// Occurs when a `TerminateProcess` win32 call returns an error.
-    TerminateProcessFailed(String),
+    TerminateProcessFailed(u32, io::Error),
     /// Occurs if the host os kernel does not have a supported docker image
     UnsupportedDockerHostKernel(String),
     /// When an error occurs attempting to interpret a sequence of u8 as a string.
@@ -336,7 +336,9 @@ impl fmt::Display for Error {
             Error::GetExitCodeProcessFailed(ref e) => e.to_string(),
             Error::CreateToolhelp32SnapshotFailed(ref e) => e.to_string(),
             Error::WaitForSingleObjectFailed(ref e) => e.to_string(),
-            Error::TerminateProcessFailed(ref e) => e.to_string(),
+            Error::TerminateProcessFailed(ref r, ref e) => {
+                format!("Failed to terminate process: {}, {}", r, e)
+            }
             Error::UnsupportedDockerHostKernel(ref e) => {
                 format!("Unsupported Docker host kernel: {}", e)
             }

--- a/components/core/src/os/process.rs
+++ b/components/core/src/os/process.rs
@@ -21,6 +21,7 @@ pub use self::windows::{become_command,
                         current_pid,
                         handle_from_pid,
                         is_alive,
+                        terminate,
                         Pid};
 use crate::{error::Error,
             util::serde_string};

--- a/components/core/src/os/process/windows.rs
+++ b/components/core/src/os/process/windows.rs
@@ -69,6 +69,15 @@ pub fn is_alive(pid: Pid) -> bool {
     }
 }
 
+pub fn terminate(pid: Pid) -> Result<()> {
+    if let Some(handle) = handle_from_pid(pid) {
+        if unsafe { processthreadsapi::TerminateProcess(handle, 1) } == 0 {
+            return Err(Error::TerminateProcessFailed(pid, io::Error::last_os_error()));
+        }
+    }
+    Ok(())
+}
+
 /// Executes a command as a child process and exits with the child's exit code.
 ///
 /// Note that if successful, this function will not return.

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -589,16 +589,13 @@ impl Manager {
 
     pub fn term(proc_lock_file: &Path) -> Result<()> {
         match read_process_lock(proc_lock_file) {
-            #[cfg(unix)]
             Ok(pid) => {
-                // TODO (CM): this only ever worked on Linux! It's a no-op
-                // on Windows! See
-                // https://github.com/habitat-sh/habitat/issues/4945
+                #[cfg(unix)]
                 process::signal(pid, Signal::TERM).map_err(|_| Error::SignalFailed)?;
+                #[cfg(windows)]
+                process::terminate(pid)?;
                 Ok(())
             }
-            #[cfg(windows)]
-            Ok(_) => Ok(()),
             Err(err) => Err(err),
         }
     }


### PR DESCRIPTION
This accomplishes the bulk of fixing #6375.

There is a "hole" in the windows service that needs filling. It will shutdown the entire console (killing all of its processes) immediately after the launcher exits which does not give `hab-sup` the opportunity to cleanly shut down.

That fix can/will exist in a separate PR.

Signed-off-by: mwrock <matt@mattwrock.com>