### PR TITLE
[TYPO] Gigabytes are "gb", not "bg"

### DIFF
--- a/components/pkg-export-docker/src/cli.rs
+++ b/components/pkg-export-docker/src/cli.rs
@@ -273,7 +273,7 @@ impl<'a, 'b> Cli<'a, 'b> {
                                                          .long("memory")
                                                          .short("m")
                                                          .help("Memory limit passed to docker \
-                                                                build's --memory arg (ex: 2bg)"));
+                                                                build's --memory arg (ex: 2gb)"));
 
         Cli { app }
     }


### PR DESCRIPTION
Signed-off-by: Christopher Maier <cmaier@chef.io>