### PR TITLE
cleanup adding interpreter paths and make it configurable

### DIFF
--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -34,7 +34,7 @@ pub enum Error {
     GossipFileRelativePath(String),
     HabitatCore(hcore::Error),
     InstallHookFailed(PackageIdent),
-    InterpreterNotFound(PackageIdent),
+    InterpreterNotFound(PackageIdent, Box<Self>),
     InvalidEventStreamToken(String),
     InvalidInstallHookMode(String),
     /// Occurs when making lower level IO calls.
@@ -109,8 +109,8 @@ impl fmt::Display for Error {
             Error::InstallHookFailed(ref ident) => {
                 format!("Install hook exited unsuccessfully: {}", ident)
             }
-            Error::InterpreterNotFound(ref ident) => {
-                format!("Unable to install interpreter ident: {}", ident)
+            Error::InterpreterNotFound(ref ident, ref e) => {
+                format!("Unable to install interpreter ident: {} - {}", ident, e)
             }
             Error::InvalidEventStreamToken(ref s) => {
                 format!("Invalid event stream token provided: '{}'", s)

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -34,6 +34,7 @@ pub enum Error {
     GossipFileRelativePath(String),
     HabitatCore(hcore::Error),
     InstallHookFailed(PackageIdent),
+    InterpreterNotFound(PackageIdent),
     InvalidEventStreamToken(String),
     InvalidInstallHookMode(String),
     /// Occurs when making lower level IO calls.
@@ -107,6 +108,9 @@ impl fmt::Display for Error {
             }
             Error::InstallHookFailed(ref ident) => {
                 format!("Install hook exited unsuccessfully: {}", ident)
+            }
+            Error::InterpreterNotFound(ref ident) => {
+                format!("Unable to install interpreter ident: {}", ident)
             }
             Error::InvalidEventStreamToken(ref s) => {
                 format!("Invalid event stream token provided: '{}'", s)

--- a/components/common/src/util/path.rs
+++ b/components/common/src/util/path.rs
@@ -94,24 +94,24 @@ async fn interpreter_paths() -> Result<Vec<PathBuf>> {
                 // Nope, no packages of the interpreter installed. Now we're going to see if the
                 // interpreter command is present on `PATH`.
                 Err(_) => {
-                    if install::type_erased_start(&mut ui::NullUi::new(),
-                                                &default_bldr_url(),
-                                                &ChannelIdent::stable(),
-                                                &(ident.clone(),
-                                                    PackageTarget::active_target())
-                                                                                .into(),
-                                                &*PROGRAM_NAME,
-                                                VERSION,
-                                                FS_ROOT_PATH.as_path(),
-                                                &cache_artifact_path(None::<String>),
-                                                None,
-                                                &InstallMode::default(),
-                                                &LocalPackageUsage::default(),
-                                                InstallHookMode::default()).await.is_err() {
-                                                    return Err(Error::InterpreterNotFound(ident));
-                                                }
-                    let pkg_install = PackageInstall::load(&ident, Some(FS_ROOT_PATH.as_ref()))?;
-                    pkg_install.paths()?
+                    match install::type_erased_start(&mut ui::NullUi::new(),
+                                                     &default_bldr_url(),
+                                                     &ChannelIdent::stable(),
+                                                     &(ident.clone(),
+                                                       PackageTarget::active_target())
+                                                                                      .into(),
+                                                     &*PROGRAM_NAME,
+                                                     VERSION,
+                                                     FS_ROOT_PATH.as_path(),
+                                                     &cache_artifact_path(None::<String>),
+                                                     None,
+                                                     &InstallMode::default(),
+                                                     &LocalPackageUsage::default(),
+                                                     InstallHookMode::default()).await
+                    {
+                        Ok(pkg_install) => pkg_install.paths()?,
+                        Err(err) => return Err(Error::InterpreterNotFound(ident, Box::new(err))),
+                    }
                 }
             }
         }

--- a/components/core/src/fs.rs
+++ b/components/core/src/fs.rs
@@ -243,7 +243,7 @@ pub fn pkg_install_path<T>(ident: &PackageIdent, fs_root: Option<T>) -> PathBuf
 /// this will "re-root" the path just under the fs_root. Otherwise returns
 /// the given path unchanged. Non-Windows platforms will always return the
 /// unchanged path.
-pub(crate) fn fs_rooted_path(path: &PathBuf, fs_root: &Path) -> PathBuf {
+pub fn fs_rooted_path(path: &PathBuf, fs_root: &Path) -> PathBuf {
     if path.starts_with("/") && cfg!(windows) {
         fs_root.join(path.strip_prefix("/").unwrap())
     } else {

--- a/www/source/docs/reference.html.md.erb
+++ b/www/source/docs/reference.html.md.erb
@@ -23,6 +23,7 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_BLDR_URL` | build system, Supervisor | `https://bldr.habitat.sh` | Sets an alternate default endpoint for communicating with Builder. Used by the Chef Habitat build system and the Supervisor |
 | `HAB_DOCKER_OPTS` | build system | no default | When running a Studio on a platform that uses Docker (macOS), additional command line options to pass to the `docker` command. |
 | `HAB_INTERNAL_BLDR_CHANNEL` | build system, Supervisor, exporters | `stable` | Channel from which Chef Habitat-specific packages (e.g., `core/hab-sup`, `core/hab-launcher`, etc.) are downloaded on-demand when first called. Generally of use only for those developing Chef Habitat. Only applies to Chef Habitat-specific packages, and nothing else. |
+| `HAB_INTERPRETER_IDENT` | Supervisor | `core/busybox-static` (`core/powershell` on Windows) | The package identifier to be used for executing the interpreter invoked by hooks. |
 | `HAB_LICENSE` | build system, Supervisor, exporters | no default | Used to accept the [Chef EULA](https://docs.chef.io/chef_license/#chef-eula). See [Accepting the Chef License](https://docs.chef.io/chef_license_accept/#habitat) for valid values. |
 | `HAB_LISTEN_CTL` | Supervisor | 127.0.0.1:9632 | The listen address for the Control Gateway. This also affects `hab` commands that interact with the Supervisor via the Control Gateway, for example: `hab sup status`. |
 | `HAB_LISTEN_GOSSIP` | Supervisor | 0.0.0.0:9638 | The listen address for the Gossip System Gateway |


### PR DESCRIPTION
This PR accomplishes four things:

1. Fixes a bug where the supervisor will use the most recent version of powershell or busybox-static installed instead of the one packaged. This is fixed with [this line](https://github.com/habitat-sh/habitat/pull/7601/files#diff-9e4f1f1544b6c3ae7b8a78d289f54773R68). My guess is that we used to store the `hab-sup` binary in the root of the package and not in `bin`.
1. Fixes [another bug](https://github.com/habitat-sh/habitat/issues/6410) where the interpreter is not propperly rooted in a local windows studio.
1. No longer allow an interpreter binary that is found on the path but not in a package to be used. I do not think this is a breaking change and do not know why we would allow this.
1. Allows a user to configure the interpreter ident via a `HAB_INTERPRETER_IDENT` env variable or config setting.
Signed-off-by: mwrock <matt@mattwrock.com>