### PR TITLE
[Docs] Emphasize the necessity of TCP for Supervisor function

### DIFF
--- a/www/source/docs/internals.html.md.erb
+++ b/www/source/docs/internals.html.md.erb
@@ -39,7 +39,7 @@ Butterfly is an eventually consistent system - it says, with a very high degree 
 
 #### Transport Protocols
 
-Supervisors communicate with each other using UDP and ZeroMQ, over port 9638.
+Supervisors communicate with each other using UDP and TCP, both using port 9638.
 
 #### Information Security
 


### PR DESCRIPTION
The Supervisor must have UDP _and_ TCP communication channels open in
order to function properly.

The fact that our TCP communication happens to be implemented in terms
of ZeroMQ at the moment isn't operationally important.

Signed-off-by: Christopher Maier <cmaier@chef.io>