### PR TITLE
run install hooks from the bottom of the dep tree up

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -522,6 +522,31 @@ steps:
       automatic:
         limit: 1
 
+  - label: "[:windows: test_pkg_install]"
+    command:
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_pkg_install
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          environment:
+            - BUILD_PKG_TARGET=x86_64-windows
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+            - HAB_ORIGIN
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[:linux: test_pkg_install]"
+    command:
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_install
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+
   - label: "[:linux: test_pkg_download]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_download

--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -213,7 +213,7 @@ function Get-Leader($Remote, $ServiceGroup) {
 }
 
 Function Invoke-BuildAndInstall($PackageName) {
-    hab pkg build test/fixtures/$PackageName
+    hab pkg build test/fixtures/$PackageName --reuse
     if($IsLinux) {
         # This changes the format of last_build from `var=value` to `$var='value'`
         # so that powershell can parse and source the script

--- a/e2e_env
+++ b/e2e_env
@@ -4,7 +4,7 @@
 #
 HAB_BLDR_URL=https://bldr.habitat.sh
 BUILD_PKG_TARGET=x86_64-linux
-HAB_ORIGIN=core
+HAB_ORIGIN=habitat-testing
 HAB_BLDR_CHANNEL=dev
 HAB_INTERNAL_BLDR_CHANNEL=dev
 HAB_LICENSE=accept-no-persist

--- a/test/end-to-end/test_pkg_install.ps1
+++ b/test/end-to-end/test_pkg_install.ps1
@@ -1,0 +1,20 @@
+Describe "pkg install" {
+    BeforeAll {
+        hab origin key generate $env:HAB_ORIGIN
+
+        Invoke-BuildAndInstall dep-pkg-1
+        Invoke-BuildAndInstall dep-pkg-2
+        Invoke-BuildAndInstall dep-pkg-3
+
+        hab pkg uninstall $env:HAB_ORIGIN/dep-pkg-3
+    }
+
+    It "installs all dependencies and executes all install hooks" {
+        $cached = Get-Item "/hab/cache/artifacts/$env:HAB_ORIGIN-dep-pkg-3*"
+        hab pkg install $cached.FullName
+        $LASTEXITCODE | Should -Be 0
+        Get-Content "$(hab pkg path $env:HAB_ORIGIN/dep-pkg-1)/INSTALL_HOOK_STATUS" | Should -Be "0"
+        Get-Content "$(hab pkg path $env:HAB_ORIGIN/dep-pkg-2)/INSTALL_HOOK_STATUS" | Should -Be "0"
+        Get-Content "$(hab pkg path $env:HAB_ORIGIN/dep-pkg-3)/INSTALL_HOOK_STATUS" | Should -Be "0"
+    }
+}

--- a/test/fixtures/dep-pkg-1/hooks/install
+++ b/test/fixtures/dep-pkg-1/hooks/install
@@ -1,0 +1,3 @@
+#!/usr/bin/env pwsh
+
+Write-Output "install hook {{pkg.name}}"

--- a/test/fixtures/dep-pkg-1/plan.ps1
+++ b/test/fixtures/dep-pkg-1/plan.ps1
@@ -1,0 +1,5 @@
+$pkg_name="dep-pkg-1"
+$pkg_origin="habitat-testing"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_version="0.0.0"
+

--- a/test/fixtures/dep-pkg-1/plan.sh
+++ b/test/fixtures/dep-pkg-1/plan.sh
@@ -1,0 +1,7 @@
+pkg_name="dep-pkg-1"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+
+do_build() { :; }
+do_install() { :; }

--- a/test/fixtures/dep-pkg-2/hooks/install
+++ b/test/fixtures/dep-pkg-2/hooks/install
@@ -1,0 +1,9 @@
+#!/usr/bin/env pwsh
+
+Write-Output "install hook {{pkg.name}}"
+
+$result = Test-Path "{{pkgPathFor "habitat-testing/dep-pkg-1"}}" -ErrorAction SilentlyContinue
+
+if(!$result) {
+    exit 1
+}

--- a/test/fixtures/dep-pkg-2/plan.ps1
+++ b/test/fixtures/dep-pkg-2/plan.ps1
@@ -1,0 +1,5 @@
+$pkg_name="dep-pkg-2"
+$pkg_origin="habitat-testing"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_version="0.0.0"
+$pkg_deps=@("habitat-testing/dep-pkg-1")

--- a/test/fixtures/dep-pkg-2/plan.sh
+++ b/test/fixtures/dep-pkg-2/plan.sh
@@ -1,0 +1,8 @@
+pkg_name="dep-pkg-2"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+pkg_deps=("dep-pkg-1")
+
+do_build() { :; }
+do_install() { :; }

--- a/test/fixtures/dep-pkg-3/hooks/install
+++ b/test/fixtures/dep-pkg-3/hooks/install
@@ -1,0 +1,9 @@
+#!/usr/bin/env pwsh
+
+Write-Output "install hook {{pkg.name}}"
+
+$result = Test-Path "{{pkgPathFor "habitat-testing/dep-pkg-2"}}" -ErrorAction SilentlyContinue
+
+if(!$result) {
+    exit 1
+}

--- a/test/fixtures/dep-pkg-3/plan.ps1
+++ b/test/fixtures/dep-pkg-3/plan.ps1
@@ -1,0 +1,5 @@
+$pkg_name="dep-pkg-3"
+$pkg_origin="habitat-testing"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_version="0.0.0"
+$pkg_deps=@("habitat-testing/dep-pkg-2")

--- a/test/fixtures/dep-pkg-3/plan.sh
+++ b/test/fixtures/dep-pkg-3/plan.sh
@@ -1,0 +1,8 @@
+pkg_name="dep-pkg-3"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+pkg_deps=("dep-pkg-2")
+
+do_build() { :; }
+do_install() { :; }


### PR DESCRIPTION
fixes #7520

This ensures that all packages are downloaded and extracted before any install hooks are run and also that the install hooks run in order from bottom most dep to highest.

There are really 2 key changes to `install.rs` that accomplish this:

### Change to `install_package`
In `install_package` we used to iterate through the deps and if a dep was already installed we would call `run_install_hook_unless_already_successful` which would run the hook if it had not been previously run or if it was not previously successful (did not exit 0). If the dep was not installed, we would install it and run the install hook.

Now we just install everything not already installed and then call `check_install_hooks` at the end which iterates the deps+self and runs `run_install_hook_unless_already_successful` for each. This has 2 benefits. First it is somewhat simpler and has ultimately the same end. Second, if for any reason a package was installed but a dep was not, the previous logic would never run the hook for the previously installed package.

### Change to `check_install_hooks`
`check_install_hooks` iterates the dependencies of the `TDEPS` file in reverse order. Deps are stored in the tdeps with the topmost dependency on top and lowest level dependencies on the bottom. We need to run the lower level deps install hooks before the install hooks of the packages that depend on them.