### PR TITLE
Add flag to ignore missing packages in seed lists

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -1092,6 +1092,8 @@ fn sub_pkg_download() -> App<'static, 'static> {
             "Target architecture to fetch. E.g. x86_64-linux. Overridden if architecture is specified in toml file")
     (@arg VERIFY: --verify
             "Verify package integrity after download (Warning: this can be slow)")
+    (@arg IGNORE_MISSING_SEEDS: --("ignore-missing-seeds")
+            "Ignore packages specified that are not present on the target Builder")
     );
     sub
 }

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -178,9 +178,9 @@ pub enum Pkg {
     /// Download Habitat artifacts (including dependencies and keys) from Builder
     Download {
         #[structopt(flatten)]
-        auth_token:         AuthToken,
+        auth_token:          AuthToken,
         #[structopt(flatten)]
-        bldr_url:           BldrUrl,
+        bldr_url:            BldrUrl,
         /// Download from the specified release channel. Overridden if channel is specified in toml
         /// file
         #[structopt(name = "CHANNEL",
@@ -188,24 +188,27 @@ pub enum Pkg {
                     long = "channel",
                     default_value = "stable",
                     env = ChannelIdent::ENVVAR)]
-        channel:            String,
+        channel:             String,
         /// The path to store downloaded artifacts
         #[structopt(name = "DOWNLOAD_DIRECTORY", long = "download-directory")]
-        download_directory: Option<PathBuf>,
+        download_directory:  Option<PathBuf>,
         /// File with newline separated package identifiers, or TOML file (ending with .toml
         /// extension)
         #[structopt(name = "PKG_IDENT_FILE", long = "file", validator = valid_ident_or_toml_file)]
-        pkg_ident_file:     Vec<String>,
+        pkg_ident_file:      Vec<String>,
         /// One or more Habitat package identifiers (ex: acme/redis)
         #[structopt(name = "PKG_IDENT")]
-        pkg_ident:          Vec<PackageIdent>,
+        pkg_ident:           Vec<PackageIdent>,
         /// Target architecture to fetch. E.g. x86_64-linux. Overridden if architecture is
         /// specified in toml file
         #[structopt(name = "PKG_TARGET", short = "t", long = "target")]
-        pkg_target:         Option<PackageTarget>,
+        pkg_target:          Option<PackageTarget>,
         /// Verify package integrity after download (Warning: this can be slow)
         #[structopt(name = "VERIFY", long = "verify")]
-        verify:             bool,
+        verify:              bool,
+        /// Ignore packages specified that are not present on the target Builder
+        #[structopt(name = "IGNORE_MISSING_SEEDS", long = "ignore-missing-seeds")]
+        ignore_missing_seed: bool,
     },
     /// Prints the runtime environment of a specific installed package
     Env {

--- a/components/hab/src/command/pkg/binlink.rs
+++ b/components/hab/src/command/pkg/binlink.rs
@@ -241,6 +241,7 @@ fn is_dest_on_path(dest_dir: &Path) -> bool {
 }
 
 #[cfg(test)]
+#[cfg(not(target_os = "macos"))]
 mod test {
     use super::{binlink_all_in_pkg,
                 start,

--- a/components/hab/src/command/pkg/download.rs
+++ b/components/hab/src/command/pkg/download.rs
@@ -114,19 +114,21 @@ pub async fn start<U>(ui: &mut U,
                       package_sets: &[PackageSet], // clippy suggestion
                       download_path: Option<&PathBuf>,
                       token: Option<&str>,
-                      verify: bool)
+                      verify: bool,
+                      ignore_missing_seeds: bool)
                       -> Result<()>
     where U: UIWriter
 {
     debug!(
            "Starting download with url: {}, product: {}, version: {}, 
-         download_path: {:?}, token: {:?}, verify: {}, set_count: {}",
+         download_path: {:?}, token: {:?}, verify: {}, ignore_missing_seeds: {}, set_count: {}",
            url,
            product,
            version,
            download_path,
            token,
            verify,
+           ignore_missing_seeds,
            package_sets.len()
     );
 
@@ -155,7 +157,8 @@ pub async fn start<U>(ui: &mut U,
                               api_client,
                               token,
                               download_path: download_path_expanded,
-                              verify };
+                              verify,
+                              ignore_missing_seeds };
 
     let download_count = task.execute(ui).await?;
 
@@ -165,12 +168,13 @@ pub async fn start<U>(ui: &mut U,
 }
 
 struct DownloadTask<'a> {
-    package_sets:  &'a [PackageSet],
-    url:           &'a str,
-    api_client:    BuilderAPIClient,
-    token:         Option<&'a str>,
-    download_path: &'a Path,
-    verify:        bool,
+    package_sets:         &'a [PackageSet],
+    url:                  &'a str,
+    api_client:           BuilderAPIClient,
+    token:                Option<&'a str>,
+    download_path:        &'a Path,
+    verify:               bool,
+    ignore_missing_seeds: bool,
 }
 
 impl<'a> DownloadTask<'a> {
@@ -208,12 +212,14 @@ impl<'a> DownloadTask<'a> {
             ui.begin(format!("Using target {}", package_set.target))?;
 
             for ident in &package_set.idents {
-                let package = self.determine_latest_from_ident(ui,
-                                                               &package_set.channel,
-                                                               package_set.target,
-                                                               &ident)
-                                  .await?;
-                expanded_packages.push((package, package_set.target));
+                if let Some(package) = self.determine_latest_from_ident(ui,
+                                                                        &package_set.channel,
+                                                                        package_set.target,
+                                                                        &ident)
+                                           .await?
+                {
+                    expanded_packages.push((package, package_set.target));
+                }
             }
         }
 
@@ -268,7 +274,7 @@ impl<'a> DownloadTask<'a> {
                                             channel_default: &ChannelIdent,
                                             target: PackageTarget,
                                             ident: &PackageIdent)
-                                            -> Result<Package>
+                                            -> Result<Option<Package>>
         where T: UIWriter
     {
         // Unlike in the install command, we always hit the online depot; our purpose is to sync
@@ -288,7 +294,7 @@ impl<'a> DownloadTask<'a> {
         {
             Ok(latest_package) => {
                 ui.status(Status::Using, format!("{}", latest_package.ident))?;
-                Ok(latest_package)
+                Ok(Some(latest_package))
             }
             Err(Error::APIClient(APIError(StatusCode::NOT_FOUND, _))) => {
                 // In install we attempt to recommend a channel to look in. That's a bit of a
@@ -297,10 +303,14 @@ impl<'a> DownloadTask<'a> {
                 // the stable channel, but for now, error.
                 ui.warn(format!("No packages matching ident {} for {} exist in the '{}' \
                                  channel. Check the package ident, target, channel and Builder \
-                                 url ({}) for correctness",
+                                 url ({}) for correctness.",
                                 ident, target, &channel, self.url))?;
-                Err(CommonError::PackageNotFound(format!("{} for {} in channel {}",
-                                                         ident, target, &channel)).into())
+                if self.ignore_missing_seeds {
+                    Ok(None)
+                } else {
+                    Err(CommonError::PackageNotFound(format!("{} for {} in channel {}",
+                                                             ident, target, &channel)).into())
+                }
             }
             Err(e) => {
                 debug!("Error fetching ident {} for target {}: {:?}",
@@ -361,7 +371,7 @@ impl<'a> DownloadTask<'a> {
                                  ui.progress())
                   .await
         {
-            Ok(_) => Ok(()),
+            k(_) => Ok(()),
             Err(api_client::Error::APIError(StatusCode::NOT_IMPLEMENTED, _)) => {
                 println!("Host platform or architecture not supported by the targeted depot; \
                           skipping.");

--- a/components/hab/src/command/pkg/download.rs
+++ b/components/hab/src/command/pkg/download.rs
@@ -371,7 +371,7 @@ impl<'a> DownloadTask<'a> {
                                  ui.progress())
                   .await
         {
-            k(_) => Ok(()),
+            Ok(_) => Ok(()),
             Err(api_client::Error::APIError(StatusCode::NOT_IMPLEMENTED, _)) => {
                 println!("Host platform or architecture not supported by the targeted depot; \
                           skipping.");

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -661,6 +661,7 @@ async fn sub_pkg_download(ui: &mut UI,
     package_sets.retain(|set| !set.idents.is_empty());
 
     let verify = verify_from_matches(m);
+    let ignore_missing_seeds = ignore_missing_seeds_from_matches(m);
 
     init();
 
@@ -671,7 +672,8 @@ async fn sub_pkg_download(ui: &mut UI,
                                   &package_sets,
                                   download_dir.as_ref(),
                                   token.as_ref().map(String::as_str),
-                                  verify).await?;
+                                  verify,
+                                  ignore_missing_seeds).await?;
     Ok(())
 }
 
@@ -1785,6 +1787,9 @@ fn strings_to_idents(strings: &[String]) -> Result<Vec<PackageIdent>> {
 }
 
 fn verify_from_matches(matches: &ArgMatches<'_>) -> bool { matches.is_present("VERIFY") }
+fn ignore_missing_seeds_from_matches(matches: &ArgMatches<'_>) -> bool {
+    matches.is_present("IGNORE_MISSING_SEEDS")
+}
 
 fn download_dir_from_matches(matches: &ArgMatches<'_>) -> Option<PathBuf> {
     matches.value_of("DOWNLOAD_DIRECTORY").map(PathBuf::from)


### PR DESCRIPTION
Partially addresses #7498 

This adds the ability to optionally ignore failures when a requested seed package is missing, as can occur when using `--channel` and the specified channel doesn't contain all requested packages.  The default behavior of fail-fast is preserved, for use in air-gap sync scenarios. 

```bash
❯ target/debug/hab pkg download --channel nope --target x86_64-linux -- core/rust core/glibc
» Storing in download directory "/Users/smacfarlane/.hab/cache"
☛ Verifying the download directory "/Users/smacfarlane/.hab/cache"
» Resolving dependencies for 2 package idents
» Using channel nope from https://bldr.habitat.sh
» Using target x86_64-linux
☁ Determining latest version of core/rust
Ø No packages matching ident core/rust for x86_64-linux exist in the 'nope' channel. Check the package ident, target, channel and Builder url (https://bldr.habitat.sh) for correctness
✗✗✗
✗✗✗ Package not found. core/rust for x86_64-linux in channel nope
✗✗✗
```

```bash
❯ target/debug/hab pkg download --channel nope --target x86_64-linux --ignore-missing-seeds -- core/rust core/glibc
» Storing in download directory "/Users/smacfarlane/.hab/cache"
☛ Verifying the download directory "/Users/smacfarlane/.hab/cache"
» Resolving dependencies for 2 package idents
» Using channel nope from https://bldr.habitat.sh
» Using target x86_64-linux
☁ Determining latest version of core/rust
Ø No packages matching ident core/rust for x86_64-linux exist in the 'nope' channel. Check the package ident, target, channel and Builder url (https://bldr.habitat.sh) for correctness
☁ Determining latest version of core/glibc
Ø No packages matching ident core/glibc for x86_64-linux exist in the 'nope' channel. Check the package ident, target, channel and Builder url (https://bldr.habitat.sh) for correctness
→ Found 0 artifacts
↓ Downloading Downloading 0 artifacts (and their signing keys)
```

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>