### PR TITLE
Correct some e2e behavior

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -44,6 +44,7 @@ steps:
     command:
       - .expeditor/scripts/end_to_end/setup_environment.sh dev
       - hab pkg install --binlink --channel=stable core/expect
+      - hab pkg install --channel=\$HAB_BLDR_CHANNEL core/hab-sup core/hab-launcher
       - test/end-to-end/hup-does-not-abandon-services.exp
     expeditor:
       executor:
@@ -56,6 +57,7 @@ steps:
     command:
       - .expeditor/scripts/end_to_end/setup_environment.sh dev
       - hab pkg install --binlink --channel=stable core/expect
+      - hab pkg install --channel=\$HAB_BLDR_CHANNEL core/hab-sup core/hab-launcher
       - test/end-to-end/hab-svc-load.exp
     expeditor:
       executor:
@@ -613,6 +615,7 @@ steps:
   - label: "[:habicat: Promote to Acceptance]"
     command:
       - .expeditor/scripts/buildkite_promote.sh dev acceptance
+    if: build.creator.name == 'Chef Expeditor'
     expeditor:
       executor:
         docker:

--- a/test/end-to-end/test_launcher_checks_supervisor_version.ps1
+++ b/test/end-to-end/test_launcher_checks_supervisor_version.ps1
@@ -41,7 +41,7 @@ function Test-LauncherFailure($version) {
 }
 
 # These tests will timeout unless the launcher and all of its dependencies
-# are already on disk. 
+# are already on disk.
 hab pkg install core/hab-launcher --channel $HAB_BLDR_CHANNEL
 
 Describe "Launcher version check" {

--- a/test/end-to-end/test_launcher_checks_supervisor_version.ps1
+++ b/test/end-to-end/test_launcher_checks_supervisor_version.ps1
@@ -40,6 +40,10 @@ function Test-LauncherFailure($version) {
     return ($supPid.ExitCode -ne 0)
 }
 
+# These tests will timeout unless the launcher and all of its dependencies
+# are already on disk. 
+hab pkg install core/hab-launcher --channel $HAB_BLDR_CHANNEL
+
 Describe "Launcher version check" {
     It "Exits with error when running an incompatible supervisor version" {
         Test-LauncherFailure "0.55.0/20180321222338" | Should -Be $true

--- a/test/end-to-end/test_supervisor_term.ps1
+++ b/test/end-to-end/test_supervisor_term.ps1
@@ -1,5 +1,3 @@
-$env:HAB_INTERNAL_BLDR_CHANNEL = "dev"
-$env:HAB_BLDR_CHANNEL = "dev"
 $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) "testpkgstophook.out"
 $launcherProc = Start-Supervisor -Timeout 45
 


### PR DESCRIPTION
This PR addresses a few issues discovered while attempting to test packages built against the upcoming refresh. 

A number of tests will timeout if the dependencies for the packages aren't already on disk. This can occur if the base image `chefes/buildkite` doesn't already have the packages cached.  Since these tests aren't specifically testing install logic, it should be safe to pre-install them using the specified $HAB_BLDR_CHANNEL. An alternative approach would be to increase the timeout values, but they'd have to be made arbitrarily large to minimize the risk of timeout. 

This also disables the promotion step via Buildkite, if the creator isn't Chef Expeditor. This gives us an extra level of safety beyond `maybe_run` from an accidental promotion. 

The final change is to remove hard-coded `HAB_BLDR_CHANNEL` in tests, in favor of letting the environment drive that. This moves us close to being able to run these e2e tests against an arbitrary channel in Builder, which will be useful for validation of pre-release changes. 

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>