### PR TITLE
[CI] Allow CI pipeline to create Github PRs, releases

### DIFF
--- a/.expeditor/finish_release.pipeline.yml
+++ b/.expeditor/finish_release.pipeline.yml
@@ -7,10 +7,10 @@ expeditor:
       env:
         HAB_ORIGIN: "core"
         PIPELINE_HAB_BLDR_URL: "https://bldr.habitat.sh"
+        GITHUB_USER: "habitat-sh" # per https://github.com/github/hub/issues/2264#issuecomment-567241335
 
 steps:
   - label: ":github: Create GitHub Release"
-    skip: "Unable to open PRs with the expeditor provided GITHUB_TOKEN currently"
     command:
       - .expeditor/scripts/finish_release/create_github_release.sh
     expeditor:
@@ -20,6 +20,8 @@ steps:
           field: token
       executor:
         docker:
+          environment:
+            - GITHUB_USER
 
   - label: ":chocolate_bar: Publish Chocolatey package"
     command:
@@ -35,21 +37,23 @@ steps:
           environment:
 
   - label: ":rust: Check for new nightly rustfmt version"
-    skip: "Unable to open PRs with the expeditor provided GITHUB_TOKEN currently"
     command:
       - .expeditor/scripts/finish_release/bump_rustfmt.sh
     expeditor:
+      account:
+        - github
       secrets:
         GITHUB_TOKEN:
-          account: github
+          account: github/habitat-sh
           field: token
       executor:
-        linux:
-          privileged: true
+        docker:
+          environment:
+            - GITHUB_USER
+
     soft_fail: true
-  
+
   - label: ":rust: Cargo update"
-    skip: "Unable to open PRs with the expeditor provided GITHUB_TOKEN currently"
     command:
       - .expeditor/scripts/finish_release/cargo_update.sh
     expeditor:
@@ -57,9 +61,10 @@ steps:
         - github
       secrets:
         GITHUB_TOKEN:
-          account: github
+          account: github/habitat-sh
           field: token
       executor:
         docker:
           environment:
+            - GITHUB_USER
     soft_fail: true

--- a/.expeditor/scripts/finish_release/cargo_update.sh
+++ b/.expeditor/scripts/finish_release/cargo_update.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-set -euo pipefail 
- 
-# shellcheck source=.expeditor/scripts/shared.sh 
-source .expeditor/scripts/shared.sh 
+set -euo pipefail
 
-branch="ci/cargo-update-$(date +"%Y%m%d%H%M%S")"
+# shellcheck source=.expeditor/scripts/shared.sh
+source .expeditor/scripts/shared.sh
+
+branch="expeditor/cargo-update-$(date +"%Y%m%d%H%M%S")"
 git checkout -b "$branch"
 
 toolchain="$(get_toolchain)"
@@ -38,7 +38,7 @@ cargo +"$toolchain" check --all --tests && update_status=$? || update_status=$?
 echo "--- :git: Publishing updated Cargo.lock"
 git add Cargo.lock
 
-git commit -s -m "Update Cargo.lock"
+git commit --signoff --message "Update Cargo.lock"
 
 pr_labels=""
 pr_message=""
@@ -65,7 +65,7 @@ push_current_branch
 # We have to use --force to open the PR. We're specifying where to push, rather than using a remote, in 
 # the previous command to avoid writing secrets to disk, so hub isn't able to read that information from
 # the git configuration
-hub pull-request --force --no-edit --draft --labels "$pr_labels" --file - <<EOF
+hub pull-request --force --no-edit --labels "$pr_labels" --file - <<EOF
 Cargo Update
 
 $pr_message


### PR DESCRIPTION
Our "finish release" pipeline does several tasks that need to interact
with Github in an authenticated way. This PR adjusts the pipeline to
provide the needed credentials to do this.

The main issue was that `hub` (which we use to create releases and
pull requests) needs additional configuration. While `hub` can be used
with the `GITHUB_TOKEN` of an application (i.e., Expeditor), we
must also set `GITHUB_USER` to the Github organization name of that
application if we wish to actually interact with the Github API with
it. See
https://github.com/github/hub/issues/2264#issuecomment-567241335 for
details.

Additionally, `maybe_run` was removed from the PR-creating
steps. Since creating a PR is an easily reversible step, there's no
harm in running it "for real".

A few other changes were made to how the PR-creating scripts are
executed to bring them closer together in terms of implementation.

Signed-off-by: Christopher Maier <cmaier@chef.io>