### PR TITLE
Remove mention of ACI exporter in CLI help

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -609,7 +609,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                 (about: "Exports the package to the specified format")
                 (aliases: &["exp"])
                 (@arg FORMAT: +required +takes_value
-                    "The export format (ex: aci, cf, docker, mesos, or tar)")
+                    "The export format (ex: cf, docker, mesos, or tar)")
                 (@arg PKG_IDENT: +required +takes_value {valid_ident}
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2) or \
                     filepath to a Habitat Artifact \

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -223,7 +223,7 @@ pub enum Pkg {
     },
     /// Exports the package to the specified format
     Export {
-        /// The export format (ex: aci, cf, docker, mesos, or tar)
+        /// The export format (ex: cf, docker, mesos, or tar)
         #[structopt(name = "FORMAT")]
         format:    String,
         /// A package identifier (ex: core/redis, core/busybox-static/1.42.2) or filepath to a


### PR DESCRIPTION
This should have gone in with #7462, but didn't due to the merge order
of other PRs.

Signed-off-by: Christopher Maier <cmaier@chef.io>