### PR TITLE
Create nightly pipeline

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -39,6 +39,8 @@ pipelines:
       description: Habitat long running end to end tests - always runs on DEV environment
   - finish_release:
       description: Tasks to be performed after a release has been promoted to stable
+  - nightly:
+      description: Nightly builds of our packages - runs against acceptance
 
 staging_areas:
   - release_staging:

--- a/.expeditor/nightly.pipeline.yml
+++ b/.expeditor/nightly.pipeline.yml
@@ -1,0 +1,28 @@
+expeditor:
+  secrets:
+    PIPELINE_HAB_AUTH_TOKEN:
+      path: account/static/habitat/chef-ci
+      field: acceptance_auth_token # Acceptance Builder
+      # auth_token = production
+  accounts:
+    - aws/chef-cd
+  defaults:
+    buildkite:
+      timeout_in_minutes: 30
+      env:
+        HAB_ORIGIN: "core"
+        PIPELINE_HAB_BLDR_URL: "https://bldr.acceptance.habitat.sh"
+
+steps:
+#######################################################################
+# Sync!
+#######################################################################
+  - label: "[:habicat: Sync packages to acceptance]"
+    command: 
+    #- .expeditor/scripts/nightly/sync_live_packages.sh 
+      - echo "Hello!"
+    executor:
+      docker:
+        environment:
+          BLDR_SOURCE_CHANNEL="refresh-2020q1-006b"
+  


### PR DESCRIPTION
This creates a pipeline for actions we wish to run nightly.

The first use case is to sync packages from live to acceptance, to ensure channel consistency between the two builder instances.

The second use case is to produce a nightly build of our packages. This may not be useful, as unlike other projects, we always build all packages on a PR, rather than only things that changed.  It may make sense to split this into an `ad-hoc` pipeline that can be triggered by external events to build and test, but not cause a release to go out.

The third use case is to produce builds of our packages against the upcoming refresh of core-plans for testing purposes. This is a temporary use case, and also fits more in line with the `ad-hoc` or triggered pipeline.

** Questions ** 
Is the nightly sync of the core origin to acceptance valuable? 
Is it worth producing nightly builds?
Does it make sense to split builds into an 'ad-hoc' pipeline?

I'm inclined to let it all be a single nightly pipeline for now, and if we find that the nightly builds aren't valuable,  but ad-hoc builds are, we can adjust later.



Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>