### PR TITLE
Readable Cached Artifacts

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -1,13 +1,6 @@
 use crate::{allow_std_io::AllowStdIo,
             error::{Error,
                     Result},
-            hab_core::{crypto::keys::box_key_pair::WrappedSealedBox,
-                       fs::AtomicWriter,
-                       package::{Identifiable,
-                                 PackageArchive,
-                                 PackageIdent,
-                                 PackageTarget},
-                       ChannelIdent},
             hab_http::ApiClient,
             response,
             BuildOnUpload,
@@ -23,6 +16,13 @@ use crate::{allow_std_io::AllowStdIo,
 use broadcast::BroadcastWriter;
 use bytes::BytesMut;
 use futures::stream::TryStreamExt;
+use habitat_core::{crypto::keys::box_key_pair::WrappedSealedBox,
+                   fs::AtomicWriter,
+                   package::{Identifiable,
+                             PackageArchive,
+                             PackageIdent,
+                             PackageTarget},
+                   ChannelIdent};
 use percent_encoding::{percent_encode,
                        AsciiSet,
                        CONTROLS};

--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -189,11 +189,7 @@ impl BuilderAPIClient {
         fs::create_dir_all(&dst_path)?;
         let file_name = response::get_header(&resp, X_FILENAME)?;
         let dst_file_path = dst_path.join(file_name);
-        let w = {
-            let mut w = AtomicWriter::new(&dst_file_path)?;
-            w.with_permissions(permissions);
-            w
-        };
+        let w = AtomicWriter::new_with_permissions(&dst_file_path, permissions)?;
         let content_length = response::get_header(&resp, CONTENT_LENGTH);
         let mut body = Cursor::new(resp.bytes().await?);
         // Blocking IO is used because of `DisplayProgress` which relies on the `Write` trait.

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -34,6 +34,8 @@ use crate::{api_client::{self,
                  UIWriter},
             FeatureFlag};
 use glob;
+#[cfg(not(windows))]
+use habitat_core::fs::DEFAULT_CACHED_ARTIFACT_PERMISSIONS;
 use habitat_core::{self,
                    crypto::{artifact,
                             keys::parse_name_with_rev,
@@ -931,7 +933,10 @@ impl<'a> InstallTask<'a> {
             debug!("copying artifact to cache, artifact_path={}, cached_path={}",
                    artifact_path.display(),
                    cache_path.display());
-            let w = AtomicWriter::new(&cache_path)?;
+            let mut w = AtomicWriter::new(&cache_path)?;
+            if cfg!(not(target_os = "windows")) {
+                w.with_permissions(DEFAULT_CACHED_ARTIFACT_PERMISSIONS);
+            }
             w.with_writer(|mut w| {
                  let mut f = File::open(artifact_path)?;
                  io::copy(&mut f, &mut w)

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -34,8 +34,6 @@ use crate::{api_client::{self,
                  UIWriter},
             FeatureFlag};
 use glob;
-#[cfg(not(windows))]
-use habitat_core::fs::DEFAULT_CACHED_ARTIFACT_PERMISSIONS;
 use habitat_core::{self,
                    crypto::{artifact,
                             keys::parse_name_with_rev,
@@ -43,7 +41,8 @@ use habitat_core::{self,
                    fs::{cache_key_path,
                         pkg_install_path,
                         svc_hooks_path,
-                        AtomicWriter},
+                        AtomicWriter,
+                        DEFAULT_CACHED_ARTIFACT_PERMISSIONS},
                    os::users,
                    package::{list::temp_package_directory,
                              FullyQualifiedPackageIdent,
@@ -934,9 +933,8 @@ impl<'a> InstallTask<'a> {
                    artifact_path.display(),
                    cache_path.display());
             let mut w = AtomicWriter::new(&cache_path)?;
-            if cfg!(not(target_os = "windows")) {
-                w.with_permissions(DEFAULT_CACHED_ARTIFACT_PERMISSIONS);
-            }
+            w.with_permissions(DEFAULT_CACHED_ARTIFACT_PERMISSIONS);
+
             w.with_writer(|mut w| {
                  let mut f = File::open(artifact_path)?;
                  io::copy(&mut f, &mut w)

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -932,9 +932,8 @@ impl<'a> InstallTask<'a> {
             debug!("copying artifact to cache, artifact_path={}, cached_path={}",
                    artifact_path.display(),
                    cache_path.display());
-            let mut w = AtomicWriter::new(&cache_path)?;
-            w.with_permissions(DEFAULT_CACHED_ARTIFACT_PERMISSIONS);
-
+            let w = AtomicWriter::new_with_permissions(&cache_path,
+                                                       DEFAULT_CACHED_ARTIFACT_PERMISSIONS)?;
             w.with_writer(|mut w| {
                  let mut f = File::open(artifact_path)?;
                  io::copy(&mut f, &mut w)

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -57,6 +57,10 @@ pub const USER_CONFIG_FILE: &str = "user.toml";
 /// have. The user and group will be `SVC_USER` / `SVC_GROUP`.
 #[cfg(not(windows))]
 const SVC_DIR_PERMISSIONS: u32 = 0o770;
+/// Permissions applied to artifacts that are brought into the
+/// artifact cache directory (i.e., CACHE_ARTIFACT_PATH)
+#[cfg(not(windows))]
+pub const DEFAULT_CACHED_ARTIFACT_PERMISSIONS: u32 = 0o644;
 
 lazy_static::lazy_static! {
     /// The default filesystem root path.

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -265,8 +265,7 @@ impl Supervisor {
                 // parent directory. In this case, the parent directory should
                 // already allow broad reading of the PID file.
                 const PIDFILE_PERMISSIONS: u32 = 0o644;
-                let mut w = fs::AtomicWriter::new(pid_file)?;
-                w.with_permissions(fs::Permissions::Explicit(PIDFILE_PERMISSIONS));
+                let w = fs::AtomicWriter::new_with_permissions(pid_file, fs::Permissions::Explicit(PIDFILE_PERMISSIONS))?;
                 w.with_writer(|f| f.write_all(pid.to_string().as_ref()))?;
             }
         }

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -25,11 +25,10 @@ use habitat_launcher_client::LauncherCli;
 use serde::{ser::SerializeStruct,
             Serialize,
             Serializer};
-#[cfg(not(windows))]
-use std::io::Write;
 use std::{fs::File,
           io::{BufRead,
-               BufReader},
+               BufReader,
+               Write},
           path::{Path,
                  PathBuf},
           result,

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -266,7 +266,7 @@ impl Supervisor {
                 // already allow broad reading of the PID file.
                 const PIDFILE_PERMISSIONS: u32 = 0o644;
                 let mut w = fs::AtomicWriter::new(pid_file)?;
-                w.with_permissions(PIDFILE_PERMISSIONS);
+                w.with_permissions(fs::Permissions::Explicit(PIDFILE_PERMISSIONS));
                 w.with_writer(|f| f.write_all(pid.to_string().as_ref()))?;
             }
         }


### PR DESCRIPTION
This addresses #6298, building off the work @stevendanna did in #7489. In particular, it ensures that installing packages yields cached artifacts that are world readable, rather than only readable by root, on Unix systems.

It introduces `habitat_core::fs::Permissions`, a new `Option`-like type abstraction over platform-specific permission representations and makes the setting of these permissions explicit in function type signatures. Though the `download` function in our API client is used to download multiple things from Builder, this change only affects package artifacts; permissions for public and private origin keys, as well as public origin encryption keys, are _not_ manipulated at all. 

Note that these permission changes apply to _all_ artifacts that are downloaded, regardless of where they are downloaded to, or by whom.

This new `Permissions` type is now used by `AtomicWriter`, and (by extension) everything that calls it. It may prove useful for other permission-related operations elsewhere in the codebase, but that work is not attempted here.

Fixes #6298