### PR TITLE
only stop the studio container at the end of the docker studio supervisor test

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -395,7 +395,6 @@ steps:
     env:
       BUILD_PKG_TARGET: x86_64-windows
       DOCKER_STUDIO_TEST: true
-      HAB_DOCKER_OPTS: "-p 9631:9631"
     expeditor:
       executor:
         windows:

--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -59,10 +59,10 @@ function Wait-PathHasContentUpdatedAfter($Path, $Time, $Timeout) {
     Wait-PathUpdatedAfter @PSBoundParameters
 }
 
-function Wait-Supervisor($Timeout = 1) {
+function Wait-Supervisor($Timeout = 1, $port = 9631) {
     Write-Host "Waiting up to $Timeout seconds for Supervisor to start..."
-    $testScript = { Test-Connection -ComputerName 127.0.0.1 -TCPPort 9631 }
-    $timeoutScript = { Write-Error "Timed out waiting $Timeout seconds for Supervisor to start" }
+    $testScript = { Test-Connection -ComputerName 127.0.0.1 -TCPPort $port }
+    $timeoutScript = { Write-Error "Timed out waiting $Timeout seconds for Supervisor to start on port $port" }
     Wait-True -TestScript $testScript -TimeoutScript $timeoutScript -Timeout $Timeout
     Write-Host "Supervisor is now running."
 }

--- a/test/end-to-end/test_studio_supervisor.ps1
+++ b/test/end-to-end/test_studio_supervisor.ps1
@@ -2,17 +2,8 @@ $cliVersion = ((hab --version) -split " ")[1]
 $env:HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL="dev"
 hab origin key generate $env:HAB_ORIGIN
 
-# Note we kill all containers before and after this test
-# At some point we can remove the BeforeAll but neet it now
-# for straggler test VMs
 
 Describe "Studio supervisor" {
-    BeforeAll {
-        if($env:DOCKER_STUDIO_TEST) {
-            docker ps -q | ForEach-Object { docker stop $_ }
-        }
-    }
-
     It "version should match hab cli" {
         $result = (Invoke-StudioRun "hab sup --version")
         $result[-1] | Should -match "sup $(($cliVersion -split '/')[0])/*"
@@ -21,8 +12,11 @@ Describe "Studio supervisor" {
     It "should be running" {
         $studioArgs = @("studio", "enter")
         if($env:DOCKER_STUDIO_TEST) {
+            $port = (Get-Random -Minimum 8000 -Maximum 9000)
+            $env:HAB_DOCKER_OPTS = "-p ${port}:9631 -l buildkitejob=$env:BUILDKITE_JOB_ID"
             $studioArgs += "-D"
         } else {
+            $port = 9631
             $studioArgs += "-R"
         }
         $procArgs = @{
@@ -31,13 +25,13 @@ Describe "Studio supervisor" {
             WindowStyle  = "hidden"
         }
         Start-Process @procArgs
-        Wait-Supervisor -Timeout 60
-        (Invoke-WebRequest "http://localhost:9631/butterfly" -UseBasicParsing).StatusCode | Should -Be 200
+        Wait-Supervisor -Timeout 60 -Port $port
+        (Invoke-WebRequest "http://localhost:$port/butterfly" -UseBasicParsing).StatusCode | Should -Be 200
     }
 
     AfterAll {
         if($env:DOCKER_STUDIO_TEST) {
-            docker ps -q | ForEach-Object { docker stop $_ }
+            docker ps -q --filter "label=buildkitejob=$env:BUILDKITE_JOB_ID" | ForEach-Object { docker stop $_ }
         }
     }
 }


### PR DESCRIPTION
fixes #7538 

We need to forcefully stop a studio container in one of the docker host tests. It ends up that this same host is either hosting other test containers or connects to a docker daemon that is testing the other container tests. Therefore we were stopping all of the tests causing them to exit with `127`. This filters to only stop a studio container.

Signed-off-by: mwrock <matt@mattwrock.com>