### PR TITLE
Make FullyQualifiedPackageIdent public and use it in Pkg

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -20,7 +20,7 @@
 //! * Verify it is un-altered
 //! * Unpack it
 
-use std::{borrow::Cow,
+use std::{convert::TryFrom,
           fmt,
           fs::{self,
                File},
@@ -259,42 +259,52 @@ impl Default for LocalPackageUsage {
 /// Represents a fully-qualified Package Identifier, meaning that the normally optional version and
 /// release package coordinates are guaranteed to be set. This fully-qualified-ness is checked on
 /// construction and as the underlying representation is immutable, this state does not change.
-#[derive(Debug)]
-struct FullyQualifiedPackageIdent<'a>(Cow<'a, PackageIdent>);
+#[derive(Eq, PartialEq, PartialOrd, Debug, Clone, Hash)]
+struct FullyQualifiedPackageIdent(PackageIdent);
 
-impl<'a> FullyQualifiedPackageIdent<'a> {
-    // TODO fn: I would much rather have implemented `TryFrom` for this, but we need to wait until
-    // the API has stabilzed and is released in Rust stable. Here's hoping!
-    // Ref: https://doc.rust-lang.org/std/convert/trait.TryFrom.html
-    fn from<I>(ident: I) -> Result<Self>
-        where I: Into<Cow<'a, PackageIdent>>
-    {
-        let ident = ident.into();
-        if ident.as_ref().fully_qualified() {
-            Ok(FullyQualifiedPackageIdent(ident))
-        } else {
-            Err(Error::HabitatCore(
-                hcore::Error::FullyQualifiedPackageIdentRequired(ident.to_owned().to_string()),
-            ))
-        }
-    }
-
-    fn archive_name(&self) -> String {
+impl FullyQualifiedPackageIdent {
+    pub fn archive_name(&self) -> String {
         self.0
             .as_ref()
             .archive_name()
-            .unwrap_or_else(|_| {
-                panic!("PackageIdent {} should be fully qualified", self.0.as_ref())
-            })
+            .unwrap_or_else(|_| panic!("PackageIdent {} should be fully qualified", self.0))
     }
 }
 
-impl<'a> AsRef<PackageIdent> for FullyQualifiedPackageIdent<'a> {
-    fn as_ref(&self) -> &PackageIdent { self.0.as_ref() }
+impl TryFrom<PackageIdent> for FullyQualifiedPackageIdent {
+    type Error = Error;
+
+    fn try_from(ident: PackageIdent) -> Result<Self> {
+        if ident.fully_qualified() {
+            Ok(FullyQualifiedPackageIdent(ident))
+        } else {
+            Err(Error::HabitatCore(
+                hcore::Error::FullyQualifiedPackageIdentRequired(ident.to_string()),
+            ))
+        }
+    }
 }
 
-impl<'a> fmt::Display for FullyQualifiedPackageIdent<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.as_ref().fmt(f) }
+impl<'a> TryFrom<&'a PackageIdent> for FullyQualifiedPackageIdent {
+    type Error = Error;
+
+    fn try_from(ident: &PackageIdent) -> Result<Self> {
+        if ident.fully_qualified() {
+            Ok(FullyQualifiedPackageIdent(ident.clone()))
+        } else {
+            Err(Error::HabitatCore(
+                hcore::Error::FullyQualifiedPackageIdentRequired(ident.to_string()),
+            ))
+        }
+    }
+}
+
+impl AsRef<PackageIdent> for FullyQualifiedPackageIdent {
+    fn as_ref(&self) -> &PackageIdent { &self.0 }
+}
+
+impl fmt::Display for FullyQualifiedPackageIdent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
 }
 
 /// Install a Habitat package.
@@ -533,7 +543,7 @@ impl<'a> InstallTask<'a> {
         where T: UIWriter
     {
         ui.begin(format!("Installing {}", local_archive.path.display()))?;
-        let target_ident = FullyQualifiedPackageIdent::from(&local_archive.ident)?;
+        let target_ident = FullyQualifiedPackageIdent::try_from(&local_archive.ident)?;
         match self.installed_package(&target_ident) {
             Some(package_install) => {
                 // The installed package was found on disk
@@ -558,14 +568,14 @@ impl<'a> InstallTask<'a> {
                                             ui: &mut T,
                                             (ident, target): (PackageIdent, PackageTarget),
                                             token: Option<&str>)
-                                            -> Result<FullyQualifiedPackageIdent<'_>>
+                                            -> Result<FullyQualifiedPackageIdent>
         where T: UIWriter
     {
         if ident.fully_qualified() {
             // If we have a fully qualified package identifier, then our work is done--there can
             // only be *one* package that satisfies a fully qualified identifier.
 
-            FullyQualifiedPackageIdent::from(ident)
+            FullyQualifiedPackageIdent::try_from(ident)
         } else if self.is_offline() {
             // If we can't contact a Builder API, then we'll find the latest installed package or
             // cached artifact that satisfies the fuzzy package identifier.
@@ -605,15 +615,14 @@ impl<'a> InstallTask<'a> {
 
             match (latest_local, latest_remote) {
                 (Ok(local), Some(remote)) => {
-                    if local.as_ref() > remote.as_ref() {
+                    if local > remote {
                         // Return the latest identifier reported by
                         // the Builder API *unless* there is a newer
                         // version found installed locally.
                         ui.status(Status::Found,
                                   format!("newer installed version ({}) than remote version \
                                            ({})",
-                                          &local,
-                                          remote.as_ref()))?;
+                                          &local, remote))?;
                         Ok(local)
                     } else {
                         Ok(remote)
@@ -626,17 +635,14 @@ impl<'a> InstallTask<'a> {
                         self.recommend_channels(ui, (&ident, target), token).await?;
                         ui.warn(format!("Locally-installed package '{}' would satisfy '{}', \
                                          but we are ignoring that as directed",
-                                        local.as_ref(),
-                                        &ident,))?;
+                                        local, &ident,))?;
                         Err(Error::PackageNotFound("".to_string()))
                     } else {
                         ui.status(Status::Missing,
                                   format!("remote version of '{}' in the '{}' channel, but an \
                                            installed version was found locally ({})",
-                                          &ident,
-                                          self.channel,
-                                          local.as_ref()))?;
-                        FullyQualifiedPackageIdent::from(local.as_ref().clone())
+                                          &ident, self.channel, local))?;
+                        Ok(local)
                     }
                 }
                 (Err(_), Some(remote)) => Ok(remote),
@@ -657,7 +663,7 @@ impl<'a> InstallTask<'a> {
     /// installed will be re-cached (as needed) and installed.
     async fn install_package<T>(&self,
                                 ui: &mut T,
-                                (ident, target): (&FullyQualifiedPackageIdent<'_>, PackageTarget),
+                                (ident, target): (&FullyQualifiedPackageIdent, PackageTarget),
                                 token: Option<&str>)
                                 -> Result<PackageInstall>
         where T: UIWriter
@@ -673,7 +679,7 @@ impl<'a> InstallTask<'a> {
         // requires a conversion that could fail (i.e. returns a `Result<...>`). Should be
         // possible though.
         for dependency in dependencies.iter() {
-            if self.installed_package(&FullyQualifiedPackageIdent::from(dependency)?)
+            if self.installed_package(&FullyQualifiedPackageIdent::try_from(dependency)?)
                    .is_some()
             {
                 ui.status(Status::Using, dependency)?;
@@ -686,7 +692,7 @@ impl<'a> InstallTask<'a> {
             } else {
                 artifacts_to_install.push(self.get_cached_artifact(
                     ui,
-                    (&FullyQualifiedPackageIdent::from(dependency)?, target),
+                    (&FullyQualifiedPackageIdent::try_from(dependency)?, target),
                     token,
                 ).await?);
             }
@@ -718,8 +724,7 @@ impl<'a> InstallTask<'a> {
     /// verifies it, and returns a handle to the package's metadata.
     async fn get_cached_artifact<T>(&self,
                                     ui: &mut T,
-                                    (ident, target): (&FullyQualifiedPackageIdent<'_>,
-                                     PackageTarget),
+                                    (ident, target): (&FullyQualifiedPackageIdent, PackageTarget),
                                     token: Option<&str>)
                                     -> Result<PackageArchive>
         where T: UIWriter
@@ -784,7 +789,7 @@ impl<'a> InstallTask<'a> {
 
     /// Adapter function to retrieve an installed package given an
     /// identifier, if it exists.
-    fn installed_package(&self, ident: &FullyQualifiedPackageIdent<'_>) -> Option<PackageInstall> {
+    fn installed_package(&self, ident: &FullyQualifiedPackageIdent) -> Option<PackageInstall> {
         PackageInstall::load(ident.as_ref(), Some(self.fs_root_path)).ok()
     }
 
@@ -792,7 +797,7 @@ impl<'a> InstallTask<'a> {
     /// identifier and returns a fully qualified package identifier if a match exists.
     fn latest_installed_or_cached(&self,
                                   ident: &PackageIdent)
-                                  -> Result<FullyQualifiedPackageIdent<'_>> {
+                                  -> Result<FullyQualifiedPackageIdent> {
         let latest_installed = self.latest_installed_ident(&ident);
         let latest_cached = self.latest_cached_ident(&ident);
         debug!("latest installed: {:?}, latest_cached: {:?}",
@@ -801,7 +806,7 @@ impl<'a> InstallTask<'a> {
             (Ok(pkg_install), Err(_)) => pkg_install,
             (Err(_), Ok(pkg_artifact)) => pkg_artifact,
             (Ok(pkg_install), Ok(pkg_artifact)) => {
-                if pkg_install.as_ref() > pkg_artifact.as_ref() {
+                if pkg_install > pkg_artifact {
                     pkg_install
                 } else {
                     pkg_artifact
@@ -814,16 +819,14 @@ impl<'a> InstallTask<'a> {
         Ok(latest)
     }
 
-    fn latest_installed_ident(&self,
-                              ident: &PackageIdent)
-                              -> Result<FullyQualifiedPackageIdent<'_>> {
+    fn latest_installed_ident(&self, ident: &PackageIdent) -> Result<FullyQualifiedPackageIdent> {
         match PackageInstall::load(ident, Some(self.fs_root_path)) {
-            Ok(pi) => FullyQualifiedPackageIdent::from(pi.ident().clone()),
+            Ok(pi) => FullyQualifiedPackageIdent::try_from(pi.ident().clone()),
             Err(_) => Err(Error::PackageNotFound("".to_string())),
         }
     }
 
-    fn latest_cached_ident(&self, ident: &PackageIdent) -> Result<FullyQualifiedPackageIdent<'_>> {
+    fn latest_cached_ident(&self, ident: &PackageIdent) -> Result<FullyQualifiedPackageIdent> {
         let filename_glob = {
             let mut ident = ident.clone();
             if ident.version.is_none() {
@@ -839,11 +842,11 @@ impl<'a> InstallTask<'a> {
         };
         let glob_path = self.artifact_cache_path.join(filename_glob);
         let glob_path = glob_path.to_string_lossy();
-        debug!("looking for cached artifacts, glob={}", glob_path.as_ref());
+        debug!("looking for cached artifacts, glob={}", glob_path);
 
         let mut latest: Vec<(PackageIdent, PackageArchive)> = Vec::with_capacity(1);
-        for file in glob::glob(glob_path.as_ref()).expect("glob pattern should compile")
-                                                  .filter_map(StdResult::ok)
+        for file in glob::glob(&glob_path).expect("glob pattern should compile")
+                                          .filter_map(StdResult::ok)
         {
             let mut artifact = PackageArchive::new(&file);
             let artifact_ident = artifact.ident().ok();
@@ -864,28 +867,28 @@ impl<'a> InstallTask<'a> {
         if latest.is_empty() {
             Err(Error::PackageNotFound("".to_string()))
         } else {
-            Ok(FullyQualifiedPackageIdent::from(latest.pop()
-                                                      .unwrap()
-                                                      .1
-                                                      .ident()?)?)
+            Ok(FullyQualifiedPackageIdent::try_from(latest.pop()
+                                                          .unwrap()
+                                                          .1
+                                                          .ident()?)?)
         }
     }
 
-    fn is_artifact_cached(&self, ident: &FullyQualifiedPackageIdent<'_>) -> bool {
+    fn is_artifact_cached(&self, ident: &FullyQualifiedPackageIdent) -> bool {
         self.cached_artifact_path(ident).is_file()
     }
 
     /// Returns the path to the location this package would exist at in
     /// the local package cache. It does not mean that the package is
     /// actually *in* the package cache, though.
-    fn cached_artifact_path(&self, ident: &FullyQualifiedPackageIdent<'_>) -> PathBuf {
+    fn cached_artifact_path(&self, ident: &FullyQualifiedPackageIdent) -> PathBuf {
         self.artifact_cache_path.join(ident.archive_name())
     }
 
     async fn fetch_latest_pkg_ident_for(&self,
                                         (ident, target): (&PackageIdent, PackageTarget),
                                         token: Option<&str>)
-                                        -> Result<FullyQualifiedPackageIdent<'_>> {
+                                        -> Result<FullyQualifiedPackageIdent> {
         self.fetch_latest_pkg_ident_in_channel_for((ident, target), &self.channel, token)
             .await
     }
@@ -895,18 +898,18 @@ impl<'a> InstallTask<'a> {
                                                     PackageTarget),
                                                    channel: &ChannelIdent,
                                                    token: Option<&str>)
-                                                   -> Result<FullyQualifiedPackageIdent<'_>> {
+                                                   -> Result<FullyQualifiedPackageIdent> {
         let origin_package = self.api_client
                                  .show_package((ident, target), channel, token)
                                  .await?;
-        FullyQualifiedPackageIdent::from(origin_package)
+        FullyQualifiedPackageIdent::try_from(origin_package)
     }
 
     /// Retrieve the identified package from the depot, ensuring that
     /// the artifact is cached locally.
     async fn fetch_artifact<T>(&self,
                                ui: &mut T,
-                               (ident, target): (&FullyQualifiedPackageIdent<'_>, PackageTarget),
+                               (ident, target): (&FullyQualifiedPackageIdent, PackageTarget),
                                token: Option<&str>)
                                -> Result<()>
         where T: UIWriter
@@ -954,7 +957,7 @@ impl<'a> InstallTask<'a> {
     /// Copies the artifact to the local artifact cache directory
     // TODO (CM): Oh, we could just pass in the LocalArchive
     fn store_artifact_in_cache(&self,
-                               ident: &FullyQualifiedPackageIdent<'_>,
+                               ident: &FullyQualifiedPackageIdent,
                                artifact_path: &Path)
                                -> Result<()> {
         // Canonicalize both paths to ensure that there aren't any symlinks when comparing them
@@ -992,7 +995,7 @@ impl<'a> InstallTask<'a> {
 
     async fn verify_artifact<T>(&self,
                                 ui: &mut T,
-                                ident: &FullyQualifiedPackageIdent<'_>,
+                                ident: &FullyQualifiedPackageIdent,
                                 token: Option<&str>,
                                 artifact: &mut PackageArchive)
                                 -> Result<()>

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -260,11 +260,7 @@ impl Default for LocalPackageUsage {
 /// release package coordinates are guaranteed to be set. This fully-qualified-ness is checked on
 /// construction and as the underlying representation is immutable, this state does not change.
 #[derive(Debug)]
-struct FullyQualifiedPackageIdent<'a> {
-    // The ident is a struct field rather than a "newtype" struct to ensure its value cannot be
-    // directly accessed
-    ident: Cow<'a, PackageIdent>,
-}
+struct FullyQualifiedPackageIdent<'a>(Cow<'a, PackageIdent>);
 
 impl<'a> FullyQualifiedPackageIdent<'a> {
     // TODO fn: I would much rather have implemented `TryFrom` for this, but we need to wait until
@@ -275,7 +271,7 @@ impl<'a> FullyQualifiedPackageIdent<'a> {
     {
         let ident = ident.into();
         if ident.as_ref().fully_qualified() {
-            Ok(FullyQualifiedPackageIdent { ident })
+            Ok(FullyQualifiedPackageIdent(ident))
         } else {
             Err(Error::HabitatCore(
                 hcore::Error::FullyQualifiedPackageIdentRequired(ident.to_owned().to_string()),
@@ -284,19 +280,21 @@ impl<'a> FullyQualifiedPackageIdent<'a> {
     }
 
     fn archive_name(&self) -> String {
-        self.ident.as_ref().archive_name().unwrap_or_else(|_| {
-                                              panic!("PackageIdent {} should be fully qualified",
-                                                     self.ident.as_ref())
-                                          })
+        self.0
+            .as_ref()
+            .archive_name()
+            .unwrap_or_else(|_| {
+                panic!("PackageIdent {} should be fully qualified", self.0.as_ref())
+            })
     }
 }
 
 impl<'a> AsRef<PackageIdent> for FullyQualifiedPackageIdent<'a> {
-    fn as_ref(&self) -> &PackageIdent { self.ident.as_ref() }
+    fn as_ref(&self) -> &PackageIdent { self.0.as_ref() }
 }
 
 impl<'a> fmt::Display for FullyQualifiedPackageIdent<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.ident.as_ref().fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.as_ref().fmt(f) }
 }
 
 /// Install a Habitat package.

--- a/components/common/src/templating/context.rs
+++ b/components/common/src/templating/context.rs
@@ -154,8 +154,8 @@ impl<'a> Serialize for Package<'a> {
         // in templates
         map.serialize_entry("origin", &self.ident.origin())?;
         map.serialize_entry("name", &self.ident.name())?;
-        map.serialize_entry("version", &self.ident.guaranteed_version())?;
-        map.serialize_entry("release", &self.ident.guaranteed_release())?;
+        map.serialize_entry("version", &self.ident.version())?;
+        map.serialize_entry("release", &self.ident.release())?;
 
         map.serialize_entry("deps", &self.deps)?;
         map.serialize_entry("env", &self.env)?;

--- a/components/common/src/templating/context.rs
+++ b/components/common/src/templating/context.rs
@@ -36,7 +36,9 @@
 use super::{config::Cfg,
             package::{Env,
                       Pkg}};
-use crate::hcore::package::PackageIdent;
+use crate::hcore::package::{FullyQualifiedPackageIdent,
+                            Identifiable,
+                            PackageIdent};
 use serde::{ser::SerializeMap,
             Serialize,
             Serializer};
@@ -88,11 +90,7 @@ impl<'a> RenderContext<'a> {
 /// Currently exposed to users under the `pkg` key.
 #[derive(Clone, Debug)]
 struct Package<'a> {
-    ident:                   Cow<'a, PackageIdent>,
-    origin:                  Cow<'a, String>,
-    name:                    Cow<'a, String>,
-    version:                 Cow<'a, String>,
-    release:                 Cow<'a, String>,
+    ident:                   Cow<'a, FullyQualifiedPackageIdent>,
     deps:                    Cow<'a, Vec<PackageIdent>>,
     env:                     Cow<'a, Env>,
     // TODO (CM): Ideally, this would be Vec<u16>, since they're ports.
@@ -116,14 +114,6 @@ struct Package<'a> {
 impl<'a> Package<'a> {
     fn from_pkg(pkg: &'a Pkg) -> Self {
         Package { ident:                   Cow::Borrowed(&pkg.ident),
-                  // TODO (CM): have Pkg use FullyQualifiedPackageIdent, and
-                  // get origin, name, version, and release from it, rather
-                  // than storing each individually; I suspect that was just
-                  // for templating
-                  origin:                  Cow::Borrowed(&pkg.origin),
-                  name:                    Cow::Borrowed(&pkg.name),
-                  version:                 Cow::Borrowed(&pkg.version),
-                  release:                 Cow::Borrowed(&pkg.release),
                   deps:                    Cow::Borrowed(&pkg.deps),
                   env:                     Cow::Borrowed(&pkg.env),
                   exposes:                 Cow::Borrowed(&pkg.exposes),
@@ -162,10 +152,10 @@ impl<'a> Serialize for Package<'a> {
 
         // Break out the components of the identifier, for easy access
         // in templates
-        map.serialize_entry("origin", &self.origin)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("version", &self.version)?;
-        map.serialize_entry("release", &self.release)?;
+        map.serialize_entry("origin", &self.ident.origin())?;
+        map.serialize_entry("name", &self.ident.name())?;
+        map.serialize_entry("version", &self.ident.guaranteed_version())?;
+        map.serialize_entry("release", &self.ident.guaranteed_release())?;
 
         map.serialize_entry("deps", &self.deps)?;
         map.serialize_entry("env", &self.env)?;
@@ -271,7 +261,7 @@ two = 2
     /// If you want to modify parts of it, it's easier to change
     /// things on a mutable reference.
     fn default_render_context<'a>() -> RenderContext<'a> {
-        let ident = PackageIdent::new("core", "test_pkg", Some("1.0.0"), Some("20180321150416"));
+        let ident = FullyQualifiedPackageIdent::new("core", "test_pkg", "1.0.0", "20180321150416");
 
         let deps = vec![PackageIdent::new("test", "pkg1", Some("1.0.0"), Some("20180321150416")),
                         PackageIdent::new("test", "pkg2", Some("2.0.0"), Some("20180321150416")),
@@ -285,15 +275,7 @@ two = 2
         export_hash.insert("blah".into(), "stuff.thing".into());
         export_hash.insert("port".into(), "test_port".into());
 
-        let pkg = Package { ident:                   Cow::Owned(ident.clone()),
-                            // TODO (CM): have Pkg use FullyQualifiedPackageIdent, and
-                            // get origin, name, version, and release from it, rather
-                            // than storing each individually; I suspect that was just
-                            // for templating
-                            origin:                  Cow::Owned(ident.origin.clone()),
-                            name:                    Cow::Owned(ident.name.clone()),
-                            version:                 Cow::Owned(ident.version.clone().unwrap()),
-                            release:                 Cow::Owned(ident.release.unwrap()),
+        let pkg = Package { ident:                   Cow::Owned(ident),
                             deps:                    Cow::Owned(deps),
                             env:                     Cow::Owned(env_hash.into()),
                             exposes:                 Cow::Owned(vec!["1234".into(),

--- a/components/common/src/templating/package.rs
+++ b/components/common/src/templating/package.rs
@@ -118,8 +118,8 @@ impl Pkg {
                         path: package.installed_path.clone(),
                         origin: package.ident.origin.clone(),
                         name: package.ident.name.clone(),
-                        version: String::from(ident.guaranteed_version()),
-                        release: String::from(ident.guaranteed_release()),
+                        version: String::from(ident.version()),
+                        release: String::from(ident.release()),
                         shutdown_signal: package.shutdown_signal()?.unwrap_or_default(),
                         shutdown_timeout: package.shutdown_timeout()?.unwrap_or_default(),
                         ident };

--- a/components/common/src/templating/package.rs
+++ b/components/common/src/templating/package.rs
@@ -4,7 +4,8 @@ use crate::{error::{Error,
                     os::{process::{ShutdownSignal,
                                    ShutdownTimeout},
                          users},
-                    package::{PackageIdent,
+                    package::{FullyQualifiedPackageIdent,
+                              PackageIdent,
                               PackageInstall},
                     util::serde_string},
             util::path};
@@ -13,6 +14,7 @@ use serde::{ser::SerializeStruct,
             Serializer};
 use std::{collections::{BTreeMap,
                         HashMap},
+          convert::TryFrom,
           env,
           iter::FromIterator,
           ops::Deref,
@@ -68,7 +70,7 @@ impl Env {
 #[derive(Clone, Debug, Deserialize)]
 pub struct Pkg {
     #[serde(with = "serde_string")]
-    pub ident:                   PackageIdent,
+    pub ident:                   FullyQualifiedPackageIdent,
     pub origin:                  String,
     pub name:                    String,
     pub version:                 String,
@@ -95,6 +97,7 @@ pub struct Pkg {
 
 impl Pkg {
     pub async fn from_install(package: &PackageInstall) -> Result<Self> {
+        let ident = FullyQualifiedPackageIdent::try_from(&package.ident)?;
         let (svc_user, svc_group) = get_user_and_group(&package)?;
         let pkg = Pkg { svc_path: fs::svc_path(&package.ident.name),
                         svc_config_path: fs::svc_config_path(&package.ident.name),
@@ -113,19 +116,13 @@ impl Pkg {
                         exposes: package.exposes()?,
                         exports: package.exports()?,
                         path: package.installed_path.clone(),
-                        ident: package.ident.clone(),
                         origin: package.ident.origin.clone(),
                         name: package.ident.name.clone(),
-                        version: package.ident
-                                        .version
-                                        .clone()
-                                        .expect("No package version in PackageInstall"),
-                        release: package.ident
-                                        .release
-                                        .clone()
-                                        .expect("No package release in PackageInstall"),
+                        version: String::from(ident.guaranteed_version()),
+                        release: String::from(ident.guaranteed_release()),
                         shutdown_signal: package.shutdown_signal()?.unwrap_or_default(),
-                        shutdown_timeout: package.shutdown_timeout()?.unwrap_or_default() };
+                        shutdown_timeout: package.shutdown_timeout()?.unwrap_or_default(),
+                        ident };
         Ok(pkg)
     }
 }

--- a/components/core/src/package.rs
+++ b/components/core/src/package.rs
@@ -8,7 +8,8 @@ pub mod target;
 
 pub use self::{archive::{FromArchive,
                          PackageArchive},
-               ident::{Identifiable,
+               ident::{FullyQualifiedPackageIdent,
+                       Identifiable,
                        PackageIdent},
                install::PackageInstall,
                list::all_packages,

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -314,14 +314,16 @@ impl FullyQualifiedPackageIdent {
             .unwrap_or_else(|_| panic!("PackageIdent {} should be fully qualified", self.0))
     }
 
-    pub fn guaranteed_version(&self) -> &str {
-        self.version()
-            .unwrap_or_else(|| panic!("PackageIdent {} should be fully qualified", self.0))
+    pub fn version(&self) -> &str {
+        Identifiable::version(self).unwrap_or_else(|| {
+                                       panic!("PackageIdent {} should be fully qualified", self.0)
+                                   })
     }
 
-    pub fn guaranteed_release(&self) -> &str {
-        self.release()
-            .unwrap_or_else(|| panic!("PackageIdent {} should be fully qualified", self.0))
+    pub fn release(&self) -> &str {
+        Identifiable::release(self).unwrap_or_else(|| {
+                                       panic!("PackageIdent {} should be fully qualified", self.0)
+                                   })
     }
 }
 

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -799,7 +799,7 @@ impl Manager {
         };
 
         if let Ok(package) =
-            PackageInstall::load(&service.pkg.ident, Some(Path::new(&*FS_ROOT_PATH)))
+            PackageInstall::load(service.pkg.ident.as_ref(), Some(Path::new(&*FS_ROOT_PATH)))
         {
             if let Err(err) = habitat_common::command::package::install::check_install_hooks(
                 &mut habitat_common::ui::UI::with_sinks(),

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -371,7 +371,7 @@ impl fmt::Display for ServiceStatus {
 impl From<ServiceStatus> for protocol::types::ServiceStatus {
     fn from(other: ServiceStatus) -> Self {
         let mut proto = protocol::types::ServiceStatus::default();
-        proto.ident = other.pkg.ident.into();
+        proto.ident = PackageIdent::from(other.pkg.ident).into();
         proto.process = Some(other.process.into());
         proto.service_group = other.service_group.into();
         proto.desired_state = Some(other.desired_state.into());

--- a/components/sup/src/manager/service/context.rs
+++ b/components/sup/src/manager/service/context.rs
@@ -220,8 +220,8 @@ impl<'a> Serialize for Package<'a> {
         // in templates
         map.serialize_entry("origin", &self.ident.origin())?;
         map.serialize_entry("name", &self.ident.name())?;
-        map.serialize_entry("version", &self.ident.guaranteed_version())?;
-        map.serialize_entry("release", &self.ident.guaranteed_release())?;
+        map.serialize_entry("version", &self.ident.version())?;
+        map.serialize_entry("release", &self.ident.release())?;
 
         map.serialize_entry("deps", &self.deps)?;
         map.serialize_entry("env", &self.env)?;

--- a/components/sup/src/manager/service/context.rs
+++ b/components/sup/src/manager/service/context.rs
@@ -43,7 +43,9 @@ use habitat_butterfly::rumor::service::SysInfo;
 use habitat_common::templating::{config::Cfg,
                                  package::{Env,
                                            Pkg}};
-use habitat_core::{package::PackageIdent,
+use habitat_core::{package::{FullyQualifiedPackageIdent,
+                             Identifiable,
+                             PackageIdent},
                    service::{ServiceBind,
                              ServiceGroup}};
 use serde::{ser::SerializeMap,
@@ -156,11 +158,7 @@ impl<'a> SystemInfo<'a> {
 /// Currently exposed to users under the `pkg` key.
 #[derive(Clone, Debug)]
 struct Package<'a> {
-    ident:           Cow<'a, PackageIdent>,
-    origin:          Cow<'a, String>,
-    name:            Cow<'a, String>,
-    version:         Cow<'a, String>,
-    release:         Cow<'a, String>,
+    ident:           Cow<'a, FullyQualifiedPackageIdent>,
     deps:            Cow<'a, Vec<PackageIdent>>,
     env:             Cow<'a, Env>,
     // TODO (CM): Ideally, this would be Vec<u16>, since they're ports.
@@ -183,14 +181,6 @@ struct Package<'a> {
 impl<'a> Package<'a> {
     fn from_pkg(pkg: &'a Pkg) -> Self {
         Package { ident:           Cow::Borrowed(&pkg.ident),
-                  // TODO (CM): have Pkg use FullyQualifiedPackageIdent, and
-                  // get origin, name, version, and release from it, rather
-                  // than storing each individually; I suspect that was just
-                  // for templating
-                  origin:          Cow::Borrowed(&pkg.origin),
-                  name:            Cow::Borrowed(&pkg.name),
-                  version:         Cow::Borrowed(&pkg.version),
-                  release:         Cow::Borrowed(&pkg.release),
                   deps:            Cow::Borrowed(&pkg.deps),
                   env:             Cow::Borrowed(&pkg.env),
                   exposes:         Cow::Borrowed(&pkg.exposes),
@@ -228,10 +218,10 @@ impl<'a> Serialize for Package<'a> {
 
         // Break out the components of the identifier, for easy access
         // in templates
-        map.serialize_entry("origin", &self.origin)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("version", &self.version)?;
-        map.serialize_entry("release", &self.release)?;
+        map.serialize_entry("origin", &self.ident.origin())?;
+        map.serialize_entry("name", &self.ident.name())?;
+        map.serialize_entry("version", &self.ident.guaranteed_version())?;
+        map.serialize_entry("release", &self.ident.guaranteed_release())?;
 
         map.serialize_entry("deps", &self.deps)?;
         map.serialize_entry("env", &self.env)?;
@@ -651,7 +641,7 @@ two = 2
                          ctl_gateway_port:  Cow::Owned(5679),
                          permanent:         Cow::Owned(false), };
 
-        let ident = PackageIdent::new("core", "test_pkg", Some("1.0.0"), Some("20180321150416"));
+        let ident = FullyQualifiedPackageIdent::new("core", "test_pkg", "1.0.0", "20180321150416");
 
         let deps = vec![PackageIdent::new("test", "pkg1", Some("1.0.0"), Some("20180321150416")),
                         PackageIdent::new("test", "pkg2", Some("2.0.0"), Some("20180321150416")),
@@ -666,14 +656,6 @@ two = 2
         export_hash.insert("port".into(), "test_port".into());
 
         let pkg = Package { ident:           Cow::Owned(ident.clone()),
-                            // TODO (CM): have Pkg use FullyQualifiedPackageIdent, and
-                            // get origin, name, version, and release from it, rather
-                            // than storing each individually; I suspect that was just
-                            // for templating
-                            origin:          Cow::Owned(ident.origin.clone()),
-                            name:            Cow::Owned(ident.name.clone()),
-                            version:         Cow::Owned(ident.version.clone().unwrap()),
-                            release:         Cow::Owned(ident.release.clone().unwrap()),
                             deps:            Cow::Owned(deps),
                             env:             Cow::Owned(env_hash.into()),
                             exposes:         Cow::Owned(vec!["1234".into(),
@@ -704,7 +686,7 @@ two = 2
         svc_member_cfg.insert("foo".into(), "bar".into());
 
         let mut me = default_svc_member();
-        me.pkg = Cow::Owned(ident);
+        me.pkg = Cow::Owned(ident.into());
         me.cfg = Cow::Owned(svc_member_cfg);
 
         let svc = Svc { service_group:          Cow::Owned(group),

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -113,7 +113,9 @@ impl Hook for HealthCheckHook {
 
     fn file_name() -> &'static str { "health-check" }
 
-    fn new(package_name: &str, pair: RenderPair, feature_flags: FeatureFlag) -> Self {
+    fn new(package_name: &str, pair: RenderPair, _feature_flags: FeatureFlag) -> Self {
+        #[cfg(windows)]
+        let feature_flags = _feature_flags;
         let out_path = hooks::stdout_log_path::<Self>(package_name);
         let err_path = hooks::stderr_log_path::<Self>(package_name);
         #[cfg(windows)]

--- a/components/sup/src/manager/service_updater/package_update_worker.rs
+++ b/components/sup/src/manager/service_updater/package_update_worker.rs
@@ -1,7 +1,8 @@
 use crate::{manager::service::Service,
             util};
 use habitat_core::{env,
-                   package::PackageIdent,
+                   package::{FullyQualifiedPackageIdent,
+                             PackageIdent},
                    service::ServiceGroup,
                    ChannelIdent};
 use std::{self,
@@ -43,9 +44,7 @@ impl PackageUpdateWorkerPeriod {
 pub struct PackageUpdateWorker {
     service_group: ServiceGroup,
     ident:         PackageIdent,
-    // TODO (DM): This field should always be fully qualified. We need a
-    // type to encapsulate that.
-    full_ident:    PackageIdent,
+    full_ident:    FullyQualifiedPackageIdent,
     channel:       ChannelIdent,
     builder_url:   String,
 }
@@ -65,8 +64,7 @@ impl PackageUpdateWorker {
     ///
     /// If a fully qualified package ident is used, the future will only resolve when that exact
     /// package is found.
-    // TODO (DM): The returned package ident should always be fully qualified. We need a type to
-    // encapsulate that.
+    // TODO (DM): The returned package ident should use FullyQualifiedPackageIdent.
     pub async fn update_to(&self, install_ident: PackageIdent) -> PackageIdent {
         let install_source = install_ident.clone().into();
         let delay = PackageUpdateWorkerPeriod::get();
@@ -77,7 +75,7 @@ impl PackageUpdateWorker {
             {
                 Ok(package) => {
                     // Only allow updates never rollbacks.
-                    if package.ident > self.full_ident {
+                    if &package.ident > self.full_ident.as_ref() {
                         debug!("'{}' package update worker found change from '{}' to '{}' for \
                                 '{}' in channel '{}'",
                                self.service_group,

--- a/components/sup/src/manager/service_updater/rolling_update_worker.rs
+++ b/components/sup/src/manager/service_updater/rolling_update_worker.rs
@@ -28,8 +28,7 @@ enum Role {
 /// died) or it can be instructed to update to a specific ident.
 enum FollowerWaitForTurn {
     PromotedToLeader,
-    // TODO (DM): This field should always be fully qualified. We need a
-    // type to encapsulate that.
+    // TODO (DM): This should use FullyQualifiedPackageIdent.
     UpdateTo(PackageIdent),
 }
 


### PR DESCRIPTION
There is much more work to be done, but this is the start of using a `FullyQualifiedPackageIdent` type. This PR does two things. Cleanup and add to the existing `FullyQualifiedPackageIdent`, and use `FullyQualifiedPackageIdent` in `Pkg`.

I removed the `Cow` in `FullyQualifiedPackageIdent`. I do not think it was buying us much, but I will certainly add it back if that is what reviewers would prefer.