### PR TITLE
Change split to second set so it pulls pkg name

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -2228,7 +2228,7 @@ try {
 
     # Load scaffolding packages if they are being used.
     if ($pkg_scaffolding) {
-        $scaff = $pkg_scaffolding.Split("/")[-1]
+        $scaff = $pkg_scaffolding.Split("/")[1]
         $lib="$(Get-HabPackagePath $scaff)/lib/scaffolding.ps1"
         Write-BuildLine "Loading Scaffolding $lib"
         if(!(Test-Path $lib)) {


### PR DESCRIPTION
Signed-off-by: John Snow <thelunaticscripter@outlook.com>

This will make it so that when the build is pulling a windows scaffolding package that has a version or a build number added to it it will still be able to properly load the lib script. 

![infinte_loop](https://media.giphy.com/media/3Xw8jY3zbFRtFd6eK8/giphy.gif)

#7424 