### PR TITLE
Always write out service PID files

### DIFF
--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -225,6 +225,27 @@ function Stop-ComposeSupervisor($Remote) {
     Start-Sleep 5
 }
 
+# Returns the PID of the given service, according to the Supervisor itself.
+#
+# Example:
+#    Get-HabServicePid "core/redis"
+#    > 29602
+#
+# Fails if the Supervisor is not running the service.
+function Get-HabServicePID($PackageName) {
+    # If the package is running, the output of `hab svc status` will look like this:
+    #
+    # package                           type        desired  state  elapsed (s)  pid    group
+    # core/redis/4.0.14/20190319155852  standalone  up       up     7717         29602  redis.default
+    #
+    # We take the last line, and then extract the value from the "pid" column.
+    #
+    # (When https://github.com/habitat-sh/habitat/issues/7525 lands,
+    # we can do this in a more self-documenting way.)
+    (((hab svc status $PackageName)[-1] -split "\s+")[5])
+}
+
+
 ###################################################################################################
 
 Import-Module (Join-Path -Path $(hab pkg path core/pester) module Pester.psd1)

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -144,7 +144,7 @@ lazy_static! {
                                                          nanoseconds").unwrap();
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 /// Determines whether the new pidfile-less behavior is enabled, or
 /// the old behavior is used.
 pub enum ServicePidSource {

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -45,12 +45,22 @@ pub struct Supervisor {
     /// precision is not necessary, but being able to get the seconds
     /// since the UNIX epoch is.
     state_entered: SystemTime,
-    /// If the Supervisor is being run with an newer Launcher that
-    /// can provide service PIDs, this will be `None`, otherwise it
-    /// will be `Some(path)`. Client code should use the `Some`/`None`
-    /// status of this field as an indicator of which mode the
-    /// Supervisor is running in.
-    pid_file:      Option<PathBuf>,
+    /// If the Supervisor is being run with an newer Launcher that can
+    /// provide service PIDs, this will be
+    /// `ServicePidSource::Launcher`; otherwise it will be
+    /// `ServicePidSource::Files`. Client code should use this as an
+    /// indicator of which mode the Supervisor is running in.
+    pid_source:    ServicePidSource,
+    /// Path at which the currently-running PID of this service is
+    /// written to disk.
+    ///
+    /// If `pid_source` is `ServicePidSource::Files`,
+    /// this will be where a restarting Supervisor figures out which
+    /// processes it should continue monitoring.
+    ///
+    /// Regardless of the value of `pid_source`, the current PID will
+    /// always be written to this path, for use by service hooks.
+    pid_file:      PathBuf,
 }
 
 impl Supervisor {
@@ -61,13 +71,11 @@ impl Supervisor {
     /// the older Launchers that can't provide service PIDs, this can
     /// be removed.
     pub fn new(service_group: &ServiceGroup, pid_source: ServicePidSource) -> Supervisor {
-        let pid_file = match pid_source {
-            ServicePidSource::Files => Some(fs::svc_pid_file(service_group.service())),
-            ServicePidSource::Launcher => None,
-        };
+        let pid_file = fs::svc_pid_file(service_group.service());
         Supervisor { service_group: service_group.clone(),
                      state: ProcessState::Down,
                      state_entered: SystemTime::now(),
+                     pid_source,
                      pid: None,
                      pid_file }
     }
@@ -76,8 +84,8 @@ impl Supervisor {
     pub fn check_process(&mut self, launcher: &LauncherCli) -> bool {
         self.pid = self.pid
                        .or_else(|| {
-                           if let Some(ref pid_file) = self.pid_file {
-                               read_pid(pid_file)
+                           if self.pid_source == ServicePidSource::Files {
+                               read_pid(&self.pid_file)
                            } else {
                                match launcher.pid_of(&self.service_group.to_string()) {
                                    Ok(maybe_pid) => maybe_pid,
@@ -101,9 +109,7 @@ impl Supervisor {
             self.change_state(ProcessState::Up);
         } else {
             self.change_state(ProcessState::Down);
-            if let Some(ref pid_file) = self.pid_file {
-                Self::cleanup_pidfile(pid_file.clone());
-            }
+            Self::cleanup_pidfile(self.pid_file.clone());
         }
 
         self.pid.is_some()
@@ -202,10 +208,7 @@ impl Supervisor {
             warn!(target: "pidfile_tracing", "Spawned service for {} has a PID of 0!", group);
         }
         self.pid = Some(pid);
-        // Only create a pidfile if we're actually using them.
-        if let Some(ref pid_file) = self.pid_file {
-            self.create_pidfile(pid_file)?;
-        }
+        self.create_pidfile(&self.pid_file)?;
         self.change_state(ProcessState::Up);
         Ok(())
     }
@@ -230,10 +233,7 @@ impl Supervisor {
                     error!(target: "pidfile_tracing", "Failed to to stop service {}", service_group);
                     };
                 });
-                // Only delete the pidfile if we're actually using one.
-                if let Some(pid_file) = pid_file {
-                    Self::cleanup_pidfile(pid_file);
-                }
+                Self::cleanup_pidfile(pid_file);
             }
         } else {
             // Not quite sure how we'd get down here without a PID...

--- a/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
+++ b/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
@@ -6,13 +6,25 @@ Describe "Service PIDs from Launcher feature" {
     Load-SupervisorService -PackageName "core/redis" -Timeout 20
     Wait-Process redis-server -Timeout 10
 
-    It "should not create PID file" {
-        Test-Path "/hab/svc/redis/PID" | Should -Be $false
+    It "should still create a PID file for use in hooks" {
+        Test-Path "/hab/svc/redis/PID" | Should -Be $true
     }
 
     Context "Supervisor is restarted" {
         $supProc = Get-Process hab-sup
         $redisProc = Get-Process redis-server
+
+        # Write a bogus PID to the file; the Supervisor should not
+        # think this is the actual PID of the service.
+        #
+        # NOTE: This is ONLY to prove, in the context of this test,
+        # that the Supervisor is not getting its idea of the process
+        # PID from the file. The Supervisor does not currently (and
+        # never did) try to keep the contents of the file in sync with
+        # the running service PID on an ongoing basis.
+        $bogusPid = $redisProc.Id + 5
+        $bogusPid | Out-File "/hab/svc/redis/PID"
+
         Restart-Supervisor
         Wait-Process redis-server -Timeout 10
         $newSupProc = Get-Process hab-sup
@@ -23,6 +35,18 @@ Describe "Service PIDs from Launcher feature" {
         }
         It "runs the same redis process" {
             $redisProc.Id | Should -Be $newRedisProc.Id
+        }
+
+        It "should not have gotten the service PID from the PID file" {
+            # The contents of the PID file are still incorrect; the
+            # Supervisor doesn't rewrite it after it restarts (it
+            # would after a full restart, but that would bring up a
+            # new service process anyway)
+            Get-Content "/hab/svc/redis/PID" | Should -Be $bogusPid
+
+            # Despite the bogus PID in the file, the Supervisor itself
+            # knows the correct PID
+            Get-HabServicePID "core/redis" | Should -Be $newRedisProc.Id
         }
     }
 }


### PR DESCRIPTION
Previously in #7214 and then #7341, the Launcher and Supervisor were
modified so that the Launcher itself became the source of truth for
the PIDs of supervised services, rather than the contents of a file on
disk.

While this improves overall Supervisor reliability, a blanket removal
the PID files altogether can break things like `reconfigure` hooks,
which need a way to access a service's PID in order to do things like
send the service signals.

This PR re-introduces PID files for services, but _only_ as a means to
communicate with hooks. The Launcher is still the ultimate source of
the PID itself.

Fixes #7508

Signed-off-by: Christopher Maier <cmaier@chef.io>