### PR TITLE
tag windows 2019 studio image with latest

### DIFF
--- a/.expeditor/scripts/release_habitat/build_docker_image.ps1
+++ b/.expeditor/scripts/release_habitat/build_docker_image.ps1
@@ -101,7 +101,7 @@ ENTRYPOINT ["/hab/pkgs/$ident/bin/powershell/pwsh.exe", "-ExecutionPolicy", "byp
         Write-Error "docker build failed, aborting"
     }
 
-    if($BaseTag -eq "ltsc2016") {
+    if($BaseTag -eq "ltsc2019") {
         Write-Host "Tagging latest image to ${imageName}:$BaseTag-$version"
         docker tag ${imageName}:$BaseTag-$version ${imageName}:latest
         if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
#7063 published the 2019 latest tag but I missed the actual tagging of the image which causes the push to fail.

Signed-off-by: mwrock <matt@mattwrock.com>