### PR TITLE
add a remotesigned execution policy to pwsh spawns

### DIFF
--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -3,11 +3,12 @@ use super::{package::Pkg,
 use crate::{error::{Error,
                     Result},
             outputln};
-#[cfg(windows)]
-use habitat_core::os::process::windows_child::{Child,
-                                               ExitStatus};
 use habitat_core::{crypto,
                    fs};
+#[cfg(windows)]
+use habitat_core::{os::process::windows_child::{Child,
+                                                ExitStatus},
+                   util};
 use serde::{Serialize,
             Serializer};
 #[cfg(unix)]
@@ -213,9 +214,8 @@ pub trait Hook: fmt::Debug + Sized + Send {
               S: AsRef<OsStr>
     {
         let ps_cmd = format!("iex $(gc {} | out-string)", path.as_ref().to_string_lossy());
-        let args = vec!["-NonInteractive", "-command", ps_cmd.as_str()];
         Ok(Child::spawn("pwsh.exe",
-                        &args,
+                        &util::pwsh_args(ps_cmd.as_str()),
                         &pkg.env.to_hash_map(),
                         &pkg.svc_user,
                         svc_encrypted_password)?)

--- a/components/core/src/util.rs
+++ b/components/core/src/util.rs
@@ -8,6 +8,24 @@ pub mod win_perm;
 
 use std::mem;
 
+/// returns the common arguments to pass to pwsh.exe when spawning a powershell instance.
+/// These arguments are optimized for a background powershell process running hooks.
+/// The NonInteractive flag specifies that the console is not intended to interact with
+/// human input and allows ctrl+break signals to trigger a graceful termination similar to
+/// a SIGTERM on linux rather than an interactive debugging prompt. The ExecutionPolicy
+/// ensures that if a more strict policy exists in the Windows Registry (ex "AllSigned"),
+/// hook execution will not fail because hook scripts are never signed. RemoteSigned is the
+/// default policy and just requires remote scripts to be signeed. Supervisor hooks are
+/// always local so "RemoteSigned" does not interfere with supervisor behavior.
+#[cfg(windows)]
+pub fn pwsh_args(command: &str) -> Vec<&str> {
+    vec!["-NonInteractive",
+         "-ExecutionPolicy",
+         "RemoteSigned",
+         "-Command",
+         command]
+}
+
 /// Provide a way to convert numeric types safely to i64
 pub trait ToI64 {
     fn to_i64(self) -> i64;

--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -3,10 +3,11 @@ use crate::{error::{Error,
             protocol::{self,
                        ShutdownMethod},
             service::Service};
-use core::os::process::{handle_from_pid,
-                        windows_child::{Child,
-                                        ExitStatus,
-                                        Handle}};
+use core::{os::process::{handle_from_pid,
+                         windows_child::{Child,
+                                         ExitStatus,
+                                         Handle}},
+           util};
 use std::{collections::HashMap,
           io,
           iter::FromIterator,
@@ -147,7 +148,7 @@ fn spawn_pwsh(ps_binary_name: &str, msg: protocol::Spawn) -> Result<Service> {
     let new_env = HashMap::from_iter(msg.env.clone().into_iter());
 
     match Child::spawn(ps_binary_name,
-                       &["-NonInteractive", "-command", ps_cmd.as_str()],
+                       &util::pwsh_args(ps_cmd.as_str()),
                        &new_env,
                        &user,
                        password)

--- a/components/sup/src/manager/service/pipe_hook_client.rs
+++ b/components/sup/src/manager/service/pipe_hook_client.rs
@@ -4,7 +4,8 @@ use habitat_common::{error::{Error,
                      outputln,
                      templating::package::Pkg};
 use habitat_core::{env as henv,
-                   os::process::windows_child::Child};
+                   os::process::windows_child::Child,
+                   util};
 use mio::{Events,
           Poll,
           PollOpt,
@@ -158,9 +159,8 @@ impl PipeHookClient {
                              process::id());
 
         // Start instance of powershell to host named pipe server for this client
-        let args = vec!["-NonInteractive", "-Command", ps_cmd.as_str()];
         let child = Child::spawn("pwsh.exe",
-                                 &args,
+                                 &util::pwsh_args(ps_cmd.as_str()),
                                  &pkg.env.to_hash_map(),
                                  &pkg.svc_user,
                                  svc_encrypted_password)?;


### PR DESCRIPTION
resolves #7421 

This also consolidates the creation of `pwsh` args into one place.

Signed-off-by: mwrock <matt@mattwrock.com>