### PR TITLE
Miscellaneous Butterfly timing refactorings

### DIFF
--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -22,9 +22,8 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
     loop {
         liveliness_checker::mark_thread_alive().and_divergent();
 
-        let newly_confirmed_members =
-            server.member_list
-                  .members_expired_to_confirmed_mlw(timing.suspicion_timeout_duration());
+        let newly_confirmed_members = server.member_list
+                                            .members_expired_to_confirmed_mlw(timing.confirm());
 
         for id in newly_confirmed_members {
             server.rumor_heat

--- a/components/butterfly/src/server/expire.rs
+++ b/components/butterfly/src/server/expire.rs
@@ -31,9 +31,8 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                   .start_hot_rumor(RumorKey::new(RumorType::Member, &id, ""));
         }
 
-        let newly_departed_members =
-            server.member_list
-                  .members_expired_to_departed_mlw(timing.departure_timeout_duration());
+        let newly_departed_members = server.member_list
+                                           .members_expired_to_departed_mlw(timing.departure());
 
         for id in newly_departed_members {
             server.rumor_heat.lock_rhw().purge(&id);

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -75,14 +75,14 @@ pub fn spawn_thread(name: String,
                           .map(|_| ())
 }
 
-/// Run the outbound thread. Gets a list of members to ping, then walks the list, probing each
-/// member.
+/// Run the outbound thread. Gets a list of members to ping, then
+/// walks the list, probing each member.
 ///
-/// If the probe completes before the next protocol period is scheduled, waits for the protocol
-/// period to finish before starting the next probe.
+/// If the probe completes within the time allotted for a single round
+/// of SWIM probing, we wait for the remainder of the probe interval
+/// before starting the next probe.
 fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timing: &Timing) -> ! {
     let mut have_members = false;
-    let protocol_period = timing.protocol_period();
     loop {
         liveliness_checker::mark_thread_alive().and_divergent();
 
@@ -114,29 +114,33 @@ fn run_loop(server: &Server, socket: &UdpSocket, rx_inbound: &AckReceiver, timin
 
         server.update_swim_round();
 
-        let probe_iteration_start = Instant::now();
-
         let check_list = server.member_list.check_list_mlr(&server.member_id);
 
+        let probe_iteration_start = Instant::now();
         for member in check_list {
             if server.member_list.pingable_mlr(&member) {
                 // If we complete the probe faster than our protocol
                 // period, we'll want to wait after we finish.
-                let protocol_period_start_time = Instant::now();
-
+                let probe_start = Instant::now();
                 probe_mlw_smr_rhw(&server, &socket, &rx_inbound, &timing, member);
-
-                if let Some(wait_time) =
-                    protocol_period.checked_sub(protocol_period_start_time.elapsed())
-                {
-                    thread::sleep(wait_time);
-                }
+                timing.sleep_for_remaining_swim_protocol_interval(probe_start);
             }
         }
 
-        if let Some(wait_time) = protocol_period.checked_sub(probe_iteration_start.elapsed()) {
-            thread::sleep(wait_time);
-        }
+        // This will only come into play if:
+        //
+        //   * there was nothing in `check_list`
+        //   * nothing in `check_list` was pingable,
+        //
+        // Basically, if we were able to probe *anything* in the loop,
+        // we would have already waited for at least this long, so
+        // this sleep would then be meaningless and would effectively
+        // be skipped.
+        //
+        // This sleep basically ensures that each probe cycle is
+        // approximately evenly spaced. Were this to be refactored to
+        // something like futures, it might not be required anymore.
+        timing.sleep_for_remaining_swim_protocol_interval(probe_iteration_start);
     }
 }
 

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -102,8 +102,9 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
             }
             let num_threads = thread_list.len();
             for guard in thread_list.drain(0..num_threads) {
-                let _ = guard.join()
-                             .map_err(|e| error!("Push worker died: {:?}", e));
+                if let Err(e) = guard.join() {
+                    error!("Push worker died: {:?}", e);
+                }
             }
             // If we've still got any time left in the gossip period, sleep
             // for that long.

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -65,11 +65,7 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
             if check_list.is_empty() {
                 break 'fanout;
             }
-            let drain_length = if check_list.len() >= FANOUT {
-                FANOUT
-            } else {
-                check_list.len()
-            };
+            let drain_length = check_list.len().min(FANOUT);
             let gossip_start_time = Instant::now();
             for member in check_list.drain(0..drain_length) {
                 if server.is_member_blocked_sblr(&member.id) {

--- a/components/butterfly/src/server/push.rs
+++ b/components/butterfly/src/server/push.rs
@@ -100,8 +100,7 @@ fn run_loop(server: &Server, timing: &Timing) -> ! {
                     }
                 }
             }
-            let num_threads = thread_list.len();
-            for guard in thread_list.drain(0..num_threads) {
+            for guard in thread_list {
                 if let Err(e) = guard.join() {
                     error!("Push worker died: {:?}", e);
                 }

--- a/components/butterfly/src/server/timing.rs
+++ b/components/butterfly/src/server/timing.rs
@@ -17,11 +17,11 @@ const DEPARTURE_TIMEOUT_DEFAULT_MS: u64 = 259_200_000;
 /// The timing of the outbound threads.
 #[derive(Debug, Clone)]
 pub struct Timing {
-    ping:                 Duration,
-    pingreq:              Duration,
-    confirm:              Duration,
-    gossip_interval_ms:   u64,
-    departure_timeout_ms: u64,
+    ping:               Duration,
+    pingreq:            Duration,
+    confirm:            Duration,
+    departure:          Duration,
+    gossip_interval_ms: u64,
 
     swim_probe_interval: Duration,
 }
@@ -31,12 +31,12 @@ impl Default for Timing {
         let swim_interval_ms = PING_TIMING_DEFAULT_MS + PINGREQ_TIMING_DEFAULT_MS;
         let confirm_ms = swim_interval_ms * SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS;
 
-        Timing { ping:                 Duration::from_millis(PING_TIMING_DEFAULT_MS),
-                 pingreq:              Duration::from_millis(PINGREQ_TIMING_DEFAULT_MS),
-                 confirm:              Duration::from_millis(confirm_ms),
-                 gossip_interval_ms:   GOSSIP_INTERVAL_DEFAULT_MS,
-                 departure_timeout_ms: DEPARTURE_TIMEOUT_DEFAULT_MS,
-                 swim_probe_interval:  Duration::from_millis(swim_interval_ms), }
+        Timing { ping:                Duration::from_millis(PING_TIMING_DEFAULT_MS),
+                 pingreq:             Duration::from_millis(PINGREQ_TIMING_DEFAULT_MS),
+                 confirm:             Duration::from_millis(confirm_ms),
+                 departure:           Duration::from_millis(DEPARTURE_TIMEOUT_DEFAULT_MS),
+                 gossip_interval_ms:  GOSSIP_INTERVAL_DEFAULT_MS,
+                 swim_probe_interval: Duration::from_millis(swim_interval_ms), }
     }
 }
 
@@ -54,6 +54,10 @@ impl Timing {
     /// consider it confirmed.
     pub fn confirm(&self) -> Duration { self.confirm }
 
+    /// How long after not hearing from a confirmed member before we
+    /// consider it departed.
+    pub fn departure(&self) -> Duration { self.departure }
+
     /// If the amount of time since `starting_point` is less than a
     /// gossip interval, sleep for the remainder of that gossip interval.
     pub fn sleep_for_remaining_gossip_interval(&self, starting_point: Instant) {
@@ -65,10 +69,6 @@ impl Timing {
     /// interval.
     pub fn sleep_for_remaining_swim_protocol_interval(&self, starting_point: Instant) {
         maybe_sleep(starting_point, self.swim_probe_interval)
-    }
-
-    pub fn departure_timeout_duration(&self) -> Duration {
-        Duration::from_millis(self.departure_timeout_ms)
     }
 }
 

--- a/components/butterfly/src/server/timing.rs
+++ b/components/butterfly/src/server/timing.rs
@@ -17,7 +17,7 @@ const DEPARTURE_TIMEOUT_DEFAULT_MS: u64 = 259_200_000;
 /// The timing of the outbound threads.
 #[derive(Debug, Clone)]
 pub struct Timing {
-    ping_ms: u64,
+    ping: Duration,
     pingreq_ms: u64,
     gossip_interval_ms: u64,
     suspicion_timeout_protocol_periods: u64,
@@ -26,7 +26,7 @@ pub struct Timing {
 
 impl Default for Timing {
     fn default() -> Timing {
-        Timing { ping_ms: PING_TIMING_DEFAULT_MS,
+        Timing { ping: Duration::from_millis(PING_TIMING_DEFAULT_MS),
                  pingreq_ms: PINGREQ_TIMING_DEFAULT_MS,
                  gossip_interval_ms: GOSSIP_INTERVAL_DEFAULT_MS,
                  suspicion_timeout_protocol_periods: SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS,
@@ -39,17 +39,17 @@ impl Timing {
     fn gossip_interval(&self) -> Duration { Duration::from_millis(self.gossip_interval_ms) }
 
     /// How long is a protocol period, in millis.
-    pub fn protocol_period_ms(&self) -> u64 { self.ping_ms + self.pingreq_ms }
+    pub fn protocol_period_ms(&self) -> u64 { PING_TIMING_DEFAULT_MS + self.pingreq_ms }
 
     /// How long a ping has to timeout.
-    pub fn ping(&self) -> Duration { Duration::from_millis(self.ping_ms) }
+    pub fn ping(&self) -> Duration { self.ping }
 
     /// How long a pingreq has to timeout.
     pub fn pingreq(&self) -> Duration { Duration::from_millis(self.pingreq_ms) }
 
     /// How long to space out individual SWIM probe rounds
     fn swim_probe_interval(&self) -> Duration {
-        Duration::from_millis(self.ping_ms + self.pingreq_ms)
+        Duration::from_millis(PING_TIMING_DEFAULT_MS + self.pingreq_ms)
     }
 
     /// If the amount of time since `starting_point` is less than a

--- a/components/butterfly/src/server/timing.rs
+++ b/components/butterfly/src/server/timing.rs
@@ -1,4 +1,6 @@
-use std::time::Duration;
+use std::{thread,
+          time::{Duration,
+                 Instant}};
 
 /// How long to wait for an Ack after we ping
 const PING_TIMING_DEFAULT_MS: u64 = 1000;
@@ -6,8 +8,8 @@ const PING_TIMING_DEFAULT_MS: u64 = 1000;
 const PINGREQ_TIMING_DEFAULT_MS: u64 = 2100;
 /// How many protocol periods before a suspect member is marked as confirmed.
 const SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS: u64 = 3;
-/// How long is the gossip period
-const GOSSIP_PERIOD_DEFAULT_MS: u64 = 1000;
+/// How long to wait between each time we send rumors out.
+const GOSSIP_INTERVAL_DEFAULT_MS: u64 = 1000;
 /// How long before we set a confirmed member to a departed member, removing them from quorums
 ///   just for your own sanity - this is 3 days.
 const DEPARTURE_TIMEOUT_DEFAULT_MS: u64 = 259_200_000;
@@ -17,7 +19,7 @@ const DEPARTURE_TIMEOUT_DEFAULT_MS: u64 = 259_200_000;
 pub struct Timing {
     ping_ms: u64,
     pingreq_ms: u64,
-    gossip_period_ms: u64,
+    gossip_interval_ms: u64,
     suspicion_timeout_protocol_periods: u64,
     departure_timeout_ms: u64,
 }
@@ -26,7 +28,7 @@ impl Default for Timing {
     fn default() -> Timing {
         Timing { ping_ms: PING_TIMING_DEFAULT_MS,
                  pingreq_ms: PINGREQ_TIMING_DEFAULT_MS,
-                 gossip_period_ms: GOSSIP_PERIOD_DEFAULT_MS,
+                 gossip_interval_ms: GOSSIP_INTERVAL_DEFAULT_MS,
                  suspicion_timeout_protocol_periods: SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS,
                  departure_timeout_ms: DEPARTURE_TIMEOUT_DEFAULT_MS, }
     }
@@ -34,7 +36,7 @@ impl Default for Timing {
 
 impl Timing {
     /// How long a gossip period should last.
-    pub fn gossip_period(&self) -> Duration { Duration::from_millis(self.gossip_period_ms) }
+    fn gossip_interval(&self) -> Duration { Duration::from_millis(self.gossip_interval_ms) }
 
     /// How long is a protocol period, in millis.
     pub fn protocol_period_ms(&self) -> u64 { self.ping_ms + self.pingreq_ms }
@@ -45,9 +47,15 @@ impl Timing {
     /// How long a pingreq has to timeout.
     pub fn pingreq(&self) -> Duration { Duration::from_millis(self.pingreq_ms) }
 
-    /// How long before the next scheduled protocol period
-    pub fn protocol_period(&self) -> Duration {
+    /// How long to space out individual SWIM probe rounds
+    fn swim_probe_interval(&self) -> Duration {
         Duration::from_millis(self.ping_ms + self.pingreq_ms)
+    }
+
+    /// If the amount of time since `starting_point` is less than a
+    /// gossip interval, sleep for the remainder of that gossip interval.
+    pub fn sleep_for_remaining_gossip_interval(&self, starting_point: Instant) {
+        maybe_sleep(starting_point, self.gossip_interval())
     }
 
     /// How long before this suspect entry times out
@@ -55,7 +63,22 @@ impl Timing {
         Duration::from_millis(self.protocol_period_ms() * self.suspicion_timeout_protocol_periods)
     }
 
+    /// If the amount of time since `starting_point` is less than a
+    /// SWIM protocol probe interval, sleep for the remainder of that
+    /// interval.
+    pub fn sleep_for_remaining_swim_protocol_interval(&self, starting_point: Instant) {
+        maybe_sleep(starting_point, self.swim_probe_interval())
+    }
+
     pub fn departure_timeout_duration(&self) -> Duration {
         Duration::from_millis(self.departure_timeout_ms)
+    }
+}
+
+/// If the amount of time elapsed from `start` is less than `timeout`,
+/// sleep for the difference.
+fn maybe_sleep(start: Instant, timeout: Duration) {
+    if let Some(amount) = timeout.checked_sub(start.elapsed()) {
+        thread::sleep(amount)
     }
 }

--- a/components/butterfly/src/server/timing.rs
+++ b/components/butterfly/src/server/timing.rs
@@ -14,15 +14,16 @@ const GOSSIP_INTERVAL_DEFAULT_MS: u64 = 1000;
 ///   just for your own sanity - this is 3 days.
 const DEPARTURE_TIMEOUT_DEFAULT_MS: u64 = 259_200_000;
 
-/// The timing of the outbound threads.
+/// Collects important timing durations and timekeeping activities for
+/// the underlying gossip protocols.
 #[derive(Debug, Clone)]
 pub struct Timing {
-    ping:               Duration,
-    pingreq:            Duration,
-    confirm:            Duration,
-    departure:          Duration,
-    gossip_interval_ms: u64,
+    ping:      Duration,
+    pingreq:   Duration,
+    confirm:   Duration,
+    departure: Duration,
 
+    gossip_interval:     Duration,
     swim_probe_interval: Duration,
 }
 
@@ -35,15 +36,12 @@ impl Default for Timing {
                  pingreq:             Duration::from_millis(PINGREQ_TIMING_DEFAULT_MS),
                  confirm:             Duration::from_millis(confirm_ms),
                  departure:           Duration::from_millis(DEPARTURE_TIMEOUT_DEFAULT_MS),
-                 gossip_interval_ms:  GOSSIP_INTERVAL_DEFAULT_MS,
+                 gossip_interval:     Duration::from_millis(GOSSIP_INTERVAL_DEFAULT_MS),
                  swim_probe_interval: Duration::from_millis(swim_interval_ms), }
     }
 }
 
 impl Timing {
-    /// How long a gossip period should last.
-    fn gossip_interval(&self) -> Duration { Duration::from_millis(self.gossip_interval_ms) }
-
     /// How long a ping has to timeout.
     pub fn ping(&self) -> Duration { self.ping }
 
@@ -61,7 +59,7 @@ impl Timing {
     /// If the amount of time since `starting_point` is less than a
     /// gossip interval, sleep for the remainder of that gossip interval.
     pub fn sleep_for_remaining_gossip_interval(&self, starting_point: Instant) {
-        maybe_sleep(starting_point, self.gossip_interval())
+        maybe_sleep(starting_point, self.gossip_interval)
     }
 
     /// If the amount of time since `starting_point` is less than a

--- a/components/butterfly/src/server/timing.rs
+++ b/components/butterfly/src/server/timing.rs
@@ -22,15 +22,20 @@ pub struct Timing {
     gossip_interval_ms: u64,
     suspicion_timeout_protocol_periods: u64,
     departure_timeout_ms: u64,
+
+    swim_probe_interval: Duration,
 }
 
 impl Default for Timing {
     fn default() -> Timing {
+        let swim_interval_ms = PING_TIMING_DEFAULT_MS + PINGREQ_TIMING_DEFAULT_MS;
+
         Timing { ping: Duration::from_millis(PING_TIMING_DEFAULT_MS),
                  pingreq: Duration::from_millis(PINGREQ_TIMING_DEFAULT_MS),
                  gossip_interval_ms: GOSSIP_INTERVAL_DEFAULT_MS,
                  suspicion_timeout_protocol_periods: SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS,
-                 departure_timeout_ms: DEPARTURE_TIMEOUT_DEFAULT_MS, }
+                 departure_timeout_ms: DEPARTURE_TIMEOUT_DEFAULT_MS,
+                 swim_probe_interval: Duration::from_millis(swim_interval_ms), }
     }
 }
 
@@ -47,11 +52,6 @@ impl Timing {
     /// How long a pingreq has to timeout.
     pub fn pingreq(&self) -> Duration { self.pingreq }
 
-    /// How long to space out individual SWIM probe rounds
-    fn swim_probe_interval(&self) -> Duration {
-        Duration::from_millis(PING_TIMING_DEFAULT_MS + PINGREQ_TIMING_DEFAULT_MS)
-    }
-
     /// If the amount of time since `starting_point` is less than a
     /// gossip interval, sleep for the remainder of that gossip interval.
     pub fn sleep_for_remaining_gossip_interval(&self, starting_point: Instant) {
@@ -67,7 +67,7 @@ impl Timing {
     /// SWIM protocol probe interval, sleep for the remainder of that
     /// interval.
     pub fn sleep_for_remaining_swim_protocol_interval(&self, starting_point: Instant) {
-        maybe_sleep(starting_point, self.swim_probe_interval())
+        maybe_sleep(starting_point, self.swim_probe_interval)
     }
 
     pub fn departure_timeout_duration(&self) -> Duration {

--- a/components/butterfly/src/server/timing.rs
+++ b/components/butterfly/src/server/timing.rs
@@ -18,7 +18,7 @@ const DEPARTURE_TIMEOUT_DEFAULT_MS: u64 = 259_200_000;
 #[derive(Debug, Clone)]
 pub struct Timing {
     ping: Duration,
-    pingreq_ms: u64,
+    pingreq: Duration,
     gossip_interval_ms: u64,
     suspicion_timeout_protocol_periods: u64,
     departure_timeout_ms: u64,
@@ -27,7 +27,7 @@ pub struct Timing {
 impl Default for Timing {
     fn default() -> Timing {
         Timing { ping: Duration::from_millis(PING_TIMING_DEFAULT_MS),
-                 pingreq_ms: PINGREQ_TIMING_DEFAULT_MS,
+                 pingreq: Duration::from_millis(PINGREQ_TIMING_DEFAULT_MS),
                  gossip_interval_ms: GOSSIP_INTERVAL_DEFAULT_MS,
                  suspicion_timeout_protocol_periods: SUSPICION_TIMEOUT_DEFAULT_PROTOCOL_PERIODS,
                  departure_timeout_ms: DEPARTURE_TIMEOUT_DEFAULT_MS, }
@@ -39,17 +39,17 @@ impl Timing {
     fn gossip_interval(&self) -> Duration { Duration::from_millis(self.gossip_interval_ms) }
 
     /// How long is a protocol period, in millis.
-    pub fn protocol_period_ms(&self) -> u64 { PING_TIMING_DEFAULT_MS + self.pingreq_ms }
+    pub fn protocol_period_ms(&self) -> u64 { PING_TIMING_DEFAULT_MS + PINGREQ_TIMING_DEFAULT_MS }
 
     /// How long a ping has to timeout.
     pub fn ping(&self) -> Duration { self.ping }
 
     /// How long a pingreq has to timeout.
-    pub fn pingreq(&self) -> Duration { Duration::from_millis(self.pingreq_ms) }
+    pub fn pingreq(&self) -> Duration { self.pingreq }
 
     /// How long to space out individual SWIM probe rounds
     fn swim_probe_interval(&self) -> Duration {
-        Duration::from_millis(PING_TIMING_DEFAULT_MS + self.pingreq_ms)
+        Duration::from_millis(PING_TIMING_DEFAULT_MS + PINGREQ_TIMING_DEFAULT_MS)
     }
 
     /// If the amount of time since `starting_point` is less than a


### PR DESCRIPTION
These are some refactorings I came across in the course of https://github.com/habitat-sh/habitat/pull/7533, but held back in the interests of getting that PR merged more quickly.

In addition to a few relatively minor tweaks to some code in the Butterfly `push` thread, there is a more interesting abstraction of the repeated sleeping logic in the `push` and `outbound` threads, as requested here: https://github.com/habitat-sh/habitat/pull/7533#discussion_r389770630. Finally, an extensive refactoring of the `Timing` struct is broken up over the final six commits for ease of review.

The goal of all of these is overall simplification and clarification of the code.