### PR TITLE
Use unique container name to bats unit tests

### DIFF
--- a/.expeditor/run-bats.sh
+++ b/.expeditor/run-bats.sh
@@ -19,6 +19,7 @@ else
 fi
 
 image="hab-bats-cleanroom"
+container_name="expeditor-ci-bats-${BUILDKITE_BUILD_ID:-local}"
 
 docker build --tag "${image}" --file ./test/Dockerfile .
 
@@ -27,6 +28,6 @@ docker build --tag "${image}" --file ./test/Dockerfile .
 docker run -it --rm \
        --mount type=bind,source="$(pwd)/..",target=/test \
        --workdir=/test \
-       --name expeditor-ci-bats \
+       --name "$container_name" \
        "${image}" \
        bats ${TESTS}


### PR DESCRIPTION
If two prs come in around the same time, and their BATS unit tests both execute on the same host, the second one to start will result in a failure because they share a container name.   Ex: https://buildkite.com/chef/habitat-sh-habitat-master-verify/builds/5241#37569fdb-0343-4330-b5d6-4ebb941efb81/114-248

This PR adds the `BUILDKITE_BUILD_ID` to the container name, defaulting to `local` if we're not executing inside buildkite.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>