### PR TITLE
Error if using `-d` when entering Windows studio

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -17,7 +17,6 @@ param (
     [switch]$q,
     [switch]$v,
     [switch]$R,
-    [switch]$D,
     [string]$command,
     [string]$commandVal,
     [string]$k,
@@ -568,17 +567,22 @@ if(!(Test-InContainer)) {
 }
 
 try {
-    switch ($command) {
-        "new" { New-Studio }
-        "run" { Invoke-StudioRun $commandVal }
-        "rm" { Remove-Studio }
-        "enter" { Enter-Studio }
-        "build" { Invoke-StudioBuild $commandVal $R }
-        "version" { Write-Host "$program $version" }
-        "help" { Write-Help }
-        default {
-            Write-Help
-            Write-Error "Invalid Argument $command"
+    if ($args.Count -gt 0) {
+        Write-Help
+        Write-Error "Invalid Argument '$args'"
+    } else {
+        switch ($command) {
+            "new" { New-Studio }
+            "run" { Invoke-StudioRun $commandVal }
+            "rm" { Remove-Studio }
+            "enter" { Enter-Studio }
+            "build" { Invoke-StudioBuild $commandVal $R }
+            "version" { Write-Host "$program $version" }
+            "help" { Write-Help }
+            default {
+                Write-Help
+                Write-Error "Invalid Command '$command'"
+            }
         }
     }
 } finally { $VerbosePreference = $currentVerbose }


### PR DESCRIPTION
Resolves #7578

This PR adds the ability to enter a docker studio with `-d` on windows. I would have rather thrown an error, but I could not come up with a reasonable workaround for the lack of case-sensitive variables in powershell (@mwrock do you have any suggestions?). This PR also adds logic causing the studio to throw an error if an unknown argument is passed in.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>