### PR TITLE
Update links to docs.chef.io

### DIFF
--- a/www/source/docs/install-habitat.html.md.erb
+++ b/www/source/docs/install-habitat.html.md.erb
@@ -11,7 +11,7 @@ Below you'll find installation instructions for each platform and their requirem
 ---
 ## <a name="accept-the-license" id="accept-the-license" data-magellan-target="accept-the-license">Accept the License</a>
 
-Please visit <a href="https://docs.chef.io/chef_license_accept.html">the license acceptance page</a> on the Chef docs site for more information.
+Please visit <a href="https://docs.chef.io/chef_license_accept/">the license acceptance page</a> on the Chef docs site for more information.
 
 ---
 ## <a name="configure-workstation" id="configure-workstation" data-magellan-target="configure-workstation">Configure Your Workstation</a>

--- a/www/source/docs/reference.html.md.erb
+++ b/www/source/docs/reference.html.md.erb
@@ -23,7 +23,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_BLDR_URL` | build system, Supervisor | `https://bldr.habitat.sh` | Sets an alternate default endpoint for communicating with Builder. Used by the Chef Habitat build system and the Supervisor |
 | `HAB_DOCKER_OPTS` | build system | no default | When running a Studio on a platform that uses Docker (macOS), additional command line options to pass to the `docker` command. |
 | `HAB_INTERNAL_BLDR_CHANNEL` | build system, Supervisor, exporters | `stable` | Channel from which Chef Habitat-specific packages (e.g., `core/hab-sup`, `core/hab-launcher`, etc.) are downloaded on-demand when first called. Generally of use only for those developing Chef Habitat. Only applies to Chef Habitat-specific packages, and nothing else. |
-| `HAB_LICENSE` | build system, Supervisor, exporters | no default | Used to accept the [Chef EULA](https://docs.chef.io/chef_license.html#chef-eula). See [Accepting the Chef License](https://docs.chef.io/chef_license_accept.html#habitat) for valid values. |
+| `HAB_LICENSE` | build system, Supervisor, exporters | no default | Used to accept the [Chef EULA](https://docs.chef.io/chef_license/#chef-eula). See [Accepting the Chef License](https://docs.chef.io/chef_license_accept/#habitat) for valid values. |
 | `HAB_LISTEN_CTL` | Supervisor | 127.0.0.1:9632 | The listen address for the Control Gateway. This also affects `hab` commands that interact with the Supervisor via the Control Gateway, for example: `hab sup status`. |
 | `HAB_LISTEN_GOSSIP` | Supervisor | 0.0.0.0:9638 | The listen address for the Gossip System Gateway |
 | `HAB_LISTEN_HTTP` | Supervisor | 0.0.0.0:9631 | The listen address for the HTTP Gateway |

--- a/www/source/legal/terms-and-conditions.html.slim
+++ b/www/source/legal/terms-and-conditions.html.slim
@@ -181,7 +181,7 @@ title: Terms and Conditions of Use
 
           li <span class="underline">Your Responsibilities</span>: By submitting or posting any User Content to
             the Sites or in connection with the Service, you agree that your User Content will comply at all
-            times with our Community Guidelines and Code of Conduct which can be found at <a href="https://docs.chef.io/community_guidelines.html">https://docs.chef.io/community_guidelines.html</a>
+            times with our Community Guidelines and Code of Conduct which can be found at <a href="https://docs.chef.io/community_guidelines/">https://docs.chef.io/community_guidelines/</a>
             (“Community Guidelines”).  Further you agree not to post, upload to, transmit, distribute, store,
             create or otherwise publish through the Sites or in connection with any Service any of the following:
           ol.lower-roman

--- a/www/source/partials/demo/_install_the_tools.html.slim
+++ b/www/source/partials/demo/_install_the_tools.html.slim
@@ -17,7 +17,7 @@
       span.asterisk * 
       | The first time you run Habitat, you will be asked to accept the License Agreement. 
       |  More details about the license can be found 
-      a href="https://docs.chef.io/chef_license.html" here.
+      a href="https://docs.chef.io/chef_license/" here.
 
   .footnote
     p.mb-0


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

Update links to docs.chef.io. Links are now pretty, so no `.html` on the end.