### PR TITLE
Add gather-logs alias to align with other products

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -860,7 +860,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
         )
         (@subcommand supportbundle =>
             (about: "Create a tarball of Habitat Supervisor data to send to support")
-            (aliases: &["supp", "suppo", "suppor", "support-bundle"])
+            (aliases: &["supp", "suppo", "suppor", "support-bundle", "gather-logs"])
         )
         (@subcommand user =>
             (about: "Commands relating to Habitat users")


### PR DESCRIPTION
Chef Infra Server and Automate use `gather-logs` when generating a support bundle, let's use this for Habitat as well please!

Signed-off-by: Shaun Mouton <smouton@chef.io>