### PR TITLE
[CI] Silently continue on errors to remove the Habitat cache

### DIFF
--- a/.expeditor/scripts/release_habitat/build_docker_image.ps1
+++ b/.expeditor/scripts/release_habitat/build_docker_image.ps1
@@ -60,8 +60,10 @@ try {
         Write-Error "core/hab-studio must be installed, aborting"
     }
 
+    # We do this to ensure that these artifacts don't erroneously end
+    # up in the image!
     Write-Host "Purging container hab cache"
-    Remove-Item "$env:FS_ROOT/hab/cache" -Recurse -Force
+    Remove-Item "$env:FS_ROOT/hab/cache" -Recurse -Force -ErrorAction SilentlyContinue
 
     $pathParts = $studioPath.Replace("\", "/").Split("/")
     $ident = [String]::Join("/", $pathParts[-4..-1])


### PR DESCRIPTION
It appears that a change to Powershell 7 in our build workers
necessitates this change (at the very least, anyway).

Signed-off-by: Christopher Maier <cmaier@chef.io>