### PR TITLE
 fix failing test where windows and linux expect different error codes

### DIFF
--- a/test/end-to-end/test_studio_can_build_packages.ps1
+++ b/test/end-to-end/test_studio_can_build_packages.ps1
@@ -19,12 +19,12 @@ Describe "Studio build" {
 
     It "does not build plan-in-root-and-habitat" {
         hab pkg build test/fixtures/plan-in-root-and-habitat
-        $LASTEXITCODE | Should -Be 1
+        $LASTEXITCODE | Should -Not -Be 0
     }
 
     It "does not build plan-in-none" {
         hab pkg build test/fixtures/plan-in-none
-        $LASTEXITCODE | Should -Be 1
+        $LASTEXITCODE | Should -Not -Be 0
     }
 
     It "builds plan in target if also in root" {


### PR DESCRIPTION
Linux and Windows retrurn different exit codes on failure. This fixes the e2e test on linux and also works on windows by simply checking for a non 0 value.

One can argue that we should return the same exit codes on both platforms but I would like to defer that to a separate PR.

Signed-off-by: mwrock <matt@mattwrock.com>