### PR TITLE
fix UDP port remaining open after supervisor terminates when a hook is still executing

### DIFF
--- a/.expeditor/scripts/verify/shared.ps1
+++ b/.expeditor/scripts/verify/shared.ps1
@@ -54,7 +54,7 @@ function Initialize-Environment {
     $env:PATH                       = New-PathString -StartingPath $env:PATH -Path "$protobufDir\bin;$zeromqDir\bin;$libarchiveDir\bin;$libsodiumDir\bin;$zlibDir\bin;$xzDir\bin;$opensslDir\bin"
 
     $vsDir = & hab pkg path core/visual-cpp-build-tools-2015
-    $env:LIB = (Get-Content "$vsDir\LIB_DIRS")
+    $env:LIB = "$(Get-Content "$vsDir\LIB_DIRS");$env:LIBZMQ_PREFIX\lib"
     $env:INCLUDE = (Get-Content "$vsDir\INCLUDE_DIRS")
     $env:PATH = New-PathString -StartingPath $env:PATH -Path (Get-Content "$vsDir\PATH")
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,7 @@ dependencies = [
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.8.3 (git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed)",
 ]
 

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -33,6 +33,9 @@ toml = { version = "*", default-features = false }
 uuid = { version = "*", features = ["v4"] }
 zmq = { git = "https://github.com/habitat-sh/rust-zmq", branch = "v0.8-symlinks-removed" }
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "*", features = ["handleapi", "winbase"] }
+
 [dev-dependencies]
 mktemp = "*"
 

--- a/components/butterfly/src/error.rs
+++ b/components/butterfly/src/error.rs
@@ -26,6 +26,7 @@ pub enum Error {
     IncarnationParse(PathBuf, num::ParseIntError),
     InvalidRumorShareLimit,
     NonExistentRumor(String, String),
+    OsError(io::Error),
     ProtocolMismatch(&'static str),
     ServiceConfigDecode(String, toml::de::Error),
     ServiceConfigNotUtf8(String, str::Utf8Error),
@@ -79,6 +80,7 @@ impl fmt::Display for Error {
                 format!("Non existent rumor asked to be written to bytes: {} {}",
                         member_id, rumor_id)
             }
+            Error::OsError(ref err) => format!("OS error: {}", err),
             Error::ProtocolMismatch(ref field) => {
                 format!("Received an unsupported or bad protocol message. Missing field: {}",
                         field)


### PR DESCRIPTION
This fixes #7590.

There is a [bug](https://github.com/rust-lang/rust/issues/70719) which surfaced in rust 1.38 where cloned sockets on windows get inherited by child processes and remain open even after the process that created the socket terminates as long as the child processes remain alive. Until this is fixed, we explicitly clear the HANDLE_FLAG_INHERIT of the socket's handle.