### PR TITLE
Allow dev environment setup script to work locally or in Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,6 @@ Vagrant.configure("2") do |config|
     v.vmx["numvcpus"] = "4"
   end
 
-  config.vm.provision "file", source: "components/hab/install.sh", destination: "/tmp/install.sh"
   config.vm.provision "shell", path: "support/linux/install_dev_0_ubuntu_latest.sh"
   config.vm.provision "shell", path: "support/linux/install_dev_8_docker.sh"
   config.vm.provision "shell", path: "support/linux/install_dev_9_linux.sh"

--- a/support/linux/install_dev_9_linux.sh
+++ b/support/linux/install_dev_9_linux.sh
@@ -45,5 +45,5 @@ else
   sudo -E addgroup --system hab || true
 fi
 
-sudo "$(dirname -- "$0")/install.sh"
+curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | sudo bash
 sudo HAB_LICENSE="accept-no-persist" hab install core/busybox-static core/hab-studio


### PR DESCRIPTION
Rather than sourcing the install script locally, we'll just use it via
`curl` like we normally do.

On one hand, it was nice to use the script from the
repository. However, you need internet access to do the setup anyway,
and this is a simple way to make the scripts work the same whether you
run them on your workstation or in a Vagrant machine.

Fixes #7454

Signed-off-by: Christopher Maier <cmaier@chef.io>