### PR TITLE
append existing path to package path in hab pkg exec

### DIFF
--- a/components/common/src/util/path.rs
+++ b/components/common/src/util/path.rs
@@ -16,7 +16,8 @@ use habitat_core::{fs::{cache_artifact_path,
                    ChannelIdent};
 use std::{env,
           fs::File,
-          io::{prelude::*,
+          io::{self,
+               prelude::*,
                BufReader},
           path::PathBuf,
           str::FromStr};
@@ -150,8 +151,9 @@ pub async fn append_interpreter_and_path(path_entries: &mut Vec<PathBuf>) -> Res
         path_entries.append(&mut os_paths);
     }
     let joined = env::join_paths(path_entries)?;
-    let path_str = joined.into_string()
-                         .expect("Unable to convert OsStr path to string!");
+    let path_str =
+        joined.into_string()
+              .map_err(|s| io::Error::new(io::ErrorKind::InvalidData, s.to_string_lossy()))?;
     Ok(path_str)
 }
 

--- a/components/hab/src/command/pkg/exec.rs
+++ b/components/hab/src/command/pkg/exec.rs
@@ -1,5 +1,6 @@
 use std::{env,
           ffi::OsString,
+          io,
           path::PathBuf};
 
 use crate::hcore::{fs::{find_command,
@@ -11,12 +12,29 @@ use crate::hcore::{fs::{find_command,
 use crate::error::{Error,
                    Result};
 
+const PATH_KEY: &str = "PATH";
+
 pub fn start<T>(ident: &PackageIdent, command: T, args: &[OsString]) -> Result<()>
     where T: Into<PathBuf>
 {
     let command = command.into();
     let pkg_install = PackageInstall::load(&ident, Some(&*FS_ROOT_PATH))?;
-    let cmd_env = pkg_install.environment_for_command()?;
+    let mut cmd_env = pkg_install.environment_for_command()?;
+
+    if let Some(path) = cmd_env.get(PATH_KEY) {
+        if let Some(val) = env::var_os(PATH_KEY) {
+            let mut paths: Vec<PathBuf> = env::split_paths(&path).collect();
+            let mut os_paths = env::split_paths(&val).collect();
+            paths.append(&mut os_paths);
+            let joined = env::join_paths(paths)?;
+            let path_str =
+                joined.into_string()
+                      .map_err(|s| {
+                          io::Error::new(io::ErrorKind::InvalidData, s.to_string_lossy())
+                      })?;
+            cmd_env.insert(PATH_KEY.to_string(), path_str);
+        }
+    }
 
     for (key, value) in cmd_env.into_iter() {
         debug!("Setting: {}='{}'", key, value);


### PR DESCRIPTION
fixes #7135

This appends the existing PATH to the path used by `hab pkg exec` to achieve PATH parity with the supervisor. The only key difference between this and the supervisor PATH for a service is that the supervisor also appends the interpreter path (powershell or busybox) because those are always needed to run the hook script which does not apply to `exec`.

Signed-off-by: mwrock <matt@mattwrock.com>