### PR TITLE
Prevent infinite loop on Windows after losing connection to Automate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,7 +1074,7 @@ dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rants 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rants 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "retry 1.0.0 (git+https://github.com/habitat-sh/retry)",
  "same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1427,7 +1427,7 @@ dependencies = [
  "prost-derive 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rants 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rants 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "rants"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4259,7 +4259,7 @@ dependencies = [
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_pcg 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-"checksum rants 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8012bbcbc3f2a22bf1dded6ee9f06cbe91a9f5f00d579c4227fd66bf4ee33a2"
+"checksum rants 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9abd23851d7e9f08649ac95c38ac2b126ef1d9331033cd31a06aed3fcfbc6ac5"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"


### PR DESCRIPTION
... by updating to rants 0.4.3

See https://github.com/davidMcneil/rants/pull/24 for details.

Signed-off-by: Christopher Maier <cmaier@chef.io>