### PR TITLE
source studio_profile.ps1 in studio enter if present

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -419,6 +419,35 @@ steps:
       automatic:
         limit: 1
 
+  - label: "[:windows: test_studio_profile]"
+    command:
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_profile
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          environment:
+            - BUILD_PKG_TARGET=x86_64-windows
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+            - HAB_ORIGIN
+    retry:
+      automatic:
+        limit: 1
+
+  - label: "[:windows: :docker: test_studio_profile]"
+    command:
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_profile
+    env:
+      BUILD_PKG_TARGET: x86_64-windows
+      DOCKER_STUDIO_TEST: true
+    expeditor:
+      executor:
+        windows:
+          os_version: 2019
+    retry:
+      automatic:
+        limit: 1
+
   - label: "[:linux: test_fresh_install_can_communicate_with_builder]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_fresh_install_can_communicate_with_builder

--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -47,6 +47,21 @@ function Wait-PathUpdatedAfter($Path, $Time, $Timeout) {
     Wait-True -TestScript $testScript -TimeoutScript $timeoutScript -Timeout $Timeout
 }
 
+function Wait-PathIncludesContent($Path, $Content, $Timeout = ($DefaultServiceTimeout)) {
+    $testScript = {
+        (Test-Path -Path $Path) -And ((Get-Content -Path $Path | Out-String).Contains($Content))
+    }
+    $timeoutScript = {
+        if(Test-Path -Path $Path) {
+            $got = "'$(Get-Content -Path $Path | Out-String)'"
+        } else {
+            $got = "...oh...actually...the file doesn't even exist"
+        }
+        Write-Error "Timed out waiting $Timeout seconds for '$Path' to include content '$Content' but got $got"
+    }
+    Wait-True -TestScript $testScript -TimeoutScript $timeoutScript -Timeout $Timeout
+}
+
 function Wait-PathHasContent($Path, $Time, $Timeout) {
     $testScript = {
         (Test-Path -Path $Path) -And ((Get-Content -Path $Path).Length -gt 0)

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -95,6 +95,7 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
                             String::from("HAB_ORIGIN"),
                             String::from("HAB_ORIGIN_KEYS"),
                             String::from("HAB_STUDIO_BACKLINE_PKG"),
+                            String::from("HAB_STUDIO_NOPROFILE"),
                             String::from("HAB_STUDIO_NOSTUDIORC"),
                             String::from("HAB_STUDIO_SUP"),
                             String::from("HAB_UPDATE_STRATEGY_FREQUENCY_MS"),

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -62,15 +62,16 @@ SUBCOMMANDS:
     version   Prints version information
 
 ENVIRONMENT VARIABLES:
-    HAB_LICENSE       Set to 'accept' or 'accept-no-persist' to accept the Habitat license
-    HAB_ORIGIN        Propagates this variable into any studios
-    HAB_ORIGIN_KEYS   Installs secret keys (\`-k' option overrides)
-    HAB_STUDIOS_HOME  Sets a home path for all Studios (default: /hab/studios)
-    HAB_STUDIO_ROOT   Sets a Studio root (\`-r' option overrides)
-    NO_SRC_PATH       If set, do not mount source path (\`-n' flag overrides)
-    QUIET             Prints less output (\`-q' flag overrides)
-    SRC_PATH          Sets the source path (\`-s' option overrides)
-    VERBOSE           Prints more verbose output (\`-v' flag overrides)
+    HAB_LICENSE           Set to 'accept' or 'accept-no-persist' to accept the Habitat license
+    HAB_ORIGIN            Propagates this variable into any studios
+    HAB_ORIGIN_KEYS       Installs secret keys (\`-k' option overrides)
+    HAB_STUDIOS_HOME      Sets a home path for all Studios (default: /hab/studios)
+    HAB_STUDIO_NOPROFILE  Disables sourcing a \`.studio_profile.ps1' in \`studio enter'
+    HAB_STUDIO_ROOT       Sets a Studio root (\`-r' option overrides)
+    NO_SRC_PATH           If set, do not mount source path (\`-n' flag overrides)
+    QUIET                 Prints less output (\`-q' flag overrides)
+    SRC_PATH              Sets the source path (\`-s' option overrides)
+    VERBOSE               Prints more verbose output (\`-v' flag overrides)
 
 SUBCOMMAND HELP:
     $program <SUBCOMMAND> -h
@@ -421,6 +422,11 @@ function Enter-Studio {
 
         New-PSDrive -Name "Habitat" -PSProvider FileSystem -Root $env:HAB_STUDIO_ENTER_ROOT | Out-Null
         Set-Location "Habitat:\src"
+
+        if((Test-Path studio_profile.ps1) -and (!$env:HAB_STUDIO_NOPROFILE)) {
+            Write-Host "--> Detected and loading studio_profile.ps1"
+            . .\studio_profile.ps1
+        }
     }
 
     if($shouldStartStudio -and (Test-Path "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK")) {

--- a/test/end-to-end/test_studio_profile.ps1
+++ b/test/end-to-end/test_studio_profile.ps1
@@ -1,0 +1,51 @@
+function Stop-ProcessTree($Id) {
+    Get-CimInstance Win32_Process | Where-Object { $_.ParentProcessId -eq $Id } | ForEach-Object { Kill-Tree $_.ProcessId }
+    Stop-Process -Id $Id -ErrorAction SilentlyContinue
+}
+
+Describe "hab studio enter with studio_profile.ps1" {
+    BeforeAll {
+        Set-Content studio_profile.ps1 -value "write-host 'hohoho';kill `$PID"
+        hab origin key generate $env:HAB_ORIGIN
+    }
+    Context "No HAB_STUDIO_NOPROFILE set" {
+        $env:HAB_STUDIO_NOPROFILE = $null
+
+        It "sources studio_profile.ps1" {
+            if($env:DOCKER_STUDIO_TEST) {
+                $habEnterCmd = "hab studio enter -D"
+            } else {
+                $habEnterCmd = "hab studio enter"
+            }
+            $result = Invoke-Expression $habEnterCmd
+            $result[-1] | Should -Be "hohoho"
+        }
+    }
+    Context "HAB_STUDIO_NOPROFILE is set" {
+        $env:HAB_STUDIO_NOPROFILE = $true
+
+        It "does not source studio_profile.ps1" {
+            $studioArgs = @("studio", "enter")
+            if($env:DOCKER_STUDIO_TEST) {
+                $env:HAB_DOCKER_OPTS = "-l buildkitejob=$env:BUILDKITE_JOB_ID"
+                $studioArgs += "-D"
+            }
+            $procArgs = @{
+                FilePath               = "hab"
+                ArgumentList           = $studioArgs
+                RedirectStandardOutput = "out.log"
+                PassThru               = $true
+            }
+            $proc = Start-Process @procArgs
+            Wait-PathIncludesContent -Path out.log -Content "[HAB-STUDIO] Habitat:\src>"
+            Kill-Tree $proc.Id
+        }
+    }
+    AfterAll {
+        Remove-Item studio_profile.ps1
+        Remove-Item out.log
+        if($env:DOCKER_STUDIO_TEST) {
+            docker ps -q --filter "label=buildkitejob=$env:BUILDKITE_JOB_ID" | ForEach-Object { docker stop $_ }
+        }
+    }
+}

--- a/www/source/docs/reference.html.md.erb
+++ b/www/source/docs/reference.html.md.erb
@@ -39,7 +39,8 @@ This is a list of all environment variables that can be used to modify the opera
 | `HAB_STUDIOS_HOME` | build system | `/hab/studios` | Directory in which to create build Studios |
 | `HAB_STUDIO_BACKLINE_PKG` | build system | `core/hab-backline/{{studio_version}}` | Overrides the default package identifier for the "backline" package which installs the Studio baseline package set. |
 | `HAB_STUDIO_ROOT` | build system | no default | Root of the current Studio under `$HAB_STUDIOS_HOME`. Infrequently overridden. |
-| `HAB_STUDIO_NOSTUDIORC` | build system | no default | When set to a non-empty value, a `.studiorc` will not be sourced when entering an interactive Studio via `hab studio enter`. |
+| `HAB_STUDIO_NOPROFILE` | build system (Windows) | no default | When set to a non-empty value, a `studio_profile.ps1` will not be sourced when entering an interactive Studio via `hab studio enter`. |
+| `HAB_STUDIO_NOSTUDIORC` | build system (Linux) | no default | When set to a non-empty value, a `.studiorc` will not be sourced when entering an interactive Studio via `hab studio enter`. |
 | `HAB_STUDIO_SUP` | build system | no default | Used to customize the arguments passed to an automatically launched Supervisor, or to disable the automatic launching by setting it to `false`, `no`, or `0`. |
 | `HAB_GLYPH_STYLE` | build system | `full` (`limited` on Windows) | Used to customize the rendering of unicode glyphs in UI messages. Valid values are `full`, `limited`, or `ascii`. |
 | `HAB_UPDATE_STRATEGY_FREQUENCY_MS` | Supervisor | 60000 | Frequency of milliseconds to check for updates when running with an [update strategy](/docs/using-habitat#using-updates) |
@@ -52,15 +53,15 @@ This is a list of all environment variables that can be used to modify the opera
 
 ### Customizing Studio
 
-When you enter a Studio, Chef Habitat will attempt to locate `/src/.studiorc` and
-source it. Think `~/.bashrc`. This file can be used to export any
+When you enter a Studio, Chef Habitat will attempt to locate `/src/.studiorc` on Linux or `/src/studio_profile.ps1` on Windows and
+source it. Think `~/.bashrc` or `$PROFILE`. This file can be used to export any
 environment variables like the ones you see above as well as any other shell
 customizations to help you develop your plans from within the Studio.
 
-To use this feature, place a `.studiorc` in the current working directory
+To use this feature, place a `.studiorc` (Linux) or `studio_profile.ps1` (Windows) in the current working directory
 where you will run `hab studio enter`.
 
-Note that a `.studiorc` will only be source when using `hab studio enter`--it will not be sourced when calling `hab studio run` or `hab studio build` (also `hab pkg build`).
+Note that a `.studiorc` or `studio_profile.ps1` will only be sourced when using `hab studio enter`--it will not be sourced when calling `hab studio run` or `hab studio build` (also `hab pkg build`).
 
 ---
 ## <a name="plan-settings" id="plan-settings" data-magellan-target="plan-settings">Plan settings</a>


### PR DESCRIPTION
closes #2562

Like `.studiorc` in Linux studios, this introduces a `studio_profile.ps1`. that one can place in the root of their plan and have it be sourced when entering a studio. Also, like `HAB_STUDIO_NOSTUDIORC` one would use `HAB_STUDIO_NOPROFILE` to suppress sourcing the profile.

Note that we use the `profile` terminology because that is the powershell ubiquitous pattern for "auto sourcing" scripts when entering the powershell interpreter environment. See https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7

Signed-off-by: mwrock <matt@mattwrock.com>