### PR TITLE
WIP hab: support multiple idents and build vars in `hab pkg env`

### DIFF
--- a/components/core/src/package/install.rs
+++ b/components/core/src/package/install.rs
@@ -4,7 +4,8 @@ use super::{list::package_list_for_ident,
                        Bind,
                        BindMapping,
                        MetaFile,
-                       PackageType},
+                       PackageType,
+                       BUILD_ENVIRONMENT_FILES},
             Identifiable,
             PackageIdent};
 use crate::{error::{Error,
@@ -217,6 +218,22 @@ impl PackageInstall {
     /// the composite, and not the fully-resolved identifiers you
     /// would get from other "dependency" metadata files.
     pub fn pkg_services(&self) -> Result<Vec<PackageIdent>> { self.read_deps(MetaFile::Services) }
+
+    pub fn build_environment(&self) -> Result<BTreeMap<String, String>> {
+        let mut env: BTreeMap<String, String> = BTreeMap::new();
+        for file in BUILD_ENVIRONMENT_FILES.iter() {
+            match self.read_metafile(*file) {
+                Ok(data) => {
+                    env.insert(file.envvar(), data.trim().to_string());
+                }
+                Err(Error::MetaFileNotFound(_)) => {}
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(env)
+    }
 
     /// Constructs and returns a `HashMap` of environment variable/value key pairs of all
     /// environment variables needed to properly run a command from the context of this package.

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -600,9 +600,13 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
              )
             (subcommand: sub_pkg_download())
             (@subcommand env =>
-                (about: "Prints the runtime environment of a specific installed package")
-                (@arg PKG_IDENT: +required +takes_value {valid_ident}
+                (about: "Prints the runtime or build-time environment of specific installed packages")
+                (@arg PKG_IDENT: +required +takes_value +multiple {valid_ident}
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
+                (@arg BUILD: -b --build
+                    "Include common build-time environment variables in addition to runtime variables")
+                (@arg APPEND_EXISTING: -a --("append-existing")
+                    "Append existing values to environment variables when printing")
             )
             (@subcommand exec =>
                 (about: "Executes a command using the 'PATH' context of an installed package")

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -210,10 +210,17 @@ pub enum Pkg {
         #[structopt(name = "IGNORE_MISSING_SEEDS", long = "ignore-missing-seeds")]
         ignore_missing_seed: bool,
     },
-    /// Prints the runtime environment of a specific installed package
+    /// Prints the runtime or build-time environment of specific installed packages
     Env {
-        #[structopt(flatten)]
-        pkg_ident: PkgIdent,
+        /// A package identifier (ex: core/redis, core/busybox-static/1.42.2)
+        #[structopt(name = "PKG_IDENT", required = true)]
+        pkg_ident:       Vec<PackageIdent>,
+        /// Include common build-time environment variables in addition to runtime variables
+        #[structopt(name = "BUILD", short = "b", long = "build")]
+        build:           bool,
+        /// Append existing values to environment variables when printing
+        #[structopt(name = "APPEND_EXISTING", short = "a", long = "append-existing")]
+        append_existing: bool,
     },
     /// Executes a command using the 'PATH' context of an installed package
     Exec {

--- a/components/hab/src/command/pkg/env.rs
+++ b/components/hab/src/command/pkg/env.rs
@@ -1,26 +1,145 @@
 use crate::{error::Result,
-            hcore::package::{PackageIdent,
+            hcore::package::{metadata::DEFAULT_AGGREGATE_SEP,
+                             PackageIdent,
                              PackageInstall}};
-use std::{collections::BTreeMap,
+use std::{collections::{BTreeMap,
+                        HashMap},
+          env,
           path::Path};
 
-pub fn start(ident: &PackageIdent, fs_root_path: &Path) -> Result<()> {
-    let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;
-    let env = pkg_install.environment_for_command()?;
-    render_environment(env);
+use lazy_static::lazy_static;
+
+pub fn start(idents: &[PackageIdent],
+             fs_root_path: &Path,
+             include_build_flags: bool,
+             append_existing: bool)
+             -> Result<()> {
+    let env = if idents.len() == 1 {
+        environment_for_ident(&idents[0], fs_root_path, include_build_flags)?
+    } else {
+        merged_environment_for_idents(idents, fs_root_path, include_build_flags)?
+    };
+
+    render_environment(env, append_existing);
     Ok(())
 }
 
-#[cfg(unix)]
-fn render_environment(env: BTreeMap<String, String>) {
-    for (key, value) in env.into_iter() {
-        println!("export {}=\"{}\"", key, value);
+fn environment_for_ident(ident: &PackageIdent,
+                         fs_root_path: &Path,
+                         include_build_flags: bool)
+                         -> Result<BTreeMap<String, String>> {
+    let pkg_install = PackageInstall::load(ident, Some(fs_root_path))?;
+    let mut env = pkg_install.environment_for_command()?;
+    if include_build_flags {
+        let mut build_env = pkg_install.build_environment()?;
+        env.append(&mut build_env);
     }
+    Ok(env)
 }
 
-#[cfg(windows)]
-fn render_environment(env: BTreeMap<String, String>) {
-    for (key, value) in env.into_iter() {
+// merged_environment_for_idents merges the runtime environments for
+// the given idents.
+//
+// If the variable is a well-known aggregate value, we merge the
+// values, removing duplicates and preserving the ordering.
+//
+// If the variable is not a well-known aggregate, the first entry
+// wins.
+fn merged_environment_for_idents(idents: &[PackageIdent],
+                                 fs_root_path: &Path,
+                                 include_build_flags: bool)
+                                 -> Result<BTreeMap<String, String>> {
+    // collect environments variables for each ident
+    let mut pkg_envs: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for ident in idents.iter() {
+        let pkg_env = environment_for_ident(ident, fs_root_path, include_build_flags)?;
+        for (key, value) in pkg_env.iter() {
+            match pkg_envs.get_mut(key) {
+                Some(v) => {
+                    v.push(value.to_string());
+                }
+                None => {
+                    pkg_envs.insert(key.to_string(), vec![value.to_string()]);
+                }
+            };
+        }
+    }
+
+    // build final enviroment map, deduplicating elements as we go.
+    let mut env: BTreeMap<String, String> = BTreeMap::new();
+    for (key, values) in pkg_envs.iter() {
+        if is_known_aggregate(key) && values.len() > 1 {
+            // NOTE(ssd) 2019-11-17: If this ends up being too
+            // expensive we could drop the deduplication.
+            let sep = &sep_for_envvar(&key);
+            let mut markmap = HashMap::new();
+            let value = values.iter()
+                              .flat_map(|v| v.split(sep))
+                              .filter(|v| markmap.insert(*v, ()).is_none())
+                              .collect::<Vec<&str>>()
+                              .join(sep);
+            env.insert(key.to_string(), value);
+        } else {
+            env.insert(key.to_string(), values[0].clone());
+        };
+    }
+    Ok(env)
+}
+
+lazy_static! {
+    static ref WELL_KNOWN_AGGREGATES: HashMap<&'static str, char> = {
+        let mut m = HashMap::new();
+        m.insert("PATH", DEFAULT_AGGREGATE_SEP);
+        m.insert("CFLAGS", ' ');
+        m.insert("CPPFLAGS", ' ');
+        m.insert("CXXFLAGS", ' ');
+        m.insert("LDFLAGS", ' ');
+        m.insert("LD_RUN_PATH", DEFAULT_AGGREGATE_SEP);
+        m.insert("PKG_CONFIG_PATH", DEFAULT_AGGREGATE_SEP);
+
+        #[cfg(windows)]
+        {
+            m.insert("INCLUDE", ';');
+            m.insert("LIB", ';');
+            m.insert("PATHEXT", ';');
+            m.insert("PSModulePath", ';');
+        }
+
+        m.insert("CLASSPATH", ';');
+        m.insert("PYTHONPATH", DEFAULT_AGGREGATE_SEP);
+        m.insert("NODE_PATH", DEFAULT_AGGREGATE_SEP);
+        m.insert("GOPATH", DEFAULT_AGGREGATE_SEP);
+        m.insert("BUNDLE_PATH", DEFAULT_AGGREGATE_SEP);
+        m.insert("BUNDLE_WITHOUT", DEFAULT_AGGREGATE_SEP);
+        m.insert("GEM_PATH", DEFAULT_AGGREGATE_SEP);
+        m.insert("RUBYLIB", DEFAULT_AGGREGATE_SEP);
+        m.insert("RUBYPATH", DEFAULT_AGGREGATE_SEP);
+        m.insert("PERL5LIB", DEFAULT_AGGREGATE_SEP);
+        m.insert("CMAKE_FIND_ROOT_PATH", ';');
+        m
+    };
+}
+
+fn is_known_aggregate(varname: &str) -> bool { WELL_KNOWN_AGGREGATES.contains_key(varname) }
+
+fn sep_for_envvar(varname: &str) -> String {
+    WELL_KNOWN_AGGREGATES.get(varname)
+                         .unwrap_or(&DEFAULT_AGGREGATE_SEP)
+                         .to_string()
+}
+
+fn render_environment(environ: BTreeMap<String, String>, append_existing: bool) {
+    for (key, mut value) in environ.into_iter() {
+        if append_existing {
+            if let Ok(existing_value) = env::var(&key) {
+                value.push_str(&sep_for_envvar(&key));
+                value.push_str(&existing_value);
+            }
+        }
+
+        #[cfg(unix)]
+        println!("export {}=\"{}\"", key, value);
+        #[cfg(windows)]
         println!("$env:{}=\"{}\"", key, value);
     }
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -672,9 +672,10 @@ async fn sub_pkg_download(ui: &mut UI,
 }
 
 fn sub_pkg_env(m: &ArgMatches<'_>) -> Result<()> {
-    let ident = PackageIdent::from_str(m.value_of("PKG_IDENT").unwrap())?;
-
-    command::pkg::env::start(&ident, &*FS_ROOT)
+    let idents = idents_from_matches(m)?;
+    let build = m.is_present("BUILD");
+    let append_existing = m.is_present("APPEND_EXISTING");
+    command::pkg::env::start(&idents, &*FS_ROOT, build, append_existing)
 }
 
 fn sub_pkg_exec(m: &ArgMatches<'_>, cmd_args: &[OsString]) -> Result<()> {


### PR DESCRIPTION
This allows the user to run commands such as

    hab pkg env core/make core/gcc

The printed environment will contain the merged environment for
certain well-known variables. For unknown variables, the first package
to include the variable wins.

The --build flag now allows the user to print the build-relevant
environment variables for the given packages.

The --append-existing flag appends any existing values of the relevant
environment variables from the processes environment to the printed
environment.

Together, these features allow us to create ad-hoc development
environment using Habitat packages, which is nice for when developing
software locally:

   eval "$(hab pkg env core/gcc core/glibc core/openssl --build --append-existing)"

This is especially nice when trying to go through the
edit-compile-debug loop using local tools. In such a case a full
habitat package build is often slow without special code inside your
plan.sh specifically for dev builds.

If we are interesting in pursuing this, I think that to make this most
useful the path forward might look like:

- Review and exactly define the semantics of how variables are merged,
  build vs runtime variables, and transitive vs non-transitive
  dependencies.

- Rewrite some of the code in hab-plan-build to use this command
  directly so that we have only 1 implementation of this code.

Signed-off-by: Steven Danna <steve@chef.io>