### PR TITLE
Automatic package cleanup with the `--keep-latest-packages` flag

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -635,6 +635,16 @@ steps:
             - HAB_UPDATE_STRATEGY_FREQUENCY_MS=3000
             - HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK=1
 
+  - label: "[:linux: test_self_keep_latest_packages]"
+    command:
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_self_keep_latest_packages
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+
   - wait
 
   - label: "[:habicat: Promote to Acceptance]"

--- a/.expeditor/scripts/end_to_end/run_e2e_test.sh
+++ b/.expeditor/scripts/end_to_end/run_e2e_test.sh
@@ -8,4 +8,6 @@ test_name=${2:-}
 source .expeditor/scripts/end_to_end/setup_environment.sh "$channel"
 if [ -n "$test_name" ]; then
     pwsh .expeditor/scripts/end_to_end/run_e2e_test_core.ps1 "$test_name"
+else
+    bash
 fi

--- a/.expeditor/scripts/end_to_end/run_e2e_test.sh
+++ b/.expeditor/scripts/end_to_end/run_e2e_test.sh
@@ -3,7 +3,9 @@
 set -euo pipefail
 
 channel=${1:?You must specify a channel value}
-test_name=${2:?You must specify a test name}
+test_name=${2:-}
 
 source .expeditor/scripts/end_to_end/setup_environment.sh "$channel"
-pwsh .expeditor/scripts/end_to_end/run_e2e_test_core.ps1 "$test_name"
+if [ -n "$test_name" ]; then
+    pwsh .expeditor/scripts/end_to_end/run_e2e_test_core.ps1 "$test_name"
+fi

--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -202,6 +202,12 @@ function Wait-Release($Ident, $Remote, $Timeout = ($DefaultServiceTimeout)) {
     Wait-True -TestScript $testScript -TimeoutScript $timeoutScript -Timeout $Timeout
 }
 
+function Wait-CommandLinesOfOutput($Cmd, $Lines, $Timeout = 20) {
+    $testScript =  { (Invoke-Expression $Cmd | Measure-Object -Line).Lines -eq $Lines }
+    $timeoutScript = { Write-Error "Timed out waiting $Timeout seconds for $Cmd to output exactly $Lines lines" }
+    Wait-True -TestScript $testScript -TimeoutScript $timeoutScript -Timeout $Timeout
+}
+
 function Get-Leader($Remote, $ServiceGroup) {
     $json = (Invoke-WebRequest "http://$Remote.habitat.dev:9631/census" | ConvertFrom-Json)
     $id = $json.census_groups.$ServiceGroup.leader_id

--- a/.expeditor/scripts/verify/run_psscriptanalyzer.ps1
+++ b/.expeditor/scripts/verify/run_psscriptanalyzer.ps1
@@ -11,7 +11,7 @@ Install-Habitat
 }
 
 & "$(hab pkg path core/powershell)\bin\pwsh" -WorkingDirectory $PSScriptRoot -Command {
-    Import-Module "$(hab pkg path core/psscriptanalyzer)\module\PSScriptanAlyzer.psd1"
+    Import-Module (Join-Path -Path "$(hab pkg path core/psscriptanalyzer)" -ChildPath "module\PSScriptAnalyzer.psd1")
 
     $excludeAnalyzeScripts = @(
         'plan.ps1',

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -543,6 +543,16 @@ mod tests {
                                   Some("1.0.0".to_string()),
                                   Some("20150521131555".to_string()));
         assert_eq!(a, b);
+
+        let a = PackageIdent::new("ty".to_string(),
+                                  "tabor".to_string(),
+                                  Some("1.0.0".to_string()),
+                                  Some("20150521131555".to_string()));
+        let b = PackageIdent::new("ty".to_string(),
+                                  "tabor".to_string(),
+                                  Some("1.0.0".to_string()),
+                                  None);
+        assert_ne!(a, b);
     }
 
     #[test]

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -1277,29 +1277,23 @@ fn sub_sup_run(_feature_flags: FeatureFlag) -> App<'static, 'static> {
                              `127.0.0.1`")
     );
 
-    // The clap_app macro does not allow numeric default values
+    // clap_app macro does not allow setting short and long help seperately
     let sub =
         sub.arg(Arg::with_name("KEEP_LATEST_PACKAGES").long("keep-latest-packages")
                                                       .takes_value(true)
-                                                      .min_values(0)
-                                                      .max_values(2)
-                                                      .default_value("1")
                                                       .validator(valid_numeric::<usize>)
                                                       .env("HAB_KEEP_LATEST_PACKAGES")
                                                       .help("Automatically cleanup old packages")
                                                       .long_help("Automatically cleanup old \
-                                                                  packages.\n\nIf this flag is \
-                                                                  enabled, service startup will \
-                                                                  initiate an uninstall of all \
-                                                                  previous versions of the \
-                                                                  associated package. This also \
-                                                                  applies when a service is \
-                                                                  restarted due to an update. \
-                                                                  If a number is passed to this \
-                                                                  argument, that number of \
-                                                                  latest versions will be kept. \
-                                                                  The same logic applies to the \
-                                                                  Supervisor package."));
+                                                                  packages.\n\nIf enabled, \
+                                                                  service startup will initiate \
+                                                                  an uninstall of all packages \
+                                                                  except for the \
+                                                                  `KEEP_LATEST_PACKAGES` most \
+                                                                  recent packages. The same \
+                                                                  logic applies to the \
+                                                                  `core/hab-sup` package on \
+                                                                  Supervisor startup."));
 
     // The clap_app macro does not allow "-" in possible values
     let sub = sub.arg(Arg::with_name("UPDATE_CONDITION").long("update-condition")

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -1277,6 +1277,33 @@ fn sub_sup_run(_feature_flags: FeatureFlag) -> App<'static, 'static> {
                              `127.0.0.1`")
     );
 
+    // The clap_app macro does not allow numeric default values
+    let sub =
+        sub.arg(Arg::with_name("KEEP_LATEST_PACKAGES").long("keep-latest-packages")
+                                                      .takes_value(true)
+                                                      .min_values(0)
+                                                      .max_values(2)
+                                                      .default_value("1")
+                                                      .validator(valid_numeric::<usize>)
+                                                      .env("HAB_KEEP_LATEST_PACKAGES")
+                                                      .help("Automatically cleanup old package \
+                                                             versions")
+                                                      .long_help("Automatically cleanup old \
+                                                                  package versions.\n\nIf this \
+                                                                  flag is enabled, service \
+                                                                  startup will initiate an \
+                                                                  uninstall of all previous \
+                                                                  versions of the associated \
+                                                                  package. This also applies \
+                                                                  when a service is restarted \
+                                                                  due to an update. If a number \
+                                                                  is passed to this argument, \
+                                                                  that number of latest \
+                                                                  versions will be kept. The \
+                                                                  same logic applies to the \
+                                                                  Supervisor package if self \
+                                                                  updates are enabled."));
+
     // The clap_app macro does not allow "-" in possible values
     let sub = sub.arg(Arg::with_name("UPDATE_CONDITION").long("update-condition")
                                                         .takes_value(true)

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -1279,21 +1279,29 @@ fn sub_sup_run(_feature_flags: FeatureFlag) -> App<'static, 'static> {
 
     // clap_app macro does not allow setting short and long help seperately
     let sub =
-        sub.arg(Arg::with_name("KEEP_LATEST_PACKAGES").long("keep-latest-packages")
-                                                      .takes_value(true)
-                                                      .validator(valid_numeric::<usize>)
-                                                      .env("HAB_KEEP_LATEST_PACKAGES")
-                                                      .help("Automatically cleanup old packages")
-                                                      .long_help("Automatically cleanup old \
-                                                                  packages.\n\nIf enabled, \
-                                                                  service startup will initiate \
-                                                                  an uninstall of all packages \
-                                                                  except for the \
-                                                                  `KEEP_LATEST_PACKAGES` most \
-                                                                  recent packages. The same \
-                                                                  logic applies to the \
-                                                                  `core/hab-sup` package on \
-                                                                  Supervisor startup."));
+        sub.arg(Arg::with_name("NUM_LATEST_PACKAGES_TO_KEEP").long("keep-latest-packages")
+                                                             .takes_value(true)
+                                                             .validator(valid_numeric::<usize>)
+                                                             .env("HAB_KEEP_LATEST_PACKAGES")
+                                                             .help("Automatically cleanup old \
+                                                                    packages")
+                                                             .long_help("Automatically cleanup \
+                                                                         old packages.\n\nIf \
+                                                                         enabled, service \
+                                                                         startup will initiate \
+                                                                         an uninstall of all \
+                                                                         packages except for \
+                                                                         the `NUM_LATEST_PACKAGES_TO_KEEP` most recent \
+                                                                         packages. This also \
+                                                                         applies when a service \
+                                                                         is restarted due to an \
+                                                                         update. The same logic \
+                                                                         applies to the \
+                                                                         `core/hab-sup` package \
+                                                                         on Supervisor startup. \
+                                                                         If this argument is \
+                                                                         not set no package \
+                                                                         cleanup is performed."));
 
     // The clap_app macro does not allow "-" in possible values
     let sub = sub.arg(Arg::with_name("UPDATE_CONDITION").long("update-condition")

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -1286,21 +1286,15 @@ fn sub_sup_run(_feature_flags: FeatureFlag) -> App<'static, 'static> {
                                                              .help("Automatically cleanup old \
                                                                     packages")
                                                              .long_help("Automatically cleanup \
-                                                                         old packages.\n\nIf \
-                                                                         enabled, service \
-                                                                         startup will initiate \
-                                                                         an uninstall of all \
-                                                                         packages except for \
-                                                                         the `NUM_LATEST_PACKAGES_TO_KEEP` most recent \
-                                                                         packages. This also \
-                                                                         applies when a service \
-                                                                         is restarted due to an \
-                                                                         update. The same logic \
-                                                                         applies to the \
-                                                                         `core/hab-sup` package \
-                                                                         on Supervisor startup. \
-                                                                         If this argument is \
-                                                                         not set no package \
+                                                                         old packages.\n\nThe \
+                                                                         Supervisor will \
+                                                                         automatically cleanup \
+                                                                         old packages only \
+                                                                         keeping the `NUM_LATEST_PACKAGES_TO_KEEP` latest \
+                                                                         packages. If this \
+                                                                         argument is not \
+                                                                         specified, no \
+                                                                         automatic package \
                                                                          cleanup is performed."));
 
     // The clap_app macro does not allow "-" in possible values

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -1286,23 +1286,20 @@ fn sub_sup_run(_feature_flags: FeatureFlag) -> App<'static, 'static> {
                                                       .default_value("1")
                                                       .validator(valid_numeric::<usize>)
                                                       .env("HAB_KEEP_LATEST_PACKAGES")
-                                                      .help("Automatically cleanup old package \
-                                                             versions")
+                                                      .help("Automatically cleanup old packages")
                                                       .long_help("Automatically cleanup old \
-                                                                  package versions.\n\nIf this \
-                                                                  flag is enabled, service \
-                                                                  startup will initiate an \
-                                                                  uninstall of all previous \
-                                                                  versions of the associated \
-                                                                  package. This also applies \
-                                                                  when a service is restarted \
-                                                                  due to an update. If a number \
-                                                                  is passed to this argument, \
-                                                                  that number of latest \
-                                                                  versions will be kept. The \
-                                                                  same logic applies to the \
-                                                                  Supervisor package if self \
-                                                                  updates are enabled."));
+                                                                  packages.\n\nIf this flag is \
+                                                                  enabled, service startup will \
+                                                                  initiate an uninstall of all \
+                                                                  previous versions of the \
+                                                                  associated package. This also \
+                                                                  applies when a service is \
+                                                                  restarted due to an update. \
+                                                                  If a number is passed to this \
+                                                                  argument, that number of \
+                                                                  latest versions will be kept. \
+                                                                  The same logic applies to the \
+                                                                  Supervisor package."));
 
     // The clap_app macro does not allow "-" in possible values
     let sub = sub.arg(Arg::with_name("UPDATE_CONDITION").long("update-condition")

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -338,6 +338,21 @@ pub struct SupRun {
     /// process (default: set in plan)
     #[structopt(name = "SHUTDOWN_TIMEOUT", long = "shutdown-timeout")]
     shutdown_timeout: Option<ShutdownTimeout>,
+    /// Automatically cleanup old package versions.
+    ///
+    /// If this flag is enabled, service startup will initiate an uninstall of all previous
+    /// versions of the associated package. This also applies when a service is restarted due to an
+    /// update. If a number is passed to this argument, that number of latest versions will be
+    /// kept. The same logic applies to the Supervisor package if self updates are enabled.
+    // TODO (DM): We want this to have a default value of 1 if set otherwise it should be none. Does
+    // Option<Option<T>> achieve this
+    #[structopt(name = "KEEP_LATEST_PACKAGES",
+                long = "keep-latest-packages",
+                default_value = "1",
+                max_values = 2, // This is needed to use an env var
+                env = "HAB_KEEP_LATEST_PACKAGES")]
+    #[allow(clippy::option_option)]
+    keep_latest_packages: Option<Option<usize>>,
 }
 
 #[derive(StructOpt)]

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -340,19 +340,13 @@ pub struct SupRun {
     shutdown_timeout: Option<ShutdownTimeout>,
     /// Automatically cleanup old packages.
     ///
-    /// If this flag is enabled, service startup will initiate an uninstall of all previous
-    /// versions of the associated package. This also applies when a service is restarted due to an
-    /// update. If a number is passed to this argument, that number of latest versions will be
-    /// kept. The same logic applies to the Supervisor package.
-    // TODO (DM): We want this to have a default value of 1 if set otherwise it should be none. Does
-    // Option<Option<T>> achieve this
+    /// If enabled, service startup will initiate an uninstall of all packages except for the
+    /// `KEEP_LATEST_PACKAGES` most recent packages. The same logic applies to the `core/hab-sup`
+    /// package on Supervisor startup.
     #[structopt(name = "KEEP_LATEST_PACKAGES",
                 long = "keep-latest-packages",
-                default_value = "1",
-                max_values = 2, // This is needed to use an env var
                 env = "HAB_KEEP_LATEST_PACKAGES")]
-    #[allow(clippy::option_option)]
-    keep_latest_packages: Option<Option<usize>>,
+    keep_latest_packages: Option<usize>,
 }
 
 #[derive(StructOpt)]

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -341,9 +341,10 @@ pub struct SupRun {
     /// Automatically cleanup old packages.
     ///
     /// If enabled, service startup will initiate an uninstall of all packages except for the
-    /// `KEEP_LATEST_PACKAGES` most recent packages. The same logic applies to the `core/hab-sup`
-    /// package on Supervisor startup.
-    #[structopt(name = "KEEP_LATEST_PACKAGES",
+    /// `NUM_LATEST_PACKAGES_TO_KEEP` most recent packages. This also applies when a service is
+    /// restarted due to an update. The same logic applies to the `core/hab-sup` package on
+    /// Supervisor startup. If this argument is not set no package cleanup is performed.
+    #[structopt(name = "NUM_LATEST_PACKAGES_TO_KEEP",
                 long = "keep-latest-packages",
                 env = "HAB_KEEP_LATEST_PACKAGES")]
     keep_latest_packages: Option<usize>,

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -340,10 +340,9 @@ pub struct SupRun {
     shutdown_timeout: Option<ShutdownTimeout>,
     /// Automatically cleanup old packages.
     ///
-    /// If enabled, service startup will initiate an uninstall of all packages except for the
-    /// `NUM_LATEST_PACKAGES_TO_KEEP` most recent packages. This also applies when a service is
-    /// restarted due to an update. The same logic applies to the `core/hab-sup` package on
-    /// Supervisor startup. If this argument is not set no package cleanup is performed.
+    /// The Supervisor will automatically cleanup old packages only keeping the
+    /// `NUM_LATEST_PACKAGES_TO_KEEP` latest packages. If this argument is not specified, no
+    /// automatic package cleanup is performed.
     #[structopt(name = "NUM_LATEST_PACKAGES_TO_KEEP",
                 long = "keep-latest-packages",
                 env = "HAB_KEEP_LATEST_PACKAGES")]

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -338,12 +338,12 @@ pub struct SupRun {
     /// process (default: set in plan)
     #[structopt(name = "SHUTDOWN_TIMEOUT", long = "shutdown-timeout")]
     shutdown_timeout: Option<ShutdownTimeout>,
-    /// Automatically cleanup old package versions.
+    /// Automatically cleanup old packages.
     ///
     /// If this flag is enabled, service startup will initiate an uninstall of all previous
     /// versions of the associated package. This also applies when a service is restarted due to an
     /// update. If a number is passed to this argument, that number of latest versions will be
-    /// kept. The same logic applies to the Supervisor package if self updates are enabled.
+    /// kept. The same logic applies to the Supervisor package.
     // TODO (DM): We want this to have a default value of 1 if set otherwise it should be none. Does
     // Option<Option<T>> achieve this
     #[structopt(name = "KEEP_LATEST_PACKAGES",

--- a/components/hab/src/command/pkg/list.rs
+++ b/components/hab/src/command/pkg/list.rs
@@ -2,11 +2,9 @@ use crate::{error::Result,
             hcore::{fs as hfs,
                     package::{list,
                               PackageIdent}}};
-
+use clap::ArgMatches;
 use habitat_common::cli::FS_ROOT;
 use std::str::FromStr;
-
-use clap::ArgMatches;
 
 /// There are three options for what we can list:
 ///   - All packages (no prefix supplied)

--- a/components/hab/src/command/pkg/list.rs
+++ b/components/hab/src/command/pkg/list.rs
@@ -44,7 +44,7 @@ impl<'a> From<&'a ArgMatches<'a>> for ListingType {
     }
 }
 
-pub fn start(listing: &ListingType, fs_root_path: &Path) -> Result<()> {
+pub fn package_list(listing: &ListingType, fs_root_path: &Path) -> Result<Vec<PackageIdent>> {
     let package_path = hfs::pkg_root_path(Some(&fs_root_path));
 
     let mut packages = match listing {
@@ -54,6 +54,11 @@ pub fn start(listing: &ListingType, fs_root_path: &Path) -> Result<()> {
     };
 
     packages.sort_unstable_by(|a, b| a.by_parts_cmp(b));
+    Ok(packages)
+}
+
+pub fn start(listing: &ListingType, fs_root_path: &Path) -> Result<()> {
+    let packages = package_list(listing, fs_root_path)?;
     for p in &packages {
         println!("{}", &p);
     }

--- a/components/hab/src/command/pkg/list.rs
+++ b/components/hab/src/command/pkg/list.rs
@@ -42,6 +42,10 @@ impl<'a> From<&'a ArgMatches<'a>> for ListingType {
     }
 }
 
+impl From<PackageIdent> for ListingType {
+    fn from(ident: PackageIdent) -> Self { ListingType::Ident(ident) }
+}
+
 pub fn package_list(listing: &ListingType) -> Result<Vec<PackageIdent>> {
     let package_path = hfs::pkg_root_path(Some(&*FS_ROOT));
 

--- a/components/hab/src/command/pkg/list.rs
+++ b/components/hab/src/command/pkg/list.rs
@@ -3,8 +3,8 @@ use crate::{error::Result,
                     package::{list,
                               PackageIdent}}};
 
-use std::{path::Path,
-          str::FromStr};
+use habitat_common::cli::FS_ROOT;
+use std::str::FromStr;
 
 use clap::ArgMatches;
 
@@ -44,8 +44,8 @@ impl<'a> From<&'a ArgMatches<'a>> for ListingType {
     }
 }
 
-pub fn package_list(listing: &ListingType, fs_root_path: &Path) -> Result<Vec<PackageIdent>> {
-    let package_path = hfs::pkg_root_path(Some(&fs_root_path));
+pub fn package_list(listing: &ListingType) -> Result<Vec<PackageIdent>> {
+    let package_path = hfs::pkg_root_path(Some(&*FS_ROOT));
 
     let mut packages = match listing {
         ListingType::AllPackages => list::all_packages(&package_path)?,
@@ -57,8 +57,8 @@ pub fn package_list(listing: &ListingType, fs_root_path: &Path) -> Result<Vec<Pa
     Ok(packages)
 }
 
-pub fn start(listing: &ListingType, fs_root_path: &Path) -> Result<()> {
-    let packages = package_list(listing, fs_root_path)?;
+pub fn start(listing: &ListingType) -> Result<()> {
+    let packages = package_list(listing)?;
     for p in &packages {
         println!("{}", &p);
     }

--- a/components/hab/src/command/pkg/uninstall_impl.rs
+++ b/components/hab/src/command/pkg/uninstall_impl.rs
@@ -82,12 +82,12 @@ pub async fn uninstall_many<U>(ui: &mut U,
         }
     }
     let uninstall_if_loaded = if even_if_loaded {
-        UninstallIfLoaded::EvenIfLoaded
+        UninstallMode::Force
     } else {
-        UninstallIfLoaded::SkipIfLoaded(&loaded_services)
+        UninstallMode::SkipIfLoaded(&loaded_services)
     };
     // Never uninstall a dependency if it is loaded
-    let dependency_uninstall_if_loaded = UninstallIfLoaded::SkipIfLoaded(&loaded_services);
+    let dependency_uninstall_if_loaded = UninstallMode::SkipIfLoaded(&loaded_services);
 
     for ident in idents {
         // 2.
@@ -225,12 +225,12 @@ async fn supervisor_services() -> Result<Vec<PackageIdent>> {
 }
 
 #[derive(Clone, Copy)]
-enum UninstallIfLoaded<'a> {
-    EvenIfLoaded,
+enum UninstallMode<'a> {
+    Force,
     SkipIfLoaded(&'a [PackageIdent]),
 }
 
-impl UninstallIfLoaded<'_> {
+impl UninstallMode<'_> {
     fn should_skip(&self, ident: &PackageIdent) -> bool {
         if let Self::SkipIfLoaded(services) = self {
             services.iter().any(|i| i.satisfies(ident))
@@ -251,7 +251,7 @@ fn maybe_delete<U>(ui: &mut U,
                    install: &PackageInstall,
                    strategy: ExecutionStrategy,
                    excludes: &[PackageIdent],
-                   uninstall_if_loaded: UninstallIfLoaded)
+                   uninstall_if_loaded: UninstallMode)
                    -> Result<bool>
     where U: UIWriter
 {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -942,7 +942,7 @@ fn sub_pkg_path(m: &ArgMatches<'_>) -> Result<()> {
 fn sub_pkg_list(m: &ArgMatches<'_>) -> Result<()> {
     let listing_type = ListingType::from(m);
 
-    command::pkg::list::start(&listing_type, &*FS_ROOT)
+    command::pkg::list::start(&listing_type)
 }
 
 fn sub_pkg_provides(m: &ArgMatches<'_>) -> Result<()> {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -10,7 +10,7 @@ extern crate log;
 use clap::{ArgMatches,
            Shell};
 use env_logger;
-
+use futures::stream::StreamExt;
 use hab::{cli::{self,
                 parse_optional_arg},
           command::{self,
@@ -27,7 +27,6 @@ use hab::{cli::{self,
           ORIGIN_ENVVAR,
           PRODUCT,
           VERSION};
-
 use habitat_api_client::BuildOnUpload;
 use habitat_common::{self as common,
                      cli::{cache_key_path_from_matches,
@@ -45,8 +44,6 @@ use habitat_common::{self as common,
                      FeatureFlag};
 #[cfg(windows)]
 use habitat_core::crypto::dpapi::encrypt;
-
-use futures::stream::StreamExt;
 use habitat_core::{crypto::{init,
                             keys::PairType,
                             BoxKeyPair,

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -286,15 +286,6 @@ fn mgrcfg_from_sup_run_matches(m: &ArgMatches,
         None
     };
 
-    let keep_latest_packages = if m.occurrences_of("KEEP_LATEST_PACKAGES") > 0
-                                  || env::var("HAB_KEEP_LATEST_PACKAGES").is_ok()
-    {
-        m.value_of("KEEP_LATEST_PACKAGES")
-         .and_then(|s| s.parse().ok())
-    } else {
-        None
-    };
-
     #[rustfmt::skip]
     let cfg = ManagerConfig {
         auto_update: m.is_present("AUTO_UPDATE"),
@@ -329,7 +320,7 @@ fn mgrcfg_from_sup_run_matches(m: &ArgMatches,
         }),
         feature_flags,
         event_stream_config,
-        keep_latest_packages,
+        keep_latest_packages: m.value_of("KEEP_LATEST_PACKAGES").and_then(|s| s.parse().ok()),
     };
 
     Ok(cfg)

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -320,7 +320,7 @@ fn mgrcfg_from_sup_run_matches(m: &ArgMatches,
         }),
         feature_flags,
         event_stream_config,
-        keep_latest_packages: m.value_of("KEEP_LATEST_PACKAGES").and_then(|s| s.parse().ok()),
+        keep_latest_packages: m.value_of("NUM_LATEST_PACKAGES_TO_KEEP").and_then(|s| s.parse().ok()),
     };
 
     Ok(cfg)

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -286,6 +286,15 @@ fn mgrcfg_from_sup_run_matches(m: &ArgMatches,
         None
     };
 
+    let keep_latest_packages = if m.occurrences_of("KEEP_LATEST_PACKAGES") > 0
+                                  || env::var("HAB_KEEP_LATEST_PACKAGES").is_ok()
+    {
+        m.value_of("KEEP_LATEST_PACKAGES")
+         .and_then(|s| s.parse().ok())
+    } else {
+        None
+    };
+
     #[rustfmt::skip]
     let cfg = ManagerConfig {
         auto_update: m.is_present("AUTO_UPDATE"),
@@ -320,6 +329,7 @@ fn mgrcfg_from_sup_run_matches(m: &ArgMatches,
         }),
         feature_flags,
         event_stream_config,
+        keep_latest_packages,
     };
 
     Ok(cfg)

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1421,8 +1421,8 @@ impl Manager {
             event::service_stopped(&service);
             user_config_watcher.remove(&service);
             service_updater.lock().remove(&service.service_group);
-            // At this point the service process is stopped, but it is technically considered
-            // "running" because its spec file still exists on disk.
+            // At this point the service process is stopped but the package is still loaded by the
+            // Supervisor.
             if let Some(latest_desired_ident) = latest_desired_on_restart {
                 Self::remove_newer_packages(&service.spec_ident, &latest_desired_ident).await;
             }

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1456,7 +1456,7 @@ impl Manager {
             // At this point the service process is stopped but the package is still loaded by the
             // Supervisor.
             if let Some(latest_desired_ident) = latest_desired_on_restart {
-                Self::remove_newer_packages(&service.spec_ident, &latest_desired_ident).await;
+                Self::uninstall_newer_packages(&service.spec_ident, &latest_desired_ident).await;
             }
         };
         Self::wrap_async_service_operation(ident,
@@ -1465,12 +1465,12 @@ impl Manager {
                                            stop_it)
     }
 
-    /// Remove packages that are newer than the specified ident.
+    /// Uninstall packages that are newer than the specified ident.
     ///
     /// This can be used to guarantee that when a service restarts it starts with the desired
     /// package.
-    async fn remove_newer_packages(install_ident: &PackageIdent,
-                                   latest_desired_ident: &PackageIdent) {
+    async fn uninstall_newer_packages(install_ident: &PackageIdent,
+                                      latest_desired_ident: &PackageIdent) {
         while let Some(latest_installed) = pkg::installed(install_ident) {
             let latest_ident = latest_installed.ident;
             if latest_ident > *latest_desired_ident {

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1421,6 +1421,8 @@ impl Manager {
             event::service_stopped(&service);
             user_config_watcher.remove(&service);
             service_updater.lock().remove(&service.service_group);
+            // At this point the service process is stopped, but it is technically considered
+            // "running" because its spec file still exists on disk.
             if let Some(latest_desired_ident) = latest_desired_on_restart {
                 Self::remove_newer_packages(&service.spec_ident, &latest_desired_ident).await;
             }

--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -34,10 +34,10 @@ pub struct SelfUpdater {
 // how things are currently structured (The service updater had a worker)
 
 impl SelfUpdater {
-    pub fn new(current: PackageIdent, update_url: String, update_channel: ChannelIdent) -> Self {
+    pub fn new(current: &PackageIdent, update_url: String, update_channel: ChannelIdent) -> Self {
         let rx = Self::init(current.clone(), update_url.clone(), update_channel.clone());
         SelfUpdater { rx,
-                      current,
+                      current: current.clone(),
                       update_url,
                       update_channel }
     }

--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -137,7 +137,8 @@ pub async fn uninstall_all_but_latest(ident: impl AsRef<PackageIdent>,
     if number_latest_to_keep >= idents.len() {
         return Ok(0);
     }
-    idents.reverse(); // The packages to keep now occur first in the list
+    // Reverse sort the idents so the latest occur first in the list
+    idents.sort_unstable_by(|a, b| b.by_parts_cmp(a));
     let to_uninstall = &idents[number_latest_to_keep..];
     uninstall_impl::uninstall_many(&mut NullUi::new(),
                                    to_uninstall,

--- a/components/sup/src/util/pkg.rs
+++ b/components/sup/src/util/pkg.rs
@@ -128,10 +128,7 @@ pub async fn install_channel_head(url: &str,
 /// Uninstall a package given a package identifier.
 ///
 /// Note: This will uninstall the package even if the service correlated with the package is
-/// "running". A package is considered "running" if it has a spec file. This can cause problems when
-/// trying to manage a service. For example, this prevents us from uninstalling a package during
-/// service rollback unless the `even_if_running` flag is set. Ultimately, this logic should be
-/// cleaned up.
+/// loaded by the Supervisor.
 pub async fn uninstall(ident: impl AsRef<PackageIdent>) -> HabResult<()> {
     uninstall_impl::uninstall(&mut NullUi::new(),
                               &ident.as_ref(),

--- a/e2e_local.sh
+++ b/e2e_local.sh
@@ -2,15 +2,32 @@
 
 set -euo pipefail
 
-test_name=${1:?You must specify a test name}
-channel=${2:-dev}
+channel=${1:?You must specify a channel value}
+# If no `$test_name` is specified, after the test setup you will be dropped into an interactive bash
+# prompt. From there you can run `pwsh .expeditor/scripts/end_to_end/run_e2e_test_core.ps1 $test_name`
+# to quickly iterate on tests.
+test_name=${2:-}
 
-docker run \
-       --rm \
-       --interactive \
-       --tty \
-       --privileged \
-       --env-file="$(pwd)/e2e_env" \
-       --volume="$(pwd):/workdir" \
-       --workdir=/workdir \
-       chefes/buildkite bash .expeditor/scripts/end_to_end/run_e2e_test.sh "$channel" "$test_name"
+echo ".expeditor/scripts/end_to_end/run_e2e_test.sh '$channel' '$test_name'"
+
+if [ -n "$test_name" ]; then
+    docker run \
+           --rm \
+           --interactive \
+           --tty \
+           --privileged \
+           --env-file="$(pwd)/e2e_env" \
+           --volume="$(pwd):/workdir" \
+           --workdir=/workdir \
+           chefes/buildkite bash -c ".expeditor/scripts/end_to_end/run_e2e_test.sh $channel $test_name"
+else
+    docker run \
+           --rm \
+           --interactive \
+           --tty \
+           --privileged \
+           --env-file="$(pwd)/e2e_env" \
+           --volume="$(pwd):/workdir" \
+           --workdir=/workdir \
+           chefes/buildkite bash -c ".expeditor/scripts/end_to_end/run_e2e_test.sh $channel" && sudo bash
+fi

--- a/e2e_local.sh
+++ b/e2e_local.sh
@@ -29,5 +29,5 @@ else
            --env-file="$(pwd)/e2e_env" \
            --volume="$(pwd):/workdir" \
            --workdir=/workdir \
-           chefes/buildkite bash -c ".expeditor/scripts/end_to_end/run_e2e_test.sh $channel" && sudo bash
+           chefes/buildkite bash -c ".expeditor/scripts/end_to_end/run_e2e_test.sh $channel"
 fi

--- a/test/end-to-end/test_at_once_service_updater.ps1
+++ b/test/end-to-end/test_at_once_service_updater.ps1
@@ -7,7 +7,7 @@ $env:HAB_AUTH_TOKEN = $env:PIPELINE_HAB_AUTH_TOKEN
 
 $supLog = New-TemporaryFile
 Start-Supervisor -LogFile $supLog -Timeout 45 -SupArgs @( `
-    "--keep-latest-packages"
+        "--keep-latest-packages"
 ) | Out-Null
 $testChannel="at-once-$([DateTime]::Now.Ticks)"
 $pkg="habitat-testing/nginx"

--- a/test/end-to-end/test_at_once_service_updater.ps1
+++ b/test/end-to-end/test_at_once_service_updater.ps1
@@ -7,7 +7,7 @@ $env:HAB_AUTH_TOKEN = $env:PIPELINE_HAB_AUTH_TOKEN
 
 $supLog = New-TemporaryFile
 Start-Supervisor -LogFile $supLog -Timeout 45 -SupArgs @( `
-        "--keep-latest-packages"
+        "--keep-latest-packages=1"
 ) | Out-Null
 $testChannel="at-once-$([DateTime]::Now.Ticks)"
 $pkg="habitat-testing/nginx"

--- a/test/end-to-end/test_self_keep_latest_packages.ps1
+++ b/test/end-to-end/test_self_keep_latest_packages.ps1
@@ -1,0 +1,40 @@
+# Test Supervisor package cleanup using the `--keep-latest-packages` option
+
+$pkg="core/hab-sup"
+
+Describe "Supervisor package cleanup" {
+    It "loads old Supervisor versions" {
+        hab pkg install "core/hab-sup/1.5.30" --channel unstable
+        hab pkg install "core/hab-sup/1.5.42" --channel unstable
+        hab pkg install "core/hab-sup/1.5.50" --channel unstable
+        hab pkg install "core/hab-sup/1.5.60" --channel unstable
+        Wait-CommandLinesOfOutput "hab pkg list $pkg" 4
+    }
+
+    Context "start the Supervisor without package cleanup" {
+        $supLog = New-TemporaryFile
+        Start-Supervisor -LogFile $supLog -Timeout 45 | Out-Null
+
+        It "does not remove old Supervisor packages" {
+            Wait-CommandLinesOfOutput "hab pkg list $pkg" 5
+        }
+        Stop-Supervisor
+        Start-Sleep 3 # Wait for the supervisor to actually stop
+    }
+
+    Context "start the Supervisor with package cleanup" {
+        $supLog = New-TemporaryFile
+        Start-Supervisor -LogFile $supLog -Timeout 45 -SupArgs @( `
+            "--keep-latest-packages=2"
+        ) | Out-Null
+
+        It "removes old Supervisor packages" {
+            Wait-CommandLinesOfOutput "hab pkg list $pkg" 2
+            hab pkg list $pkg | Select-Object -Index 0 | Should -BeLike "$pkg/1.5.60*"
+        }
+    }
+
+    AfterAll {
+        Stop-Supervisor
+    }
+}

--- a/test/end-to-end/test_self_keep_latest_packages.ps1
+++ b/test/end-to-end/test_self_keep_latest_packages.ps1
@@ -25,7 +25,7 @@ Describe "Supervisor package cleanup" {
     Context "start the Supervisor with package cleanup" {
         $supLog = New-TemporaryFile
         Start-Supervisor -LogFile $supLog -Timeout 45 -SupArgs @( `
-            "--keep-latest-packages=2"
+                "--keep-latest-packages=2"
         ) | Out-Null
 
         It "removes old Supervisor packages" {

--- a/test/end-to-end/test_self_keep_latest_packages.ps1
+++ b/test/end-to-end/test_self_keep_latest_packages.ps1
@@ -24,13 +24,14 @@ Describe "Supervisor package cleanup" {
 
     Context "start the Supervisor with package cleanup" {
         $supLog = New-TemporaryFile
+        $expected = hab pkg list core/hab-sup | Select-Object -Last 2
         Start-Supervisor -LogFile $supLog -Timeout 45 -SupArgs @( `
                 "--keep-latest-packages=2"
         ) | Out-Null
 
         It "removes old Supervisor packages" {
             Wait-CommandLinesOfOutput "hab pkg list $pkg" 2
-            hab pkg list $pkg | Select-Object -Index 0 | Should -BeLike "$pkg/1.5.60*"
+            hab pkg list $pkg | Should -Be $expected
         }
     }
 


### PR DESCRIPTION
Resolves #7552 

This PR adds the `--keep-latest-packages` flag to the `hab sup run` command.

```
--keep-latest-packages <KEEP_LATEST_PACKAGES>
    Automatically cleanup old packages.
    
    If this flag is enabled, service startup will initiate an uninstall of all previous versions of the
    associated package. This also applies when a service is restarted due to an update. If a number is passed to
    this argument, that number of latest versions will be kept. The same logic applies to the Supervisor
    package. [env: HAB_KEEP_LATEST_PACKAGES=]  [default: 1]

```

I went with `--keep-latest-packages` argument name instead of just `--keep-latest` to try and better indicate the purpose of the argument. Which name do reviewers prefer?