### PR TITLE
Prepare e2e tests for powershell 7.0

### DIFF
--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -23,8 +23,9 @@ if ($IsLinux -Or $IsMacOS) {
 
 # It may take a while to download a given service package, and
 # services may have long init scripts. Let's be generous in how long
-# we're willing to wait.
-$DefaultServiceTimeout = 40
+# we're willing to wait. Also note that tests may take considerably
+# longer to complete on buildkite than they do locally.
+$DefaultServiceTimeout = 90
 
 function Wait-True([ScriptBlock]$TestScript, [ScriptBlock]$TimeoutScript, [int]$Timeout) {
     $startTime = Get-Date
@@ -182,7 +183,7 @@ function Stop-Supervisor {
 }
 
 function Wait-Process($ProcessName, $Timeout = 1) {
-    $testScript =  { Get-Process $ProcessName -ErrorAction SilentlyContinue }
+    $testScript =  { Get-Process $ProcessName* -ErrorAction SilentlyContinue }
     $timeoutScript = { Write-Error "Timed out waiting $Timeout seconds for $ProcessName to start" }
     Wait-True -TestScript $testScript -TimeoutScript $timeoutScript -Timeout $Timeout
 }

--- a/test/end-to-end/test_event_stream.ps1
+++ b/test/end-to-end/test_event_stream.ps1
@@ -31,7 +31,7 @@ Describe "event stream connection to nats" {
     )
 
     # Start the NATS Server
-    Load-SupervisorService -PackageName $natsPkg -Timeout 20 -HealthCheckInterval 1
+    Load-SupervisorService -PackageName $natsPkg -HealthCheckInterval 1
 
     It "event stream connects and sends a health check" {
         # Wait for a few health checks to run

--- a/test/end-to-end/test_fresh_install_can_communicate_with_builder.ps1
+++ b/test/end-to-end/test_fresh_install_can_communicate_with_builder.ps1
@@ -10,10 +10,10 @@ Describe "Clean hab installation" {
     }
     It "has no user ssl cache" {
         su hab -c "test ! -d ~/.hab/cache/ssl"
-        $LASTEXITCODE | should -Be 0
+        $LASTEXITCODE | Should -Be 0
     }
     It "can talk to builder" {
         hab pkg install core/redis --channel stable
-        $LASTEXITCODE | should -Be 0
+        $LASTEXITCODE | Should -Be 0
     }
 }

--- a/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
+++ b/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
@@ -3,7 +3,7 @@
 
 Describe "Service PIDs from Launcher feature" {
     Start-Supervisor -Timeout 20
-    Load-SupervisorService -PackageName "core/redis" -Timeout 20
+    Load-SupervisorService -PackageName "core/redis"
     Wait-Process redis-server -Timeout 10
 
     It "should still create a PID file for use in hooks" {
@@ -12,7 +12,7 @@ Describe "Service PIDs from Launcher feature" {
 
     Context "Supervisor is restarted" {
         $supProc = Get-Process hab-sup
-        $redisProc = Get-Process redis-server
+        $redisProc = Get-Process redis-server*
 
         # Write a bogus PID to the file; the Supervisor should not
         # think this is the actual PID of the service.

--- a/test/end-to-end/test_service_pids_written_to_file_using_old_launcher.ps1
+++ b/test/end-to-end/test_service_pids_written_to_file_using_old_launcher.ps1
@@ -8,7 +8,7 @@ Describe "Using a Launcher that cannot provide service PIDs" {
     hab pkg install core/hab-launcher/12605/20191112144831
 
     Start-Supervisor -Timeout 20
-    Load-SupervisorService -PackageName "core/redis" -Timeout 20
+    Load-SupervisorService -PackageName "core/redis"
     Wait-Process redis-server -Timeout 10
 
     It "should create PID file" {
@@ -17,7 +17,7 @@ Describe "Using a Launcher that cannot provide service PIDs" {
 
     Context "Supervisor is restarted" {
         $supProc = Get-Process hab-sup
-        $redisProc = Get-Process redis-server
+        $redisProc = Get-Process redis-server*
         Restart-Supervisor
         Wait-Process redis-server -Timeout 10
         $newSupProc = Get-Process hab-sup

--- a/test/end-to-end/test_simple_hooks.ps1
+++ b/test/end-to-end/test_simple_hooks.ps1
@@ -5,7 +5,7 @@ Start-Supervisor -LogFile $sup_log -Timeout 45 | Out-Null
 $pkg = "$(Get-EndToEndTestingOrigin)/simple-hooks"
 
 Describe "Simple hooks output" {
-    $svc = Load-SupervisorService -PackageName $pkg -Timeout 20
+    $svc = Load-SupervisorService -PackageName $pkg
     $pkgLogsPath = Join-Path -Path $env:SystemDrive -ChildPath hab -AdditionalChildPath @("svc", $svc, "logs")
 
     It "Has correct 'install' hook stdout" {

--- a/test/end-to-end/test_supervisor_binds.ps1
+++ b/test/end-to-end/test_supervisor_binds.ps1
@@ -9,8 +9,8 @@ Describe "Supervisor binds" {
     }
 
     It "consumer bind to producer export" {
-        Load-SupervisorService -PackageName $env:HAB_ORIGIN/testpkgbindproducer -Timeout 20
-        Load-SupervisorService -PackageName $env:HAB_ORIGIN/testpkgbindconsumer -Timeout 20 -Bind alias:testpkgbindproducer.default
+        Load-SupervisorService -PackageName $env:HAB_ORIGIN/testpkgbindproducer
+        Load-SupervisorService -PackageName $env:HAB_ORIGIN/testpkgbindconsumer -Bind alias:testpkgbindproducer.default
 
         # The consumer's myconfig.conf is a template that holds the value
         # of the producers exported property which should be "default1"


### PR DESCRIPTION
This makes a few tweaks to the e2e tests in preparation for powershell 7. It is mainly extending the default timeout for waiting for supervisor services to start and removing the overrides. While I was testing, locally the current timeout were not a problem but I was having lots of buildkite timeout issues that this cleared up.

This also allows for some slightly different behavior of `Get-Process` on Linux with powershell 7. Powershell 7 will now behave similar to the native `ps` command and include not just the binary name in the process name but any additional args that is also rendered by `ps`. For example `redis-server` would be the redis process name in powershell versions prior to 7.0. However in version 7 it may be `redis-server *:6379 `.

Signed-off-by: mwrock <matt@mattwrock.com>