### PR TITLE
[Docs] Add basic `hab pkg download` file docs

### DIFF
--- a/www/data/docs_sidebar.yml
+++ b/www/data/docs_sidebar.yml
@@ -209,5 +209,7 @@ sidebar_links:
     sub_links:
     - title: Kubernetes Bastion Ring Pattern
       link: "/docs/pattern-library/#kub-bastion"
+    - title: hab pkg download Patterns
+      link: "/docs/pattern-library/#hab-pkg-download"
   - title: Contribute
     link: "/docs/contribute"

--- a/www/source/docs/pattern-library.html.md.erb
+++ b/www/source/docs/pattern-library.html.md.erb
@@ -181,3 +181,115 @@ spec:
         requests:
           storage: 10Gi
 ```
+
+## <a name="hab-pkg-download" id="hab-pkg-download" data-magellan-target="hab-pkg-download" type="anchor">hab pkg download Patterns</a>
+
+The `hab pkg download` command can be used to download individual
+packages (along with their dependencies and keys) from Builder,
+without installing them. This allows you do more easily transfer
+packages from one Builder instance to another, or to take a selective
+snapshot of particular packages.
+
+While you can download packages one-at-a-time, it can be more
+convenient to use a file to specify your packages. Two formats are
+recognized: plain text and TOML.
+
+### Plain Text Download Descriptors
+
+The simplest thing you can do is create a plain text file with a
+package identifier on each line, like so:
+
+```text
+# These are the packages needed to run a Supervisor
+core/hab-launcher
+core/hab
+core/hab-sup
+```
+
+Each line is a valid package identifier. You can also add comments using `#`.
+
+To download these packages (and their dependencies), save that to a
+file named `supervisor.txt` and run:
+
+```
+hab pkg download --file=supervisor.txt
+```
+
+This will download the packages into your existing Habitat cache
+directory. Alternatively, you can specify a directory using the
+`--download-directory` option.
+
+(You can also specify `--channel` and `--target` to further control
+which specific packages you download; run `hab pkg download --help`
+for more).
+
+### TOML Download Descriptors
+
+Plain text is fine for simple cases, but has drawbacks. For instance,
+all packages will come from the same channel, and will be for the same
+platform target. For maximum flexibility, you'll want to use TOML to
+write your download descriptor. Here is an example of one that the
+Habitat core team uses to take periodic snapshots of everything needed
+to run Builder itself:
+
+```toml
+format_version = 1
+file_descriptor = "Packages needed to run an instance of Builder"
+
+[[x86_64-linux]]
+channel = "stable"
+packages = [
+  # Supervisor and prerequisites
+  "core/hab-launcher",
+  "core/hab",
+  "core/hab-sup",
+
+  # Utilities
+  "core/sumologic",
+  "core/nmap"
+]
+
+# Targets can be repeated to specify additional subsets of packages,
+# possibly from different channels
+[[x86_64-linux]]
+channel = "stable"
+packages = [
+  # Builder services
+  "habitat/builder-api",
+  "habitat/builder-api-proxy",
+  "habitat/builder-jobsrv",
+  "habitat/builder-worker",
+  "habitat/builder-memcached",
+]
+
+[[x86_64-linux-kernel2]]
+channel = "stable"
+packages = [
+  # Supervisor and prerequisites
+  "core/hab-launcher",
+  "core/hab",
+  "core/hab-sup",
+
+  "habitat/builder-worker"
+]
+
+[[x86_64-windows]]
+channel = "stable"
+packages = [
+  # Supervisor and prerequisites
+  "core/windows-service",
+  "core/hab",
+  "core/hab-sup",
+
+  "habitat/builder-worker"
+]
+```
+
+This format allows us to specify multiple subsets of packages, from
+different channels and for different architectures. Here, we are
+pulling down all the core service packages, which run on Linux, but
+are also pulling down the platform-specific versions of the
+`habitat/builder-worker` package. Without this format, we would have
+to invoke `hab pkg download` multiple times with different
+parameters. The file allows us to capture our full intention in one
+place.

--- a/www/source/docs/pattern-library.html.md.erb
+++ b/www/source/docs/pattern-library.html.md.erb
@@ -186,7 +186,7 @@ spec:
 
 The `hab pkg download` command can be used to download individual
 packages (along with their dependencies and keys) from Builder,
-without installing them. This allows you do more easily transfer
+without installing them. This allows you to more easily transfer
 packages from one Builder instance to another, or to take a selective
 snapshot of particular packages.
 
@@ -226,7 +226,7 @@ for more).
 ### TOML Download Descriptors
 
 Plain text is fine for simple cases, but has drawbacks. For instance,
-all packages will come from the same channel, and will be for the same
+all packages will come from the same channel and will be for the same
 platform target. For maximum flexibility, you'll want to use TOML to
 write your download descriptor. Here is an example of one that the
 Habitat core team uses to take periodic snapshots of everything needed
@@ -285,7 +285,7 @@ packages = [
 ]
 ```
 
-This format allows us to specify multiple subsets of packages, from
+This format allows us to specify multiple subsets of packages from
 different channels and for different architectures. Here, we are
 pulling down all the core service packages, which run on Linux, but
 are also pulling down the platform-specific versions of the


### PR DESCRIPTION
We didn't have anything describing the formats of the files that `hab
pkg download` can take as input. There isn't currently a really great
place in the documentation structure to put this, so for now, it'll go
in the "Pattern Library", pending some broader reorganizations.

Ideally, we'd have all this in a `man` page or more extensive `hab pkg
download --help` documentation, but for now, we'll at least have it
documented somewhere.

Signed-off-by: Christopher Maier <cmaier@chef.io>