### PR TITLE
[CI] Ensure release pipeline is not poisoned by old dependencies

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -12,6 +12,8 @@ expeditor:
       env:
         HAB_ORIGIN: "core"
         PIPELINE_HAB_BLDR_URL: "https://bldr.habitat.sh"
+        # Necessary to prevent old studios from poisoning builds after core plans refreshes
+        HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL: "true"
 
 steps:
 #######################################################################


### PR DESCRIPTION
We need to prevent dependencies that already exist in the Studio don't
influence the inputs of the builds.

This is particularly important as core plans refreshes go out.

Signed-off-by: Christopher Maier <cmaier@chef.io>