### PR TITLE
Remove time crate from almost everything

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,6 @@ dependencies = [
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,7 +1396,7 @@ dependencies = [
  "serde_json 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3602,6 +3602,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time-macros-impl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4735,6 +4766,9 @@ dependencies = [
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum time 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3043ac959c44dccc548a57417876c8fe241502aed69d880efc91166c02717a93"
+"checksum time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+"checksum time-macros-impl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987cfe0537f575b5fc99909de6185f6c19c3ad8889e2275e686a873d0869ba1"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,6 @@ dependencies = [
  "serde_json 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,6 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,6 @@ dependencies = [
  "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,7 @@ dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "caps 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "configopt 0.1.0 (git+https://github.com/davidMcneil/configopt)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1395,7 +1396,6 @@ dependencies = [
  "serde_json 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3599,37 +3599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustversion 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "time-macros-impl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4763,9 +4732,6 @@ dependencies = [
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
-"checksum time 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3043ac959c44dccc548a57417876c8fe241502aed69d880efc91166c02717a93"
-"checksum time-macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
-"checksum time-macros-impl 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987cfe0537f575b5fc99909de6185f6c19c3ad8889e2275e686a873d0869ba1"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8fdd17989496f49cdc57978c96f0c9fe5e4a58a8bddc6813c449a4624f6a030b"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,6 @@ name = "habitat_pkg_export_docker"
 version = "0.0.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -28,8 +28,6 @@ serde = { version = "*", features = ["rc"] }
 serde_derive = "*"
 serde_json = "*"
 tempfile = "*"
-# See https://github.com/habitat-sh/habitat/issues/7353
-time = "0.1"
 threadpool = "*"
 toml = { version = "*", default-features = false }
 uuid = { version = "*", features = ["v4"] }

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -24,8 +24,8 @@ use std::{fmt,
                 UdpSocket},
           sync::mpsc,
           thread,
-          time::Duration};
-use time::SteadyTime;
+          time::{Duration,
+                 Instant}};
 
 /// How long to sleep between calls to `recv`.
 const PING_RECV_QUEUE_EMPTY_SLEEP_MS: u64 = 10;
@@ -126,8 +126,8 @@ fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timin
 
                 probe_mlw_smr_rhw(&server, &socket, &rx_inbound, &timing, member);
 
-                if SteadyTime::now() <= next_protocol_period {
-                    let wait_time = (next_protocol_period - SteadyTime::now()).num_milliseconds();
+                if Instant::now() <= next_protocol_period {
+                    let wait_time = (next_protocol_period - Instant::now()).as_millis();
                     if wait_time > 0 {
                         debug!("Waiting {} until the next protocol period", wait_time);
                         thread::sleep(Duration::from_millis(wait_time as u64));
@@ -136,8 +136,8 @@ fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timin
             }
         }
 
-        if SteadyTime::now() <= long_wait {
-            let wait_time = (long_wait - SteadyTime::now()).num_milliseconds();
+        if Instant::now() <= long_wait {
+            let wait_time = (long_wait - Instant::now()).as_millis();
             if wait_time > 0 {
                 thread::sleep(Duration::from_millis(wait_time as u64));
             }
@@ -258,7 +258,7 @@ fn recv_ack_mlw_rhw(server: &Server,
                 }
             }
             Err(mpsc::TryRecvError::Empty) => {
-                if SteadyTime::now() > timeout {
+                if Instant::now() > timeout {
                     warn!("Timed out waiting for Ack from {}@{}", &member.id, addr);
                     return false;
                 }

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -17,8 +17,8 @@ use habitat_core::util::ToI64;
 use prometheus::{IntCounterVec,
                  IntGaugeVec};
 use std::{thread,
-          time::Duration};
-use time::SteadyTime;
+          time::{Duration,
+                 Instant}};
 use zmq;
 
 const FANOUT: usize = 5;
@@ -107,15 +107,15 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                 let _ = guard.join()
                              .map_err(|e| error!("Push worker died: {:?}", e));
             }
-            if SteadyTime::now() < next_gossip {
-                let wait_time = (next_gossip - SteadyTime::now()).num_milliseconds();
+            if Instant::now() < next_gossip {
+                let wait_time = (next_gossip - Instant::now()).as_millis();
                 if wait_time > 0 {
                     thread::sleep(Duration::from_millis(wait_time as u64));
                 }
             }
         }
-        if SteadyTime::now() < long_wait {
-            let wait_time = (long_wait - SteadyTime::now()).num_milliseconds();
+        if Instant::now() < long_wait {
+            let wait_time = (long_wait - Instant::now()).as_millis();
             if wait_time > 0 {
                 thread::sleep(Duration::from_millis(wait_time as u64));
             }

--- a/components/butterfly/src/server/timing.rs
+++ b/components/butterfly/src/server/timing.rs
@@ -1,26 +1,26 @@
-use time::{Duration as TimeDuration,
-           SteadyTime};
+use std::time::{Duration,
+                Instant};
 
 /// How long to wait for an Ack after we ping
-const PING_TIMING_DEFAULT_MS: i64 = 1000;
+const PING_TIMING_DEFAULT_MS: u64 = 1000;
 /// How long to wait for an Ack after we PingReq - should be at least 2x the PING_TIMING_DEFAULT_MS
-const PINGREQ_TIMING_DEFAULT_MS: i64 = 2100;
+const PINGREQ_TIMING_DEFAULT_MS: u64 = 2100;
 /// How many protocol periods before a suspect member is marked as confirmed.
-const SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS: i64 = 3;
+const SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS: u64 = 3;
 /// How long is the gossip period
-const GOSSIP_PERIOD_DEFAULT_MS: i64 = 1000;
+const GOSSIP_PERIOD_DEFAULT_MS: u64 = 1000;
 /// How long before we set a confirmed member to a departed member, removing them from quorums
 ///   just for your own sanity - this is 3 days.
-const DEPARTURE_TIMEOUT_DEFAULT_MS: i64 = 259_200_000;
+const DEPARTURE_TIMEOUT_DEFAULT_MS: u64 = 259_200_000;
 
 /// The timing of the outbound threads.
 #[derive(Debug, Clone)]
 pub struct Timing {
-    pub ping_ms: i64,
-    pub pingreq_ms: i64,
-    pub gossip_period_ms: i64,
-    pub suspicion_timeout_protocol_periods: i64,
-    pub departure_timeout_ms: i64,
+    pub ping_ms: u64,
+    pub pingreq_ms: u64,
+    pub gossip_period_ms: u64,
+    pub suspicion_timeout_protocol_periods: u64,
+    pub departure_timeout_ms: u64,
 }
 
 impl Default for Timing {
@@ -35,11 +35,11 @@ impl Default for Timing {
 
 impl Timing {
     /// Set up a new Timing
-    pub fn new(ping_ms: i64,
-               pingreq_ms: i64,
-               gossip_period_ms: i64,
-               suspicion_timeout_protocol_periods: i64,
-               departure_timeout_ms: i64)
+    pub fn new(ping_ms: u64,
+               pingreq_ms: u64,
+               gossip_period_ms: u64,
+               suspicion_timeout_protocol_periods: u64,
+               departure_timeout_ms: u64)
                -> Timing {
         Timing { ping_ms,
                  pingreq_ms,
@@ -49,35 +49,32 @@ impl Timing {
     }
 
     /// When should this gossip period expire
-    pub fn gossip_timeout(&self) -> SteadyTime {
-        SteadyTime::now() + TimeDuration::milliseconds(self.gossip_period_ms)
+    pub fn gossip_timeout(&self) -> Instant {
+        Instant::now() + Duration::from_millis(self.gossip_period_ms)
     }
 
     /// How long is a protocol period, in millis.
-    pub fn protocol_period_ms(&self) -> i64 { self.ping_ms + self.pingreq_ms }
+    pub fn protocol_period_ms(&self) -> u64 { self.ping_ms + self.pingreq_ms }
 
     /// When should this ping record time out?
-    pub fn ping_timeout(&self) -> SteadyTime {
-        SteadyTime::now() + TimeDuration::milliseconds(self.ping_ms)
-    }
+    pub fn ping_timeout(&self) -> Instant { Instant::now() + Duration::from_millis(self.ping_ms) }
 
     /// When should this pingreq timeout?
-    pub fn pingreq_timeout(&self) -> SteadyTime {
-        SteadyTime::now() + TimeDuration::milliseconds(self.pingreq_ms)
+    pub fn pingreq_timeout(&self) -> Instant {
+        Instant::now() + Duration::from_millis(self.pingreq_ms)
     }
 
     /// How long before the next scheduled protocol period
-    pub fn next_protocol_period(&self) -> SteadyTime {
-        SteadyTime::now() + TimeDuration::milliseconds(self.ping_ms + self.pingreq_ms)
+    pub fn next_protocol_period(&self) -> Instant {
+        Instant::now() + Duration::from_millis(self.ping_ms + self.pingreq_ms)
     }
 
     /// How long before this suspect entry times out
-    pub fn suspicion_timeout_duration(&self) -> TimeDuration {
-        TimeDuration::milliseconds(self.protocol_period_ms()
-                                   * self.suspicion_timeout_protocol_periods)
+    pub fn suspicion_timeout_duration(&self) -> Duration {
+        Duration::from_millis(self.protocol_period_ms() * self.suspicion_timeout_protocol_periods)
     }
 
-    pub fn departure_timeout_duration(&self) -> TimeDuration {
-        TimeDuration::milliseconds(self.departure_timeout_ms)
+    pub fn departure_timeout_duration(&self) -> Duration {
+        Duration::from_millis(self.departure_timeout_ms)
     }
 }

--- a/components/butterfly/tests/common/mod.rs
+++ b/components/butterfly/tests/common/mod.rs
@@ -26,8 +26,8 @@ use std::{net::{IpAddr,
           sync::{Arc,
                  Mutex},
           thread,
-          time::Duration};
-use time::SteadyTime;
+          time::{Duration,
+                 Instant}};
 
 lazy_static::lazy_static! {
     static ref SERVER_PORT: Mutex<u16> = Mutex::new(6666);
@@ -418,7 +418,7 @@ impl SwimNet {
         let timing = Timing::default();
         let next_period = timing.next_protocol_period();
         loop {
-            if SteadyTime::now() <= next_period {
+            if Instant::now() <= next_period {
                 thread::sleep(Duration::from_millis(100));
             } else {
                 return;

--- a/components/butterfly/tests/encryption/mod.rs
+++ b/components/butterfly/tests/encryption/mod.rs
@@ -4,8 +4,7 @@ use habitat_core::crypto::keys::sym_key::SymKey;
 
 #[test]
 fn symmetric_encryption_of_wire_payloads() {
-    let ring_key = SymKey::generate_pair_for_ring("wolverine").expect("Failed to generate an in \
-                                                                       memory symkey");
+    let ring_key = SymKey::generate_pair_for_ring("wolverine");
     let mut net = btest::SwimNet::new_ring_encryption_rhw(2, &ring_key);
     net.connect_smr(0, 1);
     assert_wait_for_health_of_mlr!(net, [0..2, 0..2], Health::Alive);

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -42,8 +42,6 @@ serde_yaml = "*"
 tempfile = "*"
 retry = { git = "https://github.com/habitat-sh/retry", features = ["asynchronous"] }
 termcolor = "*"
-# See https://github.com/habitat-sh/habitat/issues/7353
-time = "0.1"
 tokio = { version = "*", features = ["full"] }
 toml = { version = "*", default-features = false }
 uuid = { version = "*", features = ["v4"] }

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -12,6 +12,7 @@ cc = "*"
 
 [dependencies]
 base64 = "*"
+chrono = "*"
 configopt = { git = "https://github.com/davidMcneil/configopt" }
 dirs = "*"
 dns-lookup = "*"
@@ -31,7 +32,6 @@ serde_derive = "*"
 serde_json = "*"
 sodiumoxide = "0.0.16"
 tempfile = "*"
-time = "0.2"
 toml = { version = "*", default-features = false }
 typemap = "*"
 url = "*"

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -31,8 +31,7 @@ serde_derive = "*"
 serde_json = "*"
 sodiumoxide = "0.0.16"
 tempfile = "*"
-# See https://github.com/habitat-sh/habitat/issues/7353
-time = "0.1"
+time = "0.2"
 toml = { version = "*", default-features = false }
 typemap = "*"
 url = "*"

--- a/components/core/src/crypto.rs
+++ b/components/core/src/crypto.rs
@@ -275,9 +275,9 @@ pub fn secure_eq<T, U>(t: T, u: U) -> bool
 pub mod test_support {
     use std::{fs::File,
               io::Read,
-              path::PathBuf};
-
-    use time;
+              path::PathBuf,
+              time::{Duration,
+                     Instant}};
 
     use crate::error as herror;
 
@@ -301,10 +301,9 @@ pub mod test_support {
     pub fn wait_until_ok<F, T>(some_fn: F) -> Option<T>
         where F: Fn() -> Result<T, herror::Error>
     {
-        let wait_duration = time::Duration::seconds(30);
-        let current_time = time::now_utc().to_timespec();
-        let stop_time = current_time + wait_duration;
-        while time::now_utc().to_timespec() < stop_time {
+        let wait_duration = Duration::from_secs(30);
+        let current_time = Instant::now();
+        while current_time.elapsed() < wait_duration {
             if let Ok(s) = some_fn() {
                 return Some(s);
             }

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -277,7 +277,7 @@ mod test {
     #[test]
     fn sign_and_verify() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
 
@@ -289,7 +289,7 @@ mod test {
     #[should_panic(expected = "Secret key is required but not present for")]
     fn sign_missing_private_key() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
 
@@ -308,7 +308,7 @@ mod test {
     #[should_panic(expected = "Public key is required but not present for")]
     fn verify_missing_public_key() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         sign(&fixture("signme.dat"), &dst, &pair).unwrap();
@@ -372,7 +372,7 @@ mod test {
     #[should_panic(expected = "Corrupt payload, can\\'t read hash type")]
     fn verify_empty_hash_type() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -386,7 +386,7 @@ mod test {
     #[should_panic(expected = "Unsupported signature type: BESTEST")]
     fn verify_invalid_hash_type() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -400,7 +400,7 @@ mod test {
     #[should_panic(expected = "Corrupt payload, can\\'t read signature")]
     fn verify_empty_signature() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -414,7 +414,7 @@ mod test {
     #[should_panic(expected = "Can\\'t decode signature")]
     fn verify_invalid_signature_decode() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -429,7 +429,7 @@ mod test {
     #[should_panic(expected = "Corrupt payload, can\\'t find end of header")]
     fn verify_missing_end_of_header() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -445,7 +445,7 @@ mod test {
     #[should_panic(expected = "Habitat artifact is invalid")]
     fn verify_corrupted_archive() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let dst = cache.path().join("signed.dat");
         let dst_corrupted = cache.path().join("corrupted.dat");
@@ -476,7 +476,7 @@ mod test {
     #[test]
     fn get_archive_reader_working() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let src = cache.path().join("src.in");
         let dst = cache.path().join("src.signed");
@@ -493,7 +493,7 @@ mod test {
     #[test]
     fn verify_get_artifact_header() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
         let src = cache.path().join("src.in");
         let dst = cache.path().join("src.signed");

--- a/components/core/src/crypto/keys.rs
+++ b/components/core/src/crypto/keys.rs
@@ -10,6 +10,7 @@ use super::{PUBLIC_BOX_KEY_VERSION,
 use crate::error::{Error,
                    Result};
 use base64;
+use chrono::Utc;
 use regex::Regex;
 use std::{collections::HashSet,
           fmt,
@@ -22,7 +23,6 @@ use std::{collections::HashSet,
                  PathBuf},
           result,
           str::FromStr};
-use time;
 
 lazy_static::lazy_static! {
     static ref NAME_WITH_REV_RE: Regex = Regex::new(r"\A(?P<name>.+)-(?P<rev>\d{14})\z").unwrap();
@@ -310,7 +310,7 @@ fn mk_key_filename<P, S1, S2>(path: P, keyname: S1, suffix: S2) -> PathBuf
 /// `{year}{month}{day}{hour24}{minute}{second}`
 /// Timestamps are in UTC time.
 // TODO (CM): Return a String, not a Result
-fn mk_revision_string() -> Result<String> { Ok(time::OffsetDateTime::now().format("%Y%m%d%H%M%S")) }
+fn mk_revision_string() -> Result<String> { Ok(Utc::now().format("%Y%m%d%H%M%S").to_string()) }
 
 pub fn parse_name_with_rev<T>(name_with_rev: T) -> Result<(String, String)>
     where T: AsRef<str>

--- a/components/core/src/crypto/keys.rs
+++ b/components/core/src/crypto/keys.rs
@@ -309,8 +309,7 @@ fn mk_key_filename<P, S1, S2>(path: P, keyname: S1, suffix: S2) -> PathBuf
 /// generates a revision string in the form:
 /// `{year}{month}{day}{hour24}{minute}{second}`
 /// Timestamps are in UTC time.
-// TODO (CM): Return a String, not a Result
-fn mk_revision_string() -> Result<String> { Ok(Utc::now().format("%Y%m%d%H%M%S").to_string()) }
+fn mk_revision_string() -> String { Utc::now().format("%Y%m%d%H%M%S").to_string() }
 
 pub fn parse_name_with_rev<T>(name_with_rev: T) -> Result<(String, String)>
     where T: AsRef<str>
@@ -633,13 +632,11 @@ mod test {
     #[test]
     fn get_key_revisions_can_return_everything() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        SigKeyPair::generate_pair_for_origin("foo").unwrap()
-                                                   .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("foo").to_pair_files(cache.path())
                                                    .unwrap();
         // we need to wait at least 1 second between generating keypairs to ensure uniqueness
         thread::sleep(Duration::from_millis(1000));
-        SigKeyPair::generate_pair_for_origin("foo").unwrap()
-                                                   .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("foo").to_pair_files(cache.path())
                                                    .unwrap();
         let revs = super::get_key_revisions("foo", cache.path(), None, &KeyType::Sig).unwrap();
         assert_eq!(2, revs.len());
@@ -648,8 +645,7 @@ mod test {
     #[test]
     fn get_key_revisions_can_only_return_keys_of_specified_type() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        SigKeyPair::generate_pair_for_origin("foo").unwrap()
-                                                   .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("foo").to_pair_files(cache.path())
                                                    .unwrap();
         let revs = super::get_key_revisions("foo", cache.path(), None, &KeyType::Sig).unwrap();
         assert_eq!(1, revs.len());
@@ -664,13 +660,11 @@ mod test {
     #[test]
     fn get_key_revisions_can_return_secret_keys() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        SigKeyPair::generate_pair_for_origin("foo").unwrap()
-                                                   .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("foo").to_pair_files(cache.path())
                                                    .unwrap();
         // we need to wait at least 1 second between generating keypairs to ensure uniqueness
         thread::sleep(Duration::from_millis(1000));
-        SigKeyPair::generate_pair_for_origin("foo").unwrap()
-                                                   .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("foo").to_pair_files(cache.path())
                                                    .unwrap();
         let revs = super::get_key_revisions("foo",
                                             cache.path(),
@@ -682,13 +676,11 @@ mod test {
     #[test]
     fn get_key_revisions_can_return_public_keys() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        SigKeyPair::generate_pair_for_origin("foo").unwrap()
-                                                   .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("foo").to_pair_files(cache.path())
                                                    .unwrap();
         // we need to wait at least 1 second between generating keypairs to ensure uniqueness
         thread::sleep(Duration::from_millis(1000));
-        SigKeyPair::generate_pair_for_origin("foo").unwrap()
-                                                   .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("foo").to_pair_files(cache.path())
                                                    .unwrap();
         let revs = super::get_key_revisions("foo",
                                             cache.path(),
@@ -756,14 +748,13 @@ mod test {
 
         for _ in 0..3 {
             wait_until_ok(|| {
-                let pair = SymKey::generate_pair_for_ring("acme")?;
+                let pair = SymKey::generate_pair_for_ring("acme");
                 pair.to_pair_files(cache.path())?;
                 Ok(())
             });
         }
 
-        SymKey::generate_pair_for_ring("acme-you").unwrap()
-                                                  .to_pair_files(cache.path())
+        SymKey::generate_pair_for_ring("acme-you").to_pair_files(cache.path())
                                                   .unwrap();
 
         let revisions =
@@ -781,14 +772,13 @@ mod test {
 
         for _ in 0..3 {
             wait_until_ok(|| {
-                let pair = SigKeyPair::generate_pair_for_origin("mutants")?;
+                let pair = SigKeyPair::generate_pair_for_origin("mutants");
                 pair.to_pair_files(cache.path())?;
                 Ok(())
             });
         }
 
-        SigKeyPair::generate_pair_for_origin("mutants-x").unwrap()
-                                                         .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("mutants-x").to_pair_files(cache.path())
                                                          .unwrap();
 
         let revisions =
@@ -808,8 +798,7 @@ mod test {
     #[test]
     fn keys_that_are_symlinks_can_still_be_found() {
         let temp_dir = Builder::new().prefix("symlinks_are_ok").tempdir().unwrap();
-        let key =
-            SymKey::generate_pair_for_ring("symlinks_are_ok").expect("Could not generate ring key");
+        let key = SymKey::generate_pair_for_ring("symlinks_are_ok");
         key.to_pair_files(temp_dir.path()).unwrap();
 
         // Create a directory in our temp directory; this will serve

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -70,7 +70,7 @@ impl BoxKeyPair {
         where S1: AsRef<str>,
               S2: AsRef<str>
     {
-        let revision = mk_revision_string()?;
+        let revision = mk_revision_string();
         let keyname =
             Self::mk_key_name_for_service(org.as_ref(), service_group.as_ref(), &revision);
         debug!("new service box key name = {}", &keyname);
@@ -216,7 +216,7 @@ impl BoxKeyPair {
     }
 
     fn generate_pair_for_string(string: &str) -> Result<Self> {
-        let revision = mk_revision_string()?;
+        let revision = mk_revision_string();
         let keyname = Self::mk_key_name_for_string(string, &revision);
         debug!("new sig key name = {}", &keyname);
         let (pk, sk) = box_::gen_keypair();

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -28,10 +28,10 @@ use std::{fs,
 pub type SigKeyPair = KeyPair<SigPublicKey, SigSecretKey>;
 
 impl SigKeyPair {
-    pub fn generate_pair_for_origin(name: &str) -> Result<Self> {
-        let revision = mk_revision_string()?;
+    pub fn generate_pair_for_origin(name: &str) -> Self {
+        let revision = mk_revision_string();
         let (pk, sk) = sign::gen_keypair();
-        Ok(Self::new(name.to_string(), revision, Some(pk), Some(sk)))
+        Self::new(name.to_string(), revision, Some(pk), Some(sk))
     }
 
     /// Return a Vec of origin keys with a given name.
@@ -346,7 +346,7 @@ mod test {
     #[test]
     fn generated_origin_pair() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
 
         assert_eq!(pair.name, "unicorn");
@@ -368,14 +368,13 @@ mod test {
         let pairs = SigKeyPair::get_pairs_for("unicorn", cache.path(), None).unwrap();
         assert_eq!(pairs.len(), 0);
 
-        SigKeyPair::generate_pair_for_origin("unicorn").unwrap()
-                                                       .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("unicorn").to_pair_files(cache.path())
                                                        .unwrap();
         let pairs = SigKeyPair::get_pairs_for("unicorn", cache.path(), None).unwrap();
         assert_eq!(pairs.len(), 1);
 
         match wait_until_ok(|| {
-                  let p = SigKeyPair::generate_pair_for_origin("unicorn")?;
+                  let p = SigKeyPair::generate_pair_for_origin("unicorn");
                   p.to_pair_files(cache.path())?;
                   Ok(())
               }) {
@@ -386,8 +385,7 @@ mod test {
         assert_eq!(pairs.len(), 2);
 
         // We should not include another named key in the count
-        SigKeyPair::generate_pair_for_origin("dragon").unwrap()
-                                                      .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("dragon").to_pair_files(cache.path())
                                                       .unwrap();
         let pairs = SigKeyPair::get_pairs_for("unicorn", cache.path(), None).unwrap();
         assert_eq!(pairs.len(), 2);
@@ -405,10 +403,10 @@ mod test {
     #[test]
     fn get_pair_for() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let p1 = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let p1 = SigKeyPair::generate_pair_for_origin("unicorn");
         p1.to_pair_files(cache.path()).unwrap();
         let p2 = match wait_until_ok(|| {
-                  let p = SigKeyPair::generate_pair_for_origin("unicorn")?;
+                  let p = SigKeyPair::generate_pair_for_origin("unicorn");
                   p.to_pair_files(cache.path())?;
                   Ok(p)
               }) {
@@ -434,7 +432,7 @@ mod test {
     #[test]
     fn get_latest_pair_for_single() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let pair = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let pair = SigKeyPair::generate_pair_for_origin("unicorn");
         pair.to_pair_files(cache.path()).unwrap();
 
         let latest = SigKeyPair::get_latest_pair_for("unicorn", cache.path(), None).unwrap();
@@ -445,11 +443,10 @@ mod test {
     #[test]
     fn get_latest_pair_for_multiple() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        SigKeyPair::generate_pair_for_origin("unicorn").unwrap()
-                                                       .to_pair_files(cache.path())
+        SigKeyPair::generate_pair_for_origin("unicorn").to_pair_files(cache.path())
                                                        .unwrap();
         let p2 = match wait_until_ok(|| {
-                  let p = SigKeyPair::generate_pair_for_origin("unicorn")?;
+                  let p = SigKeyPair::generate_pair_for_origin("unicorn");
                   p.to_pair_files(cache.path())?;
                   Ok(p)
               }) {
@@ -465,7 +462,7 @@ mod test {
     #[test]
     fn get_latest_pair_for_secret() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let p = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let p = SigKeyPair::generate_pair_for_origin("unicorn");
         p.to_pair_files(cache.path()).unwrap();
         let latest = SigKeyPair::get_latest_pair_for("unicorn",
                                                      cache.path(),
@@ -477,7 +474,7 @@ mod test {
     #[test]
     fn get_latest_pair_for_public() {
         let cache = Builder::new().prefix("key_cache").tempdir().unwrap();
-        let p = SigKeyPair::generate_pair_for_origin("unicorn").unwrap();
+        let p = SigKeyPair::generate_pair_for_origin("unicorn");
         p.to_pair_files(cache.path()).unwrap();
         let latest = SigKeyPair::get_latest_pair_for("unicorn",
                                                      cache.path(),

--- a/components/core/src/os/process.rs
+++ b/components/core/src/os/process.rs
@@ -30,18 +30,11 @@ use serde_derive::{Deserialize,
                    Serialize};
 use std::{fmt,
           result,
-          str::FromStr};
-use time::Duration;
+          str::FromStr,
+          time::Duration};
 
 /// This type encapsulates the number of seconds we should wait after
 /// send a shutdown signal to a process before we kill it.
-///
-/// (Another nice thing it does is hide the whole
-/// `std::time::Duration` / `time::Duration` mess from the rest of the
-/// code. Rather than having to juggle the two `Duration` types
-/// throughout our code, which can be confusing, we can just pass this
-/// around, and turn it into a `time::Duration` at the last possible
-/// moment.)
 #[derive(Deserialize, Serialize, Eq, PartialEq, Debug, Clone, Copy, Hash)]
 #[serde(from = "u32")]
 pub struct ShutdownTimeout(u32);
@@ -71,7 +64,7 @@ impl From<ShutdownTimeout> for u32 {
 }
 
 impl From<ShutdownTimeout> for Duration {
-    fn from(timeout: ShutdownTimeout) -> Self { Duration::seconds(timeout.0.into()) }
+    fn from(timeout: ShutdownTimeout) -> Self { Duration::from_secs(timeout.0.into()) }
 }
 
 impl ConfigOptToString for ShutdownTimeout {}

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -761,6 +761,7 @@ impl RawHandle {
 
     // TODO JB: fix this allow
     #[allow(clippy::trivially_copy_pass_by_ref)]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn read_overlapped(&self,
                                   buf: &mut [u8],
                                   overlapped: *mut OVERLAPPED)
@@ -785,6 +786,7 @@ impl RawHandle {
 
     // TODO JB: fix this allow
     #[allow(clippy::trivially_copy_pass_by_ref)]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn overlapped_result(&self,
                                     overlapped: *mut OVERLAPPED,
                                     wait: bool)

--- a/components/core/src/package.rs
+++ b/components/core/src/package.rs
@@ -26,7 +26,6 @@ pub mod test_support {
               path::{Path,
                      PathBuf},
               str::FromStr};
-    use time;
 
     pub fn fixture_path(name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
@@ -50,9 +49,7 @@ pub mod test_support {
                 pkg_ident.version = Some(String::from("1.0.0"));
             }
             if pkg_ident.release.is_none() {
-                pkg_ident.release = Some(time::now_utc().strftime("%Y%m%d%H%M%S")
-                                                        .unwrap()
-                                                        .to_string());
+                pkg_ident.release = Some(String::from("20200227153400"));
             }
         }
         let pkg_install_path = fs::pkg_install_path(&pkg_ident, Some(fs_root));

--- a/components/hab/src/command/origin/key/generate.rs
+++ b/components/hab/src/command/origin/key/generate.rs
@@ -12,7 +12,7 @@ use crate::error::{Error,
 pub fn start(ui: &mut UI, origin: &str, cache: &Path) -> Result<()> {
     if ident::is_valid_origin_name(origin) {
         ui.begin(format!("Generating origin key for {}", &origin))?;
-        let pair = SigKeyPair::generate_pair_for_origin(origin)?;
+        let pair = SigKeyPair::generate_pair_for_origin(origin);
         pair.to_pair_files(cache)?;
         ui.end(format!("Generated origin key pair {}.", &pair.name_with_rev()))?;
         Ok(())

--- a/components/hab/src/command/ring/key/generate.rs
+++ b/components/hab/src/command/ring/key/generate.rs
@@ -8,7 +8,7 @@ use crate::error::Result;
 
 pub fn start(ui: &mut UI, ring: &str, cache: &Path) -> Result<()> {
     ui.begin(format!("Generating ring key for {}", &ring))?;
-    let pair = SymKey::generate_pair_for_ring(ring)?;
+    let pair = SymKey::generate_pair_for_ring(ring);
     pair.to_pair_files(cache)?;
     ui.end(format!("Generated ring key pair {}.", &pair.name_with_rev()))?;
     Ok(())

--- a/components/hab/src/license.rs
+++ b/components/hab/src/license.rs
@@ -37,7 +37,8 @@ use crate::{common::ui::{self,
             hcore::{fs::{am_i_root,
                          FS_ROOT_PATH},
                     users::get_current_username}};
-use chrono::prelude::*;
+use chrono::{DateTime,
+             Utc};
 use dirs;
 use serde_yaml;
 use std::{env,

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -22,8 +22,6 @@ libc = "*"
 log = "*"
 prost = "*"
 semver = "*"
-# See https://github.com/habitat-sh/habitat/issues/7353
-time = "0.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi =  { version = "*", features = ["tlhelp32"] }

--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -11,9 +11,9 @@ use core::{os::process::{handle_from_pid,
 use std::{collections::HashMap,
           io,
           iter::FromIterator,
-          mem};
-use time::{Duration,
-           SteadyTime};
+          mem,
+          time::{Duration,
+                 Instant}};
 use winapi::{shared::{minwindef::{DWORD,
                                   LPDWORD,
                                   MAX_PATH},
@@ -60,9 +60,9 @@ impl Process {
                    io::Error::last_os_error());
         }
 
-        let stop_time = SteadyTime::now() + Duration::seconds(8);
+        let stop_time = Instant::now() + Duration::from_secs(8);
         loop {
-            if ret == 0 || SteadyTime::now() > stop_time {
+            if ret == 0 || Instant::now() > stop_time {
                 let proc_table = build_proc_table();
                 terminate_process_descendants(&proc_table, self.id());
                 return ShutdownMethod::Killed;

--- a/components/pkg-export-docker/Cargo.toml
+++ b/components/pkg-export-docker/Cargo.toml
@@ -17,7 +17,6 @@ doc = false
 [dependencies]
 base64 = "*"
 clap = { version = "*", features = ["suggestions", "color", "unstable"] }
-chrono = "*"
 env_logger = "*"
 hab = { path = "../hab" }
 habitat_common = { path = "../common" }

--- a/components/sup-protocol/protocols/types.proto
+++ b/components/sup-protocol/protocols/types.proto
@@ -55,7 +55,7 @@ message PackageIdent {
 }
 
 message ProcessStatus {
-  optional int64 elapsed = 1;
+  optional uint64 elapsed = 1;
   optional uint32 pid = 2;
   required ProcessState state = 3;
 }

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -55,8 +55,6 @@ serde-transcode = "*"
 state = "*"
 tempfile = "*"
 termcolor = "*"
-# See https://github.com/habitat-sh/habitat/issues/7353
-time = "0.1"
 toml = { version = "*", default-features = false }
 tokio = { version = "*", features = ["full"] }
 tokio-util = { version = "*", features = ["full"] }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -47,7 +47,6 @@ extern crate serde_derive;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate serde_json;
-extern crate time as time_crate;
 
 #[cfg(test)]
 extern crate json;

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -11,7 +11,6 @@ extern crate log;
 extern crate lazy_static;
 extern crate rustls;
 extern crate tempfile;
-extern crate time;
 extern crate url;
 
 use crate::sup::{cli::cli,

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -360,14 +360,6 @@ struct ServiceStatus {
     desired_state: DesiredState,
 }
 
-impl fmt::Display for ServiceStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f,
-               "{}, {}, group:{}",
-               self.pkg.ident, self.process, self.service_group,)
-    }
-}
-
 impl From<ServiceStatus> for protocol::types::ServiceStatus {
     fn from(other: ServiceStatus) -> Self {
         let mut proto = protocol::types::ServiceStatus::default();
@@ -385,19 +377,6 @@ struct ProcessStatus {
     elapsed: TimeDuration,
     pid:     Option<u32>,
     state:   ProcessState,
-}
-
-impl fmt::Display for ProcessStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.pid {
-            Some(pid) => {
-                write!(f,
-                       "state:{}, time:{}, pid:{}",
-                       self.state, self.elapsed, pid)
-            }
-            None => write!(f, "state:{}, time:{}", self.state, self.elapsed),
-        }
-    }
 }
 
 impl From<ProcessStatus> for protocol::types::ProcessStatus {

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -91,8 +91,8 @@ use std::{self,
                  PathBuf},
           result,
           sync::{Arc,
-                 Mutex}};
-use time::Timespec;
+                 Mutex},
+          time::SystemTime};
 
 static LOGKEY: &str = "SR";
 
@@ -504,11 +504,13 @@ impl Service {
         }
     }
 
-    pub fn last_state_change(&self) -> Timespec {
+    /// Only used as a way to see if anything has happened to this
+    /// service since the last time we might have checked
+    pub fn last_state_change(&self) -> SystemTime {
         self.supervisor
             .lock()
             .expect("Couldn't lock supervisor")
-            .state_entered
+            .state_entered()
     }
 
     /// Performs updates and executes hooks.

--- a/components/sup/src/manager/service/pipe_hook_client.rs
+++ b/components/sup/src/manager/service/pipe_hook_client.rs
@@ -194,11 +194,12 @@ impl PipeHookClient {
         // We want to wait until we know the named pipe is up and running before returning OK
         // If we suspect anything is wrong with the pipe we should terminate the pwsh process
         let start = Instant::now();
+        let timeout: Duration = PipeStartTimeout::configured_value().into();
         loop {
             match self.pipe_wait() {
                 Ok(_) => return Ok(()),
                 Err(err) => {
-                    if start.elapsed() >= PipeStartTimeout::configured_value().into() {
+                    if start.elapsed() >= timeout {
                         self.win32_result(unsafe {
                                 processthreadsapi::TerminateProcess(handle.raw(), 1)
                             })?;

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -206,17 +206,8 @@ impl Supervisor {
         Ok(())
     }
 
-    pub fn status(&self) -> (bool, String) {
-        let status = format!("{}: {} for {}",
-                             self.service_group,
-                             self.state,
-                             time::get_time() - self.state_entered);
-        let healthy = match self.state {
-            ProcessState::Up => true,
-            ProcessState::Down => false,
-        };
-        (healthy, status)
-    }
+    /// Is the process up or down?
+    pub fn status(&self) -> ProcessState { self.state }
 
     /// Returns a future that stops a service asynchronously.
     pub fn stop(&self, shutdown_config: ShutdownConfig) {

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -23,10 +23,11 @@ use habitat_launcher_client::LauncherCli;
 use serde::{ser::SerializeStruct,
             Serialize,
             Serializer};
+#[cfg(not(windows))]
+use std::io::Write;
 use std::{fs::File,
           io::{BufRead,
-               BufReader,
-               Write},
+               BufReader},
           path::{Path,
                  PathBuf},
           result,

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -37,9 +37,9 @@ static LOGKEY: &str = "SV";
 
 #[derive(Debug)]
 pub struct Supervisor {
-    service_group:     ServiceGroup,
-    state:             ProcessState,
-    pid:               Option<Pid>,
+    service_group: ServiceGroup,
+    state:         ProcessState,
+    pid:           Option<Pid>,
     /// The time at which the Supervisor's state changed. Absolute
     /// precision is not necessary, but being able to get the seconds
     /// since the UNIX epoch is.
@@ -49,7 +49,7 @@ pub struct Supervisor {
     /// will be `Some(path)`. Client code should use the `Some`/`None`
     /// status of this field as an indicator of which mode the
     /// Supervisor is running in.
-    pid_file:          Option<PathBuf>,
+    pid_file:      Option<PathBuf>,
 }
 
 impl Supervisor {
@@ -296,7 +296,7 @@ impl Supervisor {
         self.state_entered = SystemTime::now();
     }
 
-    pub fn state_entered(&self) -> SystemTime { self.state_entered.clone() }
+    pub fn state_entered(&self) -> SystemTime { self.state_entered }
 
     /// Returns how long after the UNIX Epoch this Supervisor changed
     /// state.

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -29,8 +29,9 @@ use std::{fs::File,
                Write},
           path::{Path,
                  PathBuf},
-          result};
-use time::Timespec;
+          result,
+          time::{Duration,
+                 SystemTime}};
 
 static LOGKEY: &str = "SV";
 
@@ -38,9 +39,11 @@ static LOGKEY: &str = "SV";
 pub struct Supervisor {
     service_group:     ServiceGroup,
     state:             ProcessState,
-    // TODO (CM): make this private
-    pub state_entered: Timespec,
     pid:               Option<Pid>,
+    /// The time at which the Supervisor's state changed. Absolute
+    /// precision is not necessary, but being able to get the seconds
+    /// since the UNIX epoch is.
+    state_entered: SystemTime,
     /// If the Supervisor is being run with an newer Launcher that
     /// can provide service PIDs, this will be `None`, otherwise it
     /// will be `Some(path)`. Client code should use the `Some`/`None`
@@ -63,7 +66,7 @@ impl Supervisor {
         };
         Supervisor { service_group: service_group.clone(),
                      state: ProcessState::Down,
-                     state_entered: time::get_time(),
+                     state_entered: SystemTime::now(),
                      pid: None,
                      pid_file }
     }
@@ -290,10 +293,21 @@ impl Supervisor {
             return;
         }
         self.state = state;
-        self.state_entered = time::get_time();
+        self.state_entered = SystemTime::now();
+    }
+
+    pub fn state_entered(&self) -> SystemTime { self.state_entered.clone() }
+
+    /// Returns how long after the UNIX Epoch this Supervisor changed
+    /// state.
+    fn since_epoch(&self) -> Duration {
+        self.state_entered
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("our time should ALWAYS be after the UNIX Epoch")
     }
 }
 
+// This is used to generate the output of the HTTP gateway
 impl Serialize for Supervisor {
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
         where S: Serializer
@@ -301,7 +315,7 @@ impl Serialize for Supervisor {
         let mut strukt = serializer.serialize_struct("supervisor", 5)?;
         strukt.serialize_field("pid", &self.pid)?;
         strukt.serialize_field("state", &self.state)?;
-        strukt.serialize_field("state_entered", &self.state_entered.sec)?;
+        strukt.serialize_field("state_entered", &self.since_epoch().as_secs())?;
         strukt.end()
     }
 }

--- a/components/sup/src/sys/unix/service.rs
+++ b/components/sup/src/sys/unix/service.rs
@@ -70,7 +70,7 @@ impl Process {
 
         let timeout: Duration = timeout.into();
         trace!("Waiting up to {} seconds before sending KILL to process {}",
-               timeout.num_seconds(),
+               timeout.as_secs(),
                pid_to_kill);
         let stop_time = Instant::now() + timeout;
         loop {

--- a/components/sup/src/sys/unix/service.rs
+++ b/components/sup/src/sys/unix/service.rs
@@ -13,9 +13,8 @@ use libc::{self,
            pid_t};
 use std::{ops::Neg,
           thread,
-          time::Duration as StdDuration};
-use time::{Duration as TimeDuration,
-           SteadyTime};
+          time::{Duration,
+                 Instant}};
 
 /// Kill a service process.
 pub fn kill(pid: Pid, shutdown_config: &ShutdownConfig) -> ShutdownMethod {
@@ -69,19 +68,19 @@ impl Process {
             return ShutdownMethod::AlreadyExited;
         }
 
-        let timeout: TimeDuration = timeout.into();
+        let timeout: Duration = timeout.into();
         trace!("Waiting up to {} seconds before sending KILL to process {}",
                timeout.num_seconds(),
                pid_to_kill);
-        let stop_time = SteadyTime::now() + timeout;
+        let stop_time = Instant::now() + timeout;
         loop {
             if !is_alive(pid_to_kill) {
                 return ShutdownMethod::GracefulTermination;
             }
-            if SteadyTime::now() >= stop_time {
+            if Instant::now() >= stop_time {
                 break;
             }
-            thread::sleep(StdDuration::from_millis(5));
+            thread::sleep(Duration::from_millis(5));
         }
 
         trace!("Timeout exceeded; killing process {}", pid_to_kill);

--- a/components/sup/src/sys/windows/service.rs
+++ b/components/sup/src/sys/windows/service.rs
@@ -8,9 +8,8 @@ use std::{collections::HashMap,
           io,
           mem,
           thread,
-          time::Duration as StdDuration};
-use time::{Duration as TimeDuration,
-           SteadyTime};
+          time::{Duration,
+                 Instant}};
 use winapi::{shared::minwindef::{DWORD,
                                  LPDWORD,
                                  MAX_PATH},
@@ -71,13 +70,13 @@ impl Process {
                    io::Error::last_os_error());
         }
 
-        let timeout: TimeDuration = timeout.into();
+        let timeout: Duration = timeout.into();
         trace!("Waiting up to {} seconds before terminating process {}",
-               timeout.num_seconds(),
+               timeout.as_secs(),
                self.id());
-        let stop_time = SteadyTime::now() + timeout;
+        let stop_time = Instant::now() + timeout;
         loop {
-            if ret == 0 || SteadyTime::now() > stop_time {
+            if ret == 0 || Instant::now() > stop_time {
                 let proc_table = build_proc_table();
                 terminate_process_descendants(&proc_table, self.id());
                 return ShutdownMethod::Killed;
@@ -86,7 +85,7 @@ impl Process {
             if self.status().is_some() {
                 return ShutdownMethod::GracefulTermination;
             }
-            thread::sleep(StdDuration::from_millis(5));
+            thread::sleep(Duration::from_millis(5));
         }
     }
 

--- a/components/win-users/src/sid.rs
+++ b/components/win-users/src/sid.rs
@@ -164,6 +164,7 @@ impl Sid {
         }
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(sid: &str) -> io::Result<Self> {
         let sid = WideCString::from_str(sid).expect("valid SID widestring");
         let mut buffer = null_mut();


### PR DESCRIPTION
Rather than updating everything to use the new 0.2 line of the `time` crate, it turns out that we can basically remove it from everything with a bit of refactoring. Juggling multiple time representations was a bit of a pain internally, and made things more confusing than necessary.

This PR performs the (mostly) mechanical translation from `time` to `std::time`, with interesting diversions pointed out along the way. A bit of internal refactoring and cleanup helped with this as well.

Fixes #7353

Signed-off-by: Christopher Maier <cmaier@chef.io>