### PR TITLE
Add pkg_plugins feature

### DIFF
--- a/components/hab/static/template_plan.sh
+++ b/components/hab/static/template_plan.sh
@@ -71,6 +71,12 @@ pkg_scaffolding="{{ scaffolding_ident }}"
 # pkg_scaffolding="some/scaffolding"
 {{~ /if}}
 
+{{~ #unless minimal}}
+
+# Optional.
+# The plugins for this plan.
+pkg_plugins=()
+{{~ /unless}}
 
 {{~ #unless minimal}}
 


### PR DESCRIPTION
This feature is very similar to scaffolding but allows you to provided
multiple plugins instead of single one. Multiple plugins can bring you
small pieces of handy functionality. Consider the forum thread[1]
about plugins.

[1] https://forums.habitat.sh/t/habitat-plugins/1305

Resolves: https://github.com/habitat-sh/habitat/issues/6477
Signed-off-by: Yauhen Artsiukhou <jsirex@gmail.com>