### PR TITLE
core: move from users to nix crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.69",
  "winapi 0.3.8",
 ]
 
@@ -397,7 +397,7 @@ checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
- "libc",
+ "libc 0.2.69",
  "rustc-demangle",
 ]
 
@@ -408,7 +408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -552,7 +552,7 @@ checksum = "bf6a638a1f7f409f1e545ff0036b8aa5541692c775dd36b48b75bbde50d83d1c"
 dependencies = [
  "errno",
  "error-chain 0.12.2",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -651,7 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -666,7 +666,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "winapi 0.3.8",
 ]
 
@@ -725,7 +725,7 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a4ba686dff9fa4c1c9636ce1010b0cf98ceb421361b0bb3d6faeec43bd217a7"
 dependencies = [
- "nix",
+ "nix 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8",
 ]
 
@@ -766,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.69",
  "redox_users",
  "winapi 0.3.8",
 ]
@@ -783,7 +783,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea427e983abd535e5ea03dcf395b3a7ae4546f908c8c9e59cca36cf968f82ce"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "socket2",
  "winapi 0.3.8",
 ]
@@ -856,7 +856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
 dependencies = [
  "errno-dragonfly",
- "libc",
+ "libc 0.2.69",
  "winapi 0.3.8",
 ]
 
@@ -867,7 +867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 dependencies = [
  "gcc",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -926,7 +926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.69",
  "redox_syscall",
  "winapi 0.3.8",
 ]
@@ -945,7 +945,7 @@ checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 dependencies = [
  "cfg-if",
  "crc32fast",
- "libc",
+ "libc 0.2.69",
  "miniz_oxide",
 ]
 
@@ -992,7 +992,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -1143,7 +1143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.69",
  "wasi",
 ]
 
@@ -1194,7 +1194,7 @@ dependencies = [
  "habitat_core",
  "handlebars 0.29.1",
  "lazy_static 1.4.0",
- "libc",
+ "libc 0.2.69",
  "log 0.4.8",
  "pbr",
  "rants",
@@ -1229,7 +1229,7 @@ dependencies = [
  "habitat_common",
  "habitat_core",
  "ipc-channel 0.12.0",
- "libc",
+ "libc 0.2.69",
  "log 0.4.8",
  "prost",
  "semver",
@@ -1246,7 +1246,7 @@ dependencies = [
  "habitat_common",
  "habitat_core",
  "ipc-channel 0.9.0",
- "libc",
+ "libc 0.2.69",
  "log 0.4.8",
  "prost",
  "serde",
@@ -1378,7 +1378,7 @@ dependencies = [
  "handlebars 0.28.3",
  "json",
  "lazy_static 1.4.0",
- "libc",
+ "libc 0.2.69",
  "log 0.4.8",
  "native-tls",
  "owning_ref",
@@ -1418,9 +1418,10 @@ dependencies = [
  "hex",
  "lazy_static 1.4.0",
  "libarchive",
- "libc",
+ "libc 0.2.69",
  "libsodium-sys",
  "log 0.4.8",
+ "nix 0.17.0 (git+https://github.com/nix-rust/nix.git)",
  "num_cpus",
  "os_info",
  "rand 0.7.3",
@@ -1434,7 +1435,6 @@ dependencies = [
  "toml 0.5.6",
  "typemap",
  "url",
- "users",
  "widestring 0.4.0",
  "winapi 0.3.8",
  "windows-acl",
@@ -1535,7 +1535,7 @@ dependencies = [
  "jemallocator",
  "json",
  "lazy_static 1.4.0",
- "libc",
+ "libc 0.2.69",
  "log 0.4.8",
  "log4rs",
  "mio",
@@ -1626,7 +1626,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -1651,7 +1651,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "match_cfg",
  "winapi 0.3.8",
 ]
@@ -1757,7 +1757,7 @@ checksum = "24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8"
 dependencies = [
  "bitflags",
  "inotify-sys",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -1766,7 +1766,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 dependencies = [
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -1775,7 +1775,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -1787,7 +1787,7 @@ dependencies = [
  "fnv",
  "kernel32-sys",
  "lazy_static 0.2.11",
- "libc",
+ "libc 0.2.69",
  "mio",
  "rand 0.3.23",
  "serde",
@@ -1804,7 +1804,7 @@ dependencies = [
  "crossbeam-channel",
  "fnv",
  "lazy_static 1.4.0",
- "libc",
+ "libc 0.2.69",
  "mio",
  "rand 0.6.5",
  "serde",
@@ -1847,7 +1847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
 dependencies = [
  "jemalloc-sys",
- "libc",
+ "libc 0.2.69",
  "paste",
 ]
 
@@ -1859,7 +1859,7 @@ checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
 dependencies = [
  "cc",
  "fs_extra",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -1869,7 +1869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 dependencies = [
  "jemalloc-sys",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -1951,7 +1951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da06b22cd19af338a40f5d44a0aa6352ae43839d0855a049881cbc7e1b9c914"
 dependencies = [
  "libarchive3-sys",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -1960,7 +1960,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd3beae8f59a4c7a806523269b5392037577c150446e88d684dfa6de6031ca7"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "pkg-config",
 ]
 
@@ -1969,6 +1969,11 @@ name = "libc"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+
+[[package]]
+name = "libc"
+version = "0.2.70"
+source = "git+https://github.com/rust-lang/libc/#174920c79f81968c0e7639406463cd86fccba287"
 
 [[package]]
 name = "libflate"
@@ -1989,7 +1994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c344ff12b90ef8fa1f0fffacd348c1fd041db331841fec9eab23fdb991f5e73"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.69",
  "libflate",
  "pkg-config",
  "tar",
@@ -2047,7 +2052,7 @@ dependencies = [
  "flate2",
  "fnv",
  "humantime",
- "libc",
+ "libc 0.2.69",
  "log 0.4.8",
  "log-mdc",
  "parking_lot",
@@ -2141,7 +2146,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc",
+ "libc 0.2.69",
  "log 0.4.8",
  "miow 0.2.1",
  "net2",
@@ -2180,7 +2185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
- "libc",
+ "libc 0.2.69",
  "mio",
 ]
 
@@ -2228,7 +2233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static 1.4.0",
- "libc",
+ "libc 0.2.69",
  "log 0.4.8",
  "openssl",
  "openssl-probe",
@@ -2246,8 +2251,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.69",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "nix"
+version = "0.17.0"
+source = "git+https://github.com/nix-rust/nix.git#d3fef370b843e0ffd6fc6df6e80d9bbe0d024863"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc 0.2.70",
 ]
 
 [[package]]
@@ -2259,7 +2275,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
- "libc",
+ "libc 0.2.69",
  "void",
 ]
 
@@ -2291,7 +2307,7 @@ dependencies = [
  "fsevent",
  "fsevent-sys",
  "inotify",
- "libc",
+ "libc 0.2.69",
  "mio",
  "mio-extras",
  "walkdir",
@@ -2324,7 +2340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -2355,7 +2371,7 @@ dependencies = [
  "cfg-if",
  "foreign-types",
  "lazy_static 1.4.0",
- "libc",
+ "libc 0.2.69",
  "openssl-sys",
 ]
 
@@ -2373,7 +2389,7 @@ checksum = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
- "libc",
+ "libc 0.2.69",
  "pkg-config",
  "vcpkg",
 ]
@@ -2426,7 +2442,7 @@ dependencies = [
  "backtrace",
  "cfg-if",
  "cloudabi",
- "libc",
+ "libc 0.2.69",
  "petgraph",
  "redox_syscall",
  "smallvec",
@@ -2462,7 +2478,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4403eb718d70c03ee279e51737782902c68cca01e870a33b6a2f9dfb50b9cd83"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "termion",
  "time 0.1.43",
  "winapi 0.3.8",
@@ -2735,7 +2751,7 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "rand 0.4.6",
 ]
 
@@ -2746,7 +2762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc",
+ "libc 0.2.69",
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.8",
@@ -2759,7 +2775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.7",
- "libc",
+ "libc 0.2.69",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
  "rand_hc 0.1.0",
@@ -2778,7 +2794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
- "libc",
+ "libc 0.2.69",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
@@ -2862,7 +2878,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "rand_core 0.4.2",
  "winapi 0.3.8",
 ]
@@ -2875,7 +2891,7 @@ checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
  "cloudabi",
  "fuchsia-cprng",
- "libc",
+ "libc 0.2.69",
  "rand_core 0.4.2",
  "rdrand",
  "winapi 0.3.8",
@@ -3077,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.69",
  "once_cell",
  "spin",
  "untrusted",
@@ -3198,7 +3214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 dependencies = [
  "gcc",
- "libc",
+ "libc 0.2.69",
  "rand 0.3.23",
  "rustc-serialize",
  "time 0.1.43",
@@ -3288,7 +3304,7 @@ dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc",
+ "libc 0.2.69",
  "security-framework-sys",
 ]
 
@@ -3299,7 +3315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -3422,7 +3438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
  "arc-swap",
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -3450,7 +3466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.69",
  "redox_syscall",
  "winapi 0.3.8",
 ]
@@ -3461,7 +3477,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585232e78a4fc18133eef9946d3080befdf68b906c51b621531c37e91787fa2b"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "libsodium-sys",
  "serde",
 ]
@@ -3635,7 +3651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 dependencies = [
  "filetime",
- "libc",
+ "libc 0.2.69",
  "redox_syscall",
  "xattr",
 ]
@@ -3653,7 +3669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.69",
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
@@ -3675,7 +3691,7 @@ version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "numtoa",
  "redox_syscall",
  "redox_termios",
@@ -3729,7 +3745,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "redox_syscall",
  "winapi 0.3.8",
 ]
@@ -3767,7 +3783,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "winapi 0.3.8",
 ]
 
@@ -3778,7 +3794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1330829d2e6c06771eeae476be12ff1aa9eb5e29ca718a431ab27168efde6c1"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.69",
  "standback",
  "stdweb",
  "time-macros",
@@ -3820,7 +3836,7 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static 1.4.0",
- "libc",
+ "libc 0.2.69",
  "memchr",
  "mio",
  "mio-named-pipes",
@@ -4061,16 +4077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
-dependencies = [
- "libc",
- "log 0.4.8",
-]
-
-[[package]]
 name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,7 +4282,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -4341,7 +4347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a5e28f3db6d32340aa5c46e1c7c9a398c4edbde6ed2a3d4d28e2713723904d"
 dependencies = [
  "field-offset",
- "libc",
+ "libc 0.2.69",
  "widestring 0.3.0",
  "winapi 0.3.8",
 ]
@@ -4380,7 +4386,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc",
+ "libc 0.2.69",
 ]
 
 [[package]]
@@ -4411,7 +4417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aad98a7a617d608cd9e1127147f630d24af07c7cd95ba1533246d96cbdd76c66"
 dependencies = [
  "bitflags",
- "libc",
+ "libc 0.2.69",
  "log 0.4.8",
  "zmq-sys",
 ]
@@ -4422,6 +4428,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d33a2c51dde24d5b451a2ed4b488266df221a5eaee2ee519933dc46b9a9b3648"
 dependencies = [
- "libc",
+ "libc 0.2.69",
  "metadeps",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
- "libc 0.2.69",
+ "libc",
  "winapi 0.3.8",
 ]
 
@@ -397,7 +397,7 @@ checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
- "libc 0.2.69",
+ "libc",
  "rustc-demangle",
 ]
 
@@ -408,7 +408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
 dependencies = [
  "cc",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -552,7 +552,7 @@ checksum = "bf6a638a1f7f409f1e545ff0036b8aa5541692c775dd36b48b75bbde50d83d1c"
 dependencies = [
  "errno",
  "error-chain 0.12.2",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -651,7 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -666,7 +666,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "winapi 0.3.8",
 ]
 
@@ -766,7 +766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 dependencies = [
  "cfg-if",
- "libc 0.2.69",
+ "libc",
  "redox_users",
  "winapi 0.3.8",
 ]
@@ -783,7 +783,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea427e983abd535e5ea03dcf395b3a7ae4546f908c8c9e59cca36cf968f82ce"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "socket2",
  "winapi 0.3.8",
 ]
@@ -856,7 +856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b480f641ccf0faf324e20c1d3e53d81b7484c698b42ea677f6907ae4db195371"
 dependencies = [
  "errno-dragonfly",
- "libc 0.2.69",
+ "libc",
  "winapi 0.3.8",
 ]
 
@@ -867,7 +867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 dependencies = [
  "gcc",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -926,7 +926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affc17579b132fc2461adf7c575cc6e8b134ebca52c51f5411388965227dc695"
 dependencies = [
  "cfg-if",
- "libc 0.2.69",
+ "libc",
  "redox_syscall",
  "winapi 0.3.8",
 ]
@@ -945,7 +945,7 @@ checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 dependencies = [
  "cfg-if",
  "crc32fast",
- "libc 0.2.69",
+ "libc",
  "miniz_oxide",
 ]
 
@@ -992,7 +992,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41b048a94555da0f42f1d632e2e19510084fb8e303b0daa2816e733fb3644a0"
 dependencies = [
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -1143,7 +1143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if",
- "libc 0.2.69",
+ "libc",
  "wasi",
 ]
 
@@ -1194,7 +1194,7 @@ dependencies = [
  "habitat_core",
  "handlebars 0.29.1",
  "lazy_static 1.4.0",
- "libc 0.2.69",
+ "libc",
  "log 0.4.8",
  "pbr",
  "rants",
@@ -1229,7 +1229,7 @@ dependencies = [
  "habitat_common",
  "habitat_core",
  "ipc-channel 0.12.0",
- "libc 0.2.69",
+ "libc",
  "log 0.4.8",
  "prost",
  "semver",
@@ -1246,7 +1246,7 @@ dependencies = [
  "habitat_common",
  "habitat_core",
  "ipc-channel 0.9.0",
- "libc 0.2.69",
+ "libc",
  "log 0.4.8",
  "prost",
  "serde",
@@ -1378,7 +1378,7 @@ dependencies = [
  "handlebars 0.28.3",
  "json",
  "lazy_static 1.4.0",
- "libc 0.2.69",
+ "libc",
  "log 0.4.8",
  "native-tls",
  "owning_ref",
@@ -1418,10 +1418,10 @@ dependencies = [
  "hex",
  "lazy_static 1.4.0",
  "libarchive",
- "libc 0.2.69",
+ "libc",
  "libsodium-sys",
  "log 0.4.8",
- "nix 0.17.0 (git+https://github.com/nix-rust/nix.git)",
+ "nix 0.17.0 (git+https://github.com/nix-rust/nix.git?rev=3c2107bdc221a90b02d3f7118dd96f3496762cd0)",
  "num_cpus",
  "os_info",
  "rand 0.7.3",
@@ -1535,7 +1535,7 @@ dependencies = [
  "jemallocator",
  "json",
  "lazy_static 1.4.0",
- "libc 0.2.69",
+ "libc",
  "log 0.4.8",
  "log4rs",
  "mio",
@@ -1626,7 +1626,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -1651,7 +1651,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "match_cfg",
  "winapi 0.3.8",
 ]
@@ -1757,7 +1757,7 @@ checksum = "24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8"
 dependencies = [
  "bitflags",
  "inotify-sys",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -1766,7 +1766,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 dependencies = [
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -1775,7 +1775,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -1787,7 +1787,7 @@ dependencies = [
  "fnv",
  "kernel32-sys",
  "lazy_static 0.2.11",
- "libc 0.2.69",
+ "libc",
  "mio",
  "rand 0.3.23",
  "serde",
@@ -1804,7 +1804,7 @@ dependencies = [
  "crossbeam-channel",
  "fnv",
  "lazy_static 1.4.0",
- "libc 0.2.69",
+ "libc",
  "mio",
  "rand 0.6.5",
  "serde",
@@ -1847,7 +1847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c502a5ff9dd2924f1ed32ba96e3b65735d837b4bfd978d3161b1702e66aca4b7"
 dependencies = [
  "jemalloc-sys",
- "libc 0.2.69",
+ "libc",
  "paste",
 ]
 
@@ -1859,7 +1859,7 @@ checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
 dependencies = [
  "cc",
  "fs_extra",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -1869,7 +1869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
 dependencies = [
  "jemalloc-sys",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -1951,7 +1951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da06b22cd19af338a40f5d44a0aa6352ae43839d0855a049881cbc7e1b9c914"
 dependencies = [
  "libarchive3-sys",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -1960,7 +1960,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd3beae8f59a4c7a806523269b5392037577c150446e88d684dfa6de6031ca7"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "pkg-config",
 ]
 
@@ -1969,11 +1969,6 @@ name = "libc"
 version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
-
-[[package]]
-name = "libc"
-version = "0.2.70"
-source = "git+https://github.com/rust-lang/libc/#174920c79f81968c0e7639406463cd86fccba287"
 
 [[package]]
 name = "libflate"
@@ -1994,7 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c344ff12b90ef8fa1f0fffacd348c1fd041db331841fec9eab23fdb991f5e73"
 dependencies = [
  "cc",
- "libc 0.2.69",
+ "libc",
  "libflate",
  "pkg-config",
  "tar",
@@ -2052,7 +2047,7 @@ dependencies = [
  "flate2",
  "fnv",
  "humantime",
- "libc 0.2.69",
+ "libc",
  "log 0.4.8",
  "log-mdc",
  "parking_lot",
@@ -2146,7 +2141,7 @@ dependencies = [
  "fuchsia-zircon-sys",
  "iovec",
  "kernel32-sys",
- "libc 0.2.69",
+ "libc",
  "log 0.4.8",
  "miow 0.2.1",
  "net2",
@@ -2185,7 +2180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
- "libc 0.2.69",
+ "libc",
  "mio",
 ]
 
@@ -2233,7 +2228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static 1.4.0",
- "libc 0.2.69",
+ "libc",
  "log 0.4.8",
  "openssl",
  "openssl-probe",
@@ -2251,19 +2246,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
- "libc 0.2.69",
+ "libc",
  "winapi 0.3.8",
 ]
 
 [[package]]
 name = "nix"
 version = "0.17.0"
-source = "git+https://github.com/nix-rust/nix.git#d3fef370b843e0ffd6fc6df6e80d9bbe0d024863"
+source = "git+https://github.com/nix-rust/nix.git?rev=3c2107bdc221a90b02d3f7118dd96f3496762cd0#3c2107bdc221a90b02d3f7118dd96f3496762cd0"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
- "libc 0.2.70",
+ "libc",
+ "void",
 ]
 
 [[package]]
@@ -2275,7 +2271,7 @@ dependencies = [
  "bitflags",
  "cc",
  "cfg-if",
- "libc 0.2.69",
+ "libc",
  "void",
 ]
 
@@ -2307,7 +2303,7 @@ dependencies = [
  "fsevent",
  "fsevent-sys",
  "inotify",
- "libc 0.2.69",
+ "libc",
  "mio",
  "mio-extras",
  "walkdir",
@@ -2340,7 +2336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -2371,7 +2367,7 @@ dependencies = [
  "cfg-if",
  "foreign-types",
  "lazy_static 1.4.0",
- "libc 0.2.69",
+ "libc",
  "openssl-sys",
 ]
 
@@ -2389,7 +2385,7 @@ checksum = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
- "libc 0.2.69",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2442,7 +2438,7 @@ dependencies = [
  "backtrace",
  "cfg-if",
  "cloudabi",
- "libc 0.2.69",
+ "libc",
  "petgraph",
  "redox_syscall",
  "smallvec",
@@ -2478,7 +2474,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4403eb718d70c03ee279e51737782902c68cca01e870a33b6a2f9dfb50b9cd83"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "termion",
  "time 0.1.43",
  "winapi 0.3.8",
@@ -2751,7 +2747,7 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "rand 0.4.6",
 ]
 
@@ -2762,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.69",
+ "libc",
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.8",
@@ -2775,7 +2771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.7",
- "libc 0.2.69",
+ "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
  "rand_hc 0.1.0",
@@ -2794,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
- "libc 0.2.69",
+ "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
@@ -2878,7 +2874,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "rand_core 0.4.2",
  "winapi 0.3.8",
 ]
@@ -2891,7 +2887,7 @@ checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
  "cloudabi",
  "fuchsia-cprng",
- "libc 0.2.69",
+ "libc",
  "rand_core 0.4.2",
  "rdrand",
  "winapi 0.3.8",
@@ -3093,7 +3089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703516ae74571f24b465b4a1431e81e2ad51336cb0ded733a55a1aa3eccac196"
 dependencies = [
  "cc",
- "libc 0.2.69",
+ "libc",
  "once_cell",
  "spin",
  "untrusted",
@@ -3214,7 +3210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 dependencies = [
  "gcc",
- "libc 0.2.69",
+ "libc",
  "rand 0.3.23",
  "rustc-serialize",
  "time 0.1.43",
@@ -3304,7 +3300,7 @@ dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc 0.2.69",
+ "libc",
  "security-framework-sys",
 ]
 
@@ -3315,7 +3311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -3438,7 +3434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f478ede9f64724c5d173d7bb56099ec3e2d9fc2774aac65d34b8b890405f41"
 dependencies = [
  "arc-swap",
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -3466,7 +3462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
 dependencies = [
  "cfg-if",
- "libc 0.2.69",
+ "libc",
  "redox_syscall",
  "winapi 0.3.8",
 ]
@@ -3477,7 +3473,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585232e78a4fc18133eef9946d3080befdf68b906c51b621531c37e91787fa2b"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "libsodium-sys",
  "serde",
 ]
@@ -3651,7 +3647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 dependencies = [
  "filetime",
- "libc 0.2.69",
+ "libc",
  "redox_syscall",
  "xattr",
 ]
@@ -3669,7 +3665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
- "libc 0.2.69",
+ "libc",
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
@@ -3691,7 +3687,7 @@ version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22cec9d8978d906be5ac94bceb5a010d885c626c4c8855721a4dbd20e3ac905"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "numtoa",
  "redox_syscall",
  "redox_termios",
@@ -3745,7 +3741,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "redox_syscall",
  "winapi 0.3.8",
 ]
@@ -3783,7 +3779,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "winapi 0.3.8",
 ]
 
@@ -3794,7 +3790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1330829d2e6c06771eeae476be12ff1aa9eb5e29ca718a431ab27168efde6c1"
 dependencies = [
  "cfg-if",
- "libc 0.2.69",
+ "libc",
  "standback",
  "stdweb",
  "time-macros",
@@ -3836,7 +3832,7 @@ dependencies = [
  "futures-core",
  "iovec",
  "lazy_static 1.4.0",
- "libc 0.2.69",
+ "libc",
  "memchr",
  "mio",
  "mio-named-pipes",
@@ -4282,7 +4278,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -4347,7 +4343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a5e28f3db6d32340aa5c46e1c7c9a398c4edbde6ed2a3d4d28e2713723904d"
 dependencies = [
  "field-offset",
- "libc 0.2.69",
+ "libc",
  "widestring 0.3.0",
  "winapi 0.3.8",
 ]
@@ -4386,7 +4382,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
- "libc 0.2.69",
+ "libc",
 ]
 
 [[package]]
@@ -4417,7 +4413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aad98a7a617d608cd9e1127147f630d24af07c7cd95ba1533246d96cbdd76c66"
 dependencies = [
  "bitflags",
- "libc 0.2.69",
+ "libc",
  "log 0.4.8",
  "zmq-sys",
 ]
@@ -4428,6 +4424,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d33a2c51dde24d5b451a2ed4b488266df221a5eaee2ee519933dc46b9a9b3648"
 dependencies = [
- "libc 0.2.69",
+ "libc",
  "metadeps",
 ]

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -36,7 +36,8 @@ typemap = "*"
 url = "*"
 
 [target.'cfg(not(windows))'.dependencies]
-users = "*"
+# Pulling from git until https://github.com/nix-rust/nix/commit/3c2107bdc221a90b02d3f7118dd96f3496762cd0 is released
+nix = { git = "https://github.com/nix-rust/nix.git" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "*"

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -36,9 +36,10 @@ typemap = "*"
 url = "*"
 
 [target.'cfg(not(windows))'.dependencies]
-# Pulling from git until https://github.com/nix-rust/nix/commit/3c2107bdc221a90b02d3f7118dd96f3496762cd0 is released
-nix = { git = "https://github.com/nix-rust/nix.git" }
-
+# Pulling from git until
+# https://github.com/nix-rust/nix/commit/3c2107bdc221a90b02d3f7118dd96f3496762cd0
+# is released, which will be the next release after v0.17.0
+nix = {  git = "https://github.com/nix-rust/nix.git", rev = "3c2107bdc221a90b02d3f7118dd96f3496762cd0" }
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "*"
 

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -1,10 +1,9 @@
-use std::path::PathBuf;
-
-use crate::error::{Error,
-                   Result};
-
+use crate::{error::{Error,
+                    Result},
+            ok_log};
 use nix::unistd::{Group,
                   User};
+use std::path::PathBuf;
 
 /// This is currently the "master check" for whether the Supervisor
 /// can behave "as root".
@@ -26,35 +25,33 @@ pub fn can_run_services_as_svc_user() -> bool {
 pub fn can_run_services_as_svc_user() -> bool { true }
 
 pub fn get_uid_by_name(owner: &str) -> Option<u32> {
-    User::from_name(owner).ok()
-                          .flatten()
-                          .map(|u| u.uid.as_raw())
+    ok_log!(User::from_name(owner)).flatten()
+                                   .map(|u| u.uid.as_raw())
 }
 
 pub fn get_gid_by_name(group: &str) -> Option<u32> {
-    Group::from_name(group).ok()
-                           .flatten()
-                           .map(|g| g.gid.as_raw())
+    ok_log!(Group::from_name(group)).flatten()
+                                    .map(|g| g.gid.as_raw())
 }
 
 /// Any members that fail conversion from OsString to string will be omitted
 pub fn get_members_by_groupname(group: &str) -> Option<Vec<String>> {
-    Group::from_name(group).ok().flatten().map(|g| g.mem)
+    ok_log!(Group::from_name(group)).flatten().map(|g| g.mem)
 }
 
 pub fn get_current_username() -> Option<String> {
     let uid = nix::unistd::getuid();
-    User::from_uid(uid).ok().flatten().map(|u| u.name)
+    ok_log!(User::from_uid(uid)).flatten().map(|u| u.name)
 }
 
 pub fn get_current_groupname() -> Option<String> {
     let gid = nix::unistd::getgid();
-    Group::from_gid(gid).ok().flatten().map(|g| g.name)
+    ok_log!(Group::from_gid(gid)).flatten().map(|g| g.name)
 }
 
 pub fn get_effective_username() -> Option<String> {
     let euid = nix::unistd::geteuid();
-    User::from_uid(euid).ok().flatten().map(|u| u.name)
+    ok_log!(User::from_uid(euid)).flatten().map(|u| u.name)
 }
 
 pub fn get_effective_uid() -> u32 { nix::unistd::geteuid().as_raw() }
@@ -63,11 +60,11 @@ pub fn get_effective_gid() -> u32 { nix::unistd::getegid().as_raw() }
 
 pub fn get_effective_groupname() -> Option<String> {
     let egid = nix::unistd::getegid();
-    Group::from_gid(egid).ok().flatten().map(|g| g.name)
+    ok_log!(Group::from_gid(egid)).flatten().map(|g| g.name)
 }
 
 pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
-    User::from_name(username).ok().flatten().map(|u| u.dir)
+    ok_log!(User::from_name(username)).flatten().map(|u| u.dir)
 }
 
 pub fn root_level_account() -> String { "root".to_string() }

--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -2,9 +2,9 @@ use std::path::PathBuf;
 
 use crate::error::{Error,
                    Result};
-use users::{self,
-            os::unix::{GroupExt,
-                       UserExt}};
+
+use nix::unistd::{Group,
+                  User};
 
 /// This is currently the "master check" for whether the Supervisor
 /// can behave "as root".
@@ -26,46 +26,48 @@ pub fn can_run_services_as_svc_user() -> bool {
 pub fn can_run_services_as_svc_user() -> bool { true }
 
 pub fn get_uid_by_name(owner: &str) -> Option<u32> {
-    users::get_user_by_name(owner).map(|u| u.uid())
+    User::from_name(owner).ok()
+                          .flatten()
+                          .map(|u| u.uid.as_raw())
 }
 
 pub fn get_gid_by_name(group: &str) -> Option<u32> {
-    users::get_group_by_name(group).map(|g| g.gid())
+    Group::from_name(group).ok()
+                           .flatten()
+                           .map(|g| g.gid.as_raw())
 }
 
 /// Any members that fail conversion from OsString to string will be omitted
 pub fn get_members_by_groupname(group: &str) -> Option<Vec<String>> {
-    users::get_group_by_name(group).map(|g| {
-                                       g.members()
-                                        .to_vec()
-                                        .into_iter()
-                                        .filter_map(|os_string| os_string.into_string().ok())
-                                        .collect()
-                                   })
+    Group::from_name(group).ok().flatten().map(|g| g.mem)
 }
 
 pub fn get_current_username() -> Option<String> {
-    users::get_current_username().and_then(|os_string| os_string.into_string().ok())
+    let uid = nix::unistd::getuid();
+    User::from_uid(uid).ok().flatten().map(|u| u.name)
 }
 
 pub fn get_current_groupname() -> Option<String> {
-    users::get_current_groupname().and_then(|os_string| os_string.into_string().ok())
+    let gid = nix::unistd::getgid();
+    Group::from_gid(gid).ok().flatten().map(|g| g.name)
 }
 
 pub fn get_effective_username() -> Option<String> {
-    users::get_effective_username().and_then(|os_string| os_string.into_string().ok())
+    let euid = nix::unistd::geteuid();
+    User::from_uid(euid).ok().flatten().map(|u| u.name)
 }
 
-pub fn get_effective_uid() -> u32 { users::get_effective_uid() }
+pub fn get_effective_uid() -> u32 { nix::unistd::geteuid().as_raw() }
 
-pub fn get_effective_gid() -> u32 { users::get_effective_gid() }
+pub fn get_effective_gid() -> u32 { nix::unistd::getegid().as_raw() }
 
 pub fn get_effective_groupname() -> Option<String> {
-    users::get_effective_groupname().and_then(|os_string| os_string.into_string().ok())
+    let egid = nix::unistd::getegid();
+    Group::from_gid(egid).ok().flatten().map(|g| g.name)
 }
 
 pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
-    users::get_user_by_name(username).map(|u| PathBuf::from(u.home_dir()))
+    User::from_name(username).ok().flatten().map(|u| u.dir)
 }
 
 pub fn root_level_account() -> String { "root".to_string() }

--- a/components/core/src/util.rs
+++ b/components/core/src/util.rs
@@ -8,6 +8,24 @@ pub mod win_perm;
 
 use std::mem;
 
+/// Same as `Result::ok()`, but logs the error case. Useful for
+/// ignoring error cases, while still leaving a paper trail.
+#[macro_export]
+macro_rules! ok_log {
+    ($result:expr) => {
+        match $result {
+            Ok(val) => Some(val),
+            Err(e) => {
+                warn!("Intentionally ignored error ({}:{}): {:?}",
+                      file!(),
+                      line!(),
+                      e);
+                None
+            }
+        }
+    };
+}
+
 /// returns the common arguments to pass to pwsh.exe when spawning a powershell instance.
 /// These arguments are optimized for a background powershell process running hooks.
 /// The NonInteractive flag specifies that the console is not intended to interact with


### PR DESCRIPTION
The nix crate is a bit more robust than the users create with respect
to its error handling. This moves us directly to the nix create
without changing any of the APIs in core::users.

This likely resolves #7298 for many users as nix correctly handles
ERANGE errors from getgrnam_r. However, the nix still enforces a
maximum buffer size of 16KB, so there is still a chance for a failure
caused by a large group. We could avoid this by calling libc directly
or working with upstream to make the buffer size configurable.

Review Notes:

- We should follow up with a change to change the API in the users module from returning `Option<T>`s to `Result<Option<T>`.  I started on this and the changes are pretty straightforward, but I need to look at each call site to decide whether it makes sense to ignore the errors or not.

- I still don't love the 16KB limit.  I'm thinking the best bet might be to work with upstream to make this configurable.

Signed-off-by: Steven Danna <steve@chef.io>