### PR TITLE
Move builder-worker post release step higher in the release readme

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -205,10 +205,17 @@ making them "officially" available to the world, and thus "released".
 # Post-Release Tasks
 The Buildkite release is fairly-well automated at this point, but once it is complete, there are still a few remaining manual tasks to perform. In time, these will be automated as well.
 
-## Verify the Acceptance environment is using the new hab-backline
+## The Builder Worker
 
-Running [`update-hab-backline.sh`](https://github.com/habitat-sh/habitat/blob/master/update-hab-backline.sh)
-is handled by buildkite. If it is necessary to do manually, you can find instructions in [a previous release of this file.](https://github.com/habitat-sh/habitat/blob/bebf0fdfb738e1304ea201717fb6054733b17939/RELEASE.md#update-the-acceptance-environment-with-the-new-hab-backline)
+New `habitat/builder-worker` packages will automatically be built by
+Builder's `post_habitat_release` pipeline ([definition](https://github.com/habitat-sh/builder/blob/master/.expeditor/post_habitat_release.pipeline.yml)),
+[Buildkite
+pipeline](https://buildkite.com/chef/habitat-sh-builder-master-post-habitat-release))
+when a Habitat release completes. Please follow along in that pipeline
+to ensure that the new packages are validated and properly promoted to
+the stable channel.
+
+After building the workers and promoting them to acceptance, you will be prompted to build packages in acceptance to ensure that they are behaving propperly. You should build both a Windows and a Linux package. The key things you are looking for are that the builds succeed and that their build output indicates they are using the new stable versions of `hab`, `hab-plan-build` and `hab-studio`.
 
 ## Update the Changelog
 
@@ -260,16 +267,6 @@ Make sure the commands from the trace output look correct when the script execut
 1. The version is the new dev version after the one we just released; there should be a `-dev` suffix
 1. The install is from the `unstable` channel
 1. The upload is to the `stable` channel
-
-## The Builder Worker
-
-New `habitat/builder-worker` packages will automatically be built by
-Builder's `post_habitat_release` pipeline ([definition](https://github.com/habitat-sh/builder/blob/cm/builder-worker-automation/.expeditor/post_habitat_release.pipeline.yml)),
-[Buildkite
-pipeline](https://buildkite.com/chef/habitat-sh-builder-master-post-habitat-release))
-when a Habitat release completes. Please follow along in that pipeline
-to ensure that the new packages are validated and properly promoted to
-the stable channel.
 
 # Release Notification
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -266,18 +266,6 @@ also consult [Expeditor's CHANGELOG
 documentation](https://expeditor.chef.io/docs/reference/changelog/)
 for additional details.
 
-## Update the Acceptance environment with the new hab-backline
-
-While buildkite handles adding the new stable backline version to the acceptance workers, this does not make the backline packages accesible from the acceptance depot. We must upload the stable backline to the acceptance bldr. In order to do this, (from a Linux machine):
-
-```
-./update-hab-backline.sh unstable '<release_version>'
-```
-
-Note that `<release_version>` should be the stable version being released. If your auth token isn't specified in your environment, you can add `-z <AUTH_TOKEN>`
-(or any other arguments to pass to the `hab pkg upload` command) to the
-`update-hab-backline.sh` script after the channel and version arguments.
-
 # Release Notification
 
 1. Create new posts in [Chef Release Announcements](https://discourse.chef.io/c/chef-release) on the Chef Discourse as well as [Announcements](https://forums.habitat.sh/c/announcements) in the Habitat forums.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -268,29 +268,15 @@ for additional details.
 
 ## Update the Acceptance environment with the new hab-backline
 
-While buildkite handles adding the new stable backline version to acceptance, updating the new unstable
-version must be done manually. In order to do this, (from a Linux machine):
+While buildkite handles adding the new stable backline version to the acceptance workers, this does not make the backline packages accesible from the acceptance depot. We must upload the stable backline to the acceptance bldr. In order to do this, (from a Linux machine):
 
 ```
-./update-hab-backline.sh unstable $(< VERSION)
+./update-hab-backline.sh unstable '<release_version>'
 ```
 
-If your auth token isn't specified in your environment, you can add `-z <AUTH_TOKEN>`
+Note that `<release_version>` should be the stable version being released. If your auth token isn't specified in your environment, you can add `-z <AUTH_TOKEN>`
 (or any other arguments to pass to the `hab pkg upload` command) to the
 `update-hab-backline.sh` script after the channel and version arguments.
-
-NOTE: Until Builder automatically builds linux2 packages in response to web hook activity, you may need to manually trigger a build after you've merged the version bump PR. If that is the case, you can use the CLI:
-
-```sh
-hab bldr job start core/hab-backline x86_64-linux-kernel2
-```
-
-Once the Acceptance Builder is doing this, then we will no longer need to worry about this step.
-
-Make sure the commands from the trace output look correct when the script executes:
-1. The version is the new dev version after the one we just released; there should be a `-dev` suffix
-1. The install is from the `unstable` channel
-1. The upload is to the `stable` channel
 
 # Release Notification
 


### PR DESCRIPTION
Currently one of the first post-release tasks mentioned in the `RELEASE.md` is to verify that acceptance is using the new backline. However it will not use the new backline until the new builder-workers have been promoted which is mentioned later in the readme.

This moves the notes about the builder-worker higher up in the document. Then it removes the section about verifying backline because verifying backline is part of the builder-worker promotion and everything one needs to do to verify it is covered in the builder worker notes.

One point up for discusion here is the section [Update the Acceptance environment with the new hab-backline](https://github.com/habitat-sh/habitat/blob/master/RELEASE.md#update-the-acceptance-environment-with-the-new-hab-backline). I am confused about this section and have the folllowing questions:

* Why do we need to upload the current unstable backline packages to acceptance?
* Is the actual intent of this section to upload the `stable` versions to acceptance because they are missing.

My guess is that this section is outdated and should be updated to cover syncing the acceptance hab packages with what is in stable. Does that sound correct?

Signed-off-by: mwrock <matt@mattwrock.com>