### PR TITLE
fix powershell builds when giving a path not ending in a slash

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -1549,12 +1549,12 @@ $targetPaths = @()
 $paths = @()
 $finalPaths = @()
 $candidateTargetPaths = @(
-    "${PLAN_CONTEXT}$pkg_target\plan.ps1",
-    "${PLAN_CONTEXT}habitat\$pkg_target\plan.ps1"
+    (Resolve-RootedPath "$PLAN_CONTEXT\$pkg_target\plan.ps1"),
+    (Resolve-RootedPath "$PLAN_CONTEXT\habitat\$pkg_target\plan.ps1")
 )
 $candidatePaths = @(
-    "${PLAN_CONTEXT}plan.ps1",
-    "${PLAN_CONTEXT}habitat\plan.ps1"
+    (Resolve-RootedPath "$PLAN_CONTEXT\plan.ps1"),
+    (Resolve-RootedPath "$PLAN_CONTEXT\habitat\plan.ps1")
 )
 
 # Lets notate all of the existing plan paths


### PR DESCRIPTION
This fixes a recently introduced bug when the path being built does not end in a slash. `PLAN_CONTEXT` may or may not end in a slash. If we add a slash to the end we might end up with a double shash. Using `Resolve-RootedPatrh` will remove any such double slashes.

Signed-off-by: mwrock <matt@mattwrock.com>