### PR TITLE
adds hab origin info subcommand

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -693,6 +693,16 @@ impl BuilderAPIClient {
         Ok(resp.json().await?)
     }
 
+    /// Retrieves public metadata for an origin
+    ///
+    ///  # Arguments
+    ///    * Token: &str - bearer token for authentication/authorization
+    ///
+    ///  # Expected API response on success
+    ///    * HTTP 200
+    ///
+    ///  # Return
+    ///    * Result<OriginInfoResponse>
     pub async fn origin_info(&self, token: &str, origin: &str) -> Result<OriginInfoResponse> {
         let path = format!("depot/origins/{}", origin);
 

--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -12,6 +12,7 @@ use crate::{allow_std_io::AllowStdIo,
             response,
             BuildOnUpload,
             DisplayProgress,
+            OriginInfoResponse,
             OriginKeyIdent,
             OriginSecret,
             Package,
@@ -685,6 +686,15 @@ impl BuilderAPIClient {
                                        token: &str)
                                        -> Result<UserOriginInvitationsResponse> {
         let path = "user/invitations";
+
+        let resp = self.0.get(&path).bearer_auth(token).send().await?;
+        let resp = response::ok_if(resp, &[StatusCode::OK]).await?;
+
+        Ok(resp.json().await?)
+    }
+
+    pub async fn origin_info(&self, token: &str, origin: &str) -> Result<OriginInfoResponse> {
+        let path = format!("depot/origins/{}", origin);
 
         let resp = self.0.get(&path).bearer_auth(token).send().await?;
         let resp = response::ok_if(resp, &[StatusCode::OK]).await?;

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -254,7 +254,7 @@ mod json_date_format {
     }
 }
 
-pub fn convert_to_json<T>(src: &T) -> Result<Json>
+fn convert_to_json<T>(src: &T) -> Result<Json>
     where T: Serialize
 {
     serde_json::to_value(src).map_err(|e| habitat_core::Error::RenderContextSerialization(e).into())

--- a/components/builder-api-client/src/lib.rs
+++ b/components/builder-api-client/src/lib.rs
@@ -27,6 +27,8 @@ use std::{fmt,
 use chrono::{DateTime,
              Utc};
 use reqwest::IntoUrl;
+use serde::Serialize;
+use serde_json::Value as Json;
 use tabwriter::TabWriter;
 
 use crate::hab_core::package::PackageIdent;
@@ -194,6 +196,16 @@ pub struct OriginChannelIdent {
     pub name: String,
 }
 
+#[derive(Clone, Serialize, Deserialize)]
+pub struct OriginInfoResponse {
+    pub default_package_visibility: String,
+    pub name: String,
+    #[serde(with = "json_u64")]
+    pub owner_id: u64,
+    pub owner_account: String,
+    pub private_key_name: String,
+}
+
 #[derive(Clone, Deserialize)]
 pub struct OriginInvitation {
     #[serde(with = "json_u64")]
@@ -242,6 +254,12 @@ mod json_date_format {
     }
 }
 
+pub fn convert_to_json<T>(src: &T) -> Result<Json>
+    where T: Serialize
+{
+    serde_json::to_value(src).map_err(|e| habitat_core::Error::RenderContextSerialization(e).into())
+}
+
 // Returns a library object that implements elastic tabstops
 fn tabw() -> TabWriter<Vec<u8>> { TabWriter::new(Vec::new()) }
 
@@ -255,11 +273,15 @@ fn tabify(mut tw: TabWriter<Vec<u8>>, s: &str) -> Result<String> {
     })
 }
 
-pub trait Tabular {
+pub trait PortableText {
+    fn as_json(&self) -> Result<Json>;
+}
+
+pub trait TabularText {
     fn as_tabbed(&self) -> Result<String>;
 }
 
-impl Tabular for UserOriginInvitationsResponse {
+impl TabularText for UserOriginInvitationsResponse {
     fn as_tabbed(&self) -> Result<String> {
         let tw = tabw().padding(2).minwidth(5);
         if !self.0.is_empty() {
@@ -281,7 +303,7 @@ impl Tabular for UserOriginInvitationsResponse {
     }
 }
 
-impl Tabular for PendingOriginInvitationsResponse {
+impl TabularText for PendingOriginInvitationsResponse {
     fn as_tabbed(&self) -> Result<String> {
         let tw = tabw().padding(2).minwidth(5);
         if !self.invitations.is_empty() {
@@ -299,6 +321,24 @@ impl Tabular for PendingOriginInvitationsResponse {
             Ok(String::from(""))
         }
     }
+}
+
+impl TabularText for OriginInfoResponse {
+    fn as_tabbed(&self) -> Result<String> {
+        let tw = tabw().padding(2).minwidth(5);
+        let mut body = Vec::new();
+        body.push(String::from("Owner Id\tOwner Account\tPrivate Key\tPackage Visibility"));
+        body.push(format!("{}\t{}\t{}\t{}",
+                          self.owner_id,
+                          self.owner_account,
+                          self.private_key_name,
+                          self.default_package_visibility));
+        tabify(tw, &body.join("\n"))
+    }
+}
+
+impl PortableText for OriginInfoResponse {
+    fn as_json(&self) -> Result<Json> { convert_to_json(&self) }
 }
 
 #[derive(Clone, Deserialize)]

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -134,6 +134,8 @@ pub enum Error {
     PrivilegeNotHeld,
     /// When an error occurs parsing or compiling a regular expression.
     RegexParse(regex::Error),
+    /// When an error occurs serializing rendering context
+    RenderContextSerialization(serde_json::Error),
     /// When an error occurs converting a `String` from a UTF-8 byte vector.
     StringFromUtf8Error(string::FromUtf8Error),
     /// When the system target (platform and architecture) do not match the package target.
@@ -325,6 +327,9 @@ impl fmt::Display for Error {
                                         and 'SE_ASSIGNPRIMARYTOKEN_NAME' privilege to spawn a new \
                                         process as a different user"
                                                                     .to_string(),
+            Error::RenderContextSerialization(ref e) => {
+                format!("Unable to serialize rendering context, {}", e)
+            }
             Error::RegexParse(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
             Error::TargetMatchError(ref e) => e.to_string(),

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -326,7 +326,17 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                      "Specify an alternate Builder endpoint. If not specified, the value will \
                      be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
                      https://bldr.habitat.sh)")
-                (@arg AUTH_TOKEN: -z --auth +required +takes_value "Authentication token for Builder")
+                (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
+            )
+            (@subcommand info =>
+                (about: "Displays general information about an origin")
+                (@arg ORIGIN: +required {valid_origin} "The origin name to be queried")
+                (@arg TO_JSON: -j --json "Output will be rendered in json")
+                (@arg BLDR_URL: -u --url +takes_value {valid_url}
+                     "Specify an alternate Builder endpoint. If not specified, the value will \
+                     be taken from the `HAB_BLDR_URL` environment variable if defined. (default: \
+                     https://bldr.habitat.sh)")
+                (@arg AUTH_TOKEN: -z --auth +takes_value "Authentication token for Builder")
             )
             (@subcommand invitations =>
                 (about: "Manage origin member invitations")

--- a/components/hab/src/command/origin.rs
+++ b/components/hab/src/command/origin.rs
@@ -1,6 +1,7 @@
 pub mod create;
 pub mod delete;
 pub mod depart;
+pub mod info;
 pub mod invitations;
 pub mod key;
 pub mod secret;

--- a/components/hab/src/command/origin/info.rs
+++ b/components/hab/src/command/origin/info.rs
@@ -1,0 +1,54 @@
+use crate::{api_client::{Client,
+                         PortableText,
+                         TabularText},
+            common::ui::{Status,
+                         UIWriter,
+                         UI},
+            error::{Error,
+                    Result},
+            PRODUCT,
+            VERSION};
+
+pub async fn start(ui: &mut UI,
+                   bldr_url: &str,
+                   token: &str,
+                   origin: &str,
+                   to_json: bool)
+                   -> Result<()> {
+    let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
+
+    match api_client.origin_info(token, origin).await {
+        Ok(resp) => {
+            if to_json {
+                // match as_json(&resp) {
+                match resp.as_json() {
+                    Ok(body) => {
+                        println!("{}", body);
+                        Ok(())
+                    }
+                    Err(e) => {
+                        ui.fatal(format!("Failed to deserialize into json! {:?}.", e))?;
+                        Err(Error::from(e))
+                    }
+                }
+            } else {
+                ui.status(Status::Discovering, "origin metadata".to_string())?;
+                println!("Origin [{}]:", origin);
+                match resp.as_tabbed() {
+                    Ok(body) => {
+                        println!("{}", body);
+                        Ok(())
+                    }
+                    Err(e) => {
+                        ui.fatal(format!("Failed to format origin metadata! {:?}.", e))?;
+                        Err(Error::from(e))
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            ui.fatal(format!("Failed to retrieve origin metadata! {:?}.", e))?;
+            Err(Error::from(e))
+        }
+    }
+}

--- a/components/hab/src/command/origin/info.rs
+++ b/components/hab/src/command/origin/info.rs
@@ -20,7 +20,6 @@ pub async fn start(ui: &mut UI,
     match api_client.origin_info(token, origin).await {
         Ok(resp) => {
             if to_json {
-                // match as_json(&resp) {
                 match resp.as_json() {
                     Ok(body) => {
                         println!("{}", body);

--- a/components/hab/src/command/origin/invitations/list_pending_origin.rs
+++ b/components/hab/src/command/origin/invitations/list_pending_origin.rs
@@ -1,6 +1,6 @@
 use crate::{api_client::{self,
                          Client,
-                         Tabular},
+                         TabularText},
             common::ui::{Status,
                          UIWriter,
                          UI},

--- a/components/hab/src/command/origin/invitations/list_user.rs
+++ b/components/hab/src/command/origin/invitations/list_user.rs
@@ -1,5 +1,5 @@
 use crate::{api_client::{Client,
-                         Tabular},
+                         TabularText},
             common::ui::{Status,
                          UIWriter,
                          UI},

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -225,6 +225,7 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                 ("delete", Some(m)) => sub_origin_delete(ui, m).await?,
                 ("transfer", Some(m)) => sub_origin_transfer_ownership(ui, m).await?,
                 ("depart", Some(m)) => sub_origin_depart(ui, m).await?,
+                ("info", Some(m)) => sub_origin_info(ui, m).await?,
                 _ => unreachable!(),
             }
         }
@@ -480,6 +481,14 @@ async fn sub_origin_create(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let url = bldr_url_from_matches(&m)?;
     let token = auth_token_param_or_env(&m)?;
     command::origin::create::start(ui, &url, &token, &origin).await
+}
+
+async fn sub_origin_info(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
+    let origin = m.value_of("ORIGIN").expect("required ORIGIN");
+    let url = bldr_url_from_matches(&m)?;
+    let token = auth_token_param_or_env(&m)?;
+    let to_json = m.is_present("TO_JSON");
+    command::origin::info::start(ui, &url, &token, &origin, to_json).await
 }
 
 async fn sub_origin_delete(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {


### PR DESCRIPTION
This provides `hab origin info <ORIGIN>` such that users can determine public origin metadata; for example, the origin's owner. Determining the owner is now possible due to https://github.com/habitat-sh/builder/pull/1290.

![Who-Owns-It jpg](https://user-images.githubusercontent.com/1991696/74277254-334b0e00-4ce5-11ea-811b-157337ea0267.png)

It provides a `--json` flag and underlying Trait implementation that can easily be applied to other API responses, where appropriate.

```
$ ./target/debug/hab origin info jeremymv2
☁ Discovering origin metadata
Origin [jeremymv2]:
Owner Id            Owner Account  Private Key               Package Visibility
835646971166441582  jeremymv2      jeremymv2-20171024221121  public

$ ./target/debug/hab origin info jeremymv2 --json
{"default_package_visibility":"public","name":"jeremymv2","owner_account":"jeremymv2","owner_id":"835646971166441582","private_key_name":"jeremymv2-20171024221121"}
$
```

Signed-off-by: Jeremy J. Miller <jm@chef.io>