### PR TITLE
Fix rolling update when using track-channel update condition

### DIFF
--- a/test/end-to-end/multi-supervisor/testcases/rolling_update/run_test.ps1
+++ b/test/end-to-end/multi-supervisor/testcases/rolling_update/run_test.ps1
@@ -34,7 +34,7 @@ Describe "Rolling Update and Rollback" {
 
         @("alpha", "beta") | ForEach-Object {
             It "rollback release on $_" {
-                Wait-Release -Ident $initalRelease -Remote $_
+                Wait-Release -Ident $initialRelease -Remote $_
             }
         }
     }


### PR DESCRIPTION
This PR fixes service updates in the case of using `--strategy=rolling` and `--update-condition=track-channel`.

When service rollback was not allowed, we were able to compare leader and follower packages to determine where we were in the rolling update process. Now that we allow services to rollback we can no longer use this strategy. There are two components to the fix:

1. Track exactly what version we are updating to and make comparisons against that.
2. Uninstall all later versions of a package than the package we are updating to. It used to be we only did this when using the `track-channel` update condition. However, to avoid scenario 2 detailed in #7160 we need to do this regardless of update condition.

There are substantial changes to `rolling_update_worker.rs`. As part of this change, I tried to add comments explaining how the rolling update works. I would be happy to walk through the logic of `rolling_update_worker.rs` for any reviewers interested.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>