### PR TITLE
windows-service improvements

### DIFF
--- a/components/windows-service/HabService.cs
+++ b/components/windows-service/HabService.cs
@@ -151,19 +151,9 @@ namespace HabService
                 }
                 else
                 {
-                    // because we declare hab-launcher as a runtime dep
-                    // this path should exist
-                    string launcherBase = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "hab\\pkgs\\core\\hab-launcher");
-                    string latestLauncher = LastDirectory(LastDirectory(launcherBase));
-                    return Path.Combine(latestLauncher, "bin\\hab-launch.exe");
+                    throw new InvalidOperationException("Missing 'launcherPath' application setting in config.");
                 }
             }
-        }
-
-        private static string LastDirectory(string path)
-        {
-            string[] dirs = Directory.GetDirectories(path);
-            return dirs[dirs.Length - 1];
         }
 
         private void SupOutputHandler(object sender, DataReceivedEventArgs e)

--- a/components/windows-service/HabService.cs
+++ b/components/windows-service/HabService.cs
@@ -2,6 +2,7 @@
 using System.Configuration;
 using System.Diagnostics;
 using System.IO;
+using System.Management;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.ServiceProcess;
@@ -184,6 +185,16 @@ namespace HabService
         private void ExitHandler(object sender, System.EventArgs e)
         {
             log.Error(String.Format("Habitat Supervisor has exited with exit code {0}", proc.ExitCode));
+            var mos = new ManagementObjectSearcher("SELECT ProcessId FROM Win32_Process WHERE Name='hab-sup.exe' AND ParentProcessId=" + proc.Id);
+            // There should really only be 1 but the searcher returns a collection
+            // We want to make sure that the supervisor is allowed time to shut down
+            // before stopping the service so that any of its services
+            // cleanly shut down.
+            foreach (ManagementObject mo in mos.Get()) {
+                var sup = Process.GetProcessById(Convert.ToInt32(mo["ProcessID"]));
+                log.Info("Waiting for Supervisor to exit...");
+                sup.WaitForExit();
+            }
             Stop();
         }
 

--- a/components/windows-service/habitat.ps1
+++ b/components/windows-service/habitat.ps1
@@ -1,6 +1,6 @@
 function Install-HabService {
     if($null -ne (Get-Service Habitat -ErrorAction SilentlyContinue)) {
-        Write-Error "The Habitat service is already installed. Please run 'hab exec core/windows-service uninstall' first if you wish to reinstall."
+        Write-Error "The Habitat service is already installed. Please run 'hab pkg exec core/windows-service uninstall' first if you wish to reinstall."
         return
     }
 

--- a/components/windows-service/hooks/install
+++ b/components/windows-service/hooks/install
@@ -1,5 +1,20 @@
 . {{pkg.path}}\bin\habitat.ps1
 
+function Set-LauncherPath {
+    $launcherPath = '{{pkgPathFor "core/hab-launcher"}}\bin\hab-launch.exe'
+    [xml]$configXml = Get-Content (Join-Path "{{pkg.svc_path}}" HabService.dll.config)
+    $launcherPathNodeList = $configXml.configuration.appSettings.SelectNodes("add[@key='launcherPath']")
+    if($launcherPathNodeList.Count -eq 0) {
+        $launcherPathNode = $configXml.CreateElement("add")
+        $launcherPathNode.SetAttribute("key", "launcherPath") | Out-Null
+        $configXml.configuration.appSettings.AppendChild($launcherPathNode) | Out-Null
+    } else {
+        $launcherPathNode = $launcherPathNodeList[0]
+    }
+    $launcherPathNode.SetAttribute("value", $launcherPath) | Out-Null
+    $configXml.Save((Join-Path "{{pkg.svc_path}}" HabService.dll.config))
+}
+
 $isRunning = $false
 
 if((Get-Service Habitat -ErrorAction SilentlyContinue) -ne $null) {
@@ -20,6 +35,8 @@ Install-HabService
 if(Test-Path $configPathBU) {
     Move-Item $configPathBU $configPath -Force
 }
+
+Set-LauncherPath
 
 if($isRunning) {
     Start-Service Habitat


### PR DESCRIPTION
This addresses two key issues:

* Wait for the supervisor to exit before stopping the service upon launcher termination. If someone forcefully kills the launcher process or issues a `hab sup term`, the exit handler for the launcher is fired which immediately shuts down the service and prevents the supervisor from cleanly stopping any running services. So this fully resolves #6375 
* It fixes #7417 by running the launcher in the packages dependency.

Additionally this fixes a small messaging issue that a user recently brought to my attention.