### PR TITLE
[REFACTOR] Push Windows Docker Engine check earlier

### DIFF
--- a/components/pkg-export-docker/src/error.rs
+++ b/components/pkg-export-docker/src/error.rs
@@ -16,10 +16,6 @@ pub enum Error {
     BuildFailed(ExitStatus),
     #[fail(display = "Could not determine Docker image ID for image: {}", _0)]
     DockerImageIdNotFound(String),
-    #[fail(display = "Switch to Windows containers to export Docker images on Windows. Current \
-                      Docker Server OS is set to: {}",
-           _0)]
-    DockerNotInWindowsMode(String),
     #[fail(display = "Invalid registry type: {}", _0)]
     InvalidRegistryType(String),
     #[fail(display = "{}", _0)]

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -36,6 +36,7 @@ mod cli;
 mod docker;
 mod error;
 mod graph;
+mod os;
 #[cfg(unix)]
 mod rootfs;
 mod util;
@@ -206,6 +207,8 @@ pub async fn export<'a>(ui: &'a mut UI,
 pub async fn export_for_cli_matches(ui: &mut UI,
                                     matches: &clap::ArgMatches<'_>)
                                     -> Result<Option<DockerImage>> {
+    os::ensure_proper_docker_platform()?;
+
     let default_url = default_bldr_url();
     let spec = BuildSpec::new_from_cli_matches(&matches, &default_url)?;
     let naming = Naming::new_from_cli_matches(&matches);

--- a/components/pkg-export-docker/src/os.rs
+++ b/components/pkg-export-docker/src/os.rs
@@ -1,0 +1,5 @@
+//! OS-specific implementations of various things.
+
+mod check;
+
+pub(crate) use check::ensure_proper_docker_platform;

--- a/components/pkg-export-docker/src/os/check.rs
+++ b/components/pkg-export-docker/src/os/check.rs
@@ -1,0 +1,13 @@
+#[cfg(not(windows))]
+use crate::error::Result;
+
+/// Linux Docker daemons currently only run in one mode, so this can
+/// be a no-op.
+#[cfg(not(windows))]
+pub(crate) fn ensure_proper_docker_platform() -> Result<()> { Ok(()) }
+
+// On Windows, however, we have a bit more work to do.
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub(crate) use windows::ensure_proper_docker_platform;

--- a/components/pkg-export-docker/src/os/check/windows.rs
+++ b/components/pkg-export-docker/src/os/check/windows.rs
@@ -1,0 +1,61 @@
+use crate::{error::Result,
+            util};
+
+/// Currently when exporting containers on Windows, the Docker daemon
+/// *must* be in Windows mode (i.e., only Windows containers can be
+/// exported on Windows machines).
+///
+/// If the daemon is in Linux mode, we return an error and should stop
+/// the export process.
+pub(crate) fn ensure_proper_docker_platform() -> Result<()> {
+    match DockerOS::current() {
+        DockerOS::Windows => Ok(()),
+        other => Err(Error::DockerNotInWindowsMode(other).into()),
+    }
+}
+
+#[derive(Debug, Fail)]
+enum Error {
+    #[fail(display = "Only Windows container export is supported; please set your Docker daemon \
+                      to Windows container mode.\n\nThe Docker daemon is currently set for: {:?}",
+           _0)]
+    DockerNotInWindowsMode(DockerOS),
+}
+
+/// Describes the OS of the containers the Docker daemon is currently
+/// configured to manage.
+#[derive(Clone, Debug)]
+enum DockerOS {
+    /// Docker daemon is managing Linux containers
+    Linux,
+    /// Docker daemon is managing Windows containers
+    Windows,
+    /// Generic fall-through for error handling and extra paranoia
+    Unknown(String),
+}
+
+impl DockerOS {
+    /// Returns the OS for which the locally-running Docker daemon is
+    /// managing containers.
+    ///
+    /// Daemons running on Linux would report "Linux", while a Windows
+    /// daemon may report "Windows" or "Linux", depending on what mode
+    /// it is currently running in.
+    fn current() -> DockerOS {
+        let mut cmd = util::docker_cmd();
+        cmd.arg("version").arg("--format='{{.Server.Os}}'");
+        debug!("Running command: {:?}", cmd);
+        let result = cmd.output().expect("Docker command failed to spawn");
+        let result = String::from_utf8_lossy(&result.stdout);
+        if result.contains("windows") {
+            DockerOS::Windows
+        } else if result.contains("linux") {
+            DockerOS::Linux
+        } else {
+            // We really shouldn't get down here, but we *are* parsing
+            // strings from other software that might change in the
+            // future.
+            DockerOS::Unknown(result.to_string())
+        }
+    }
+}

--- a/components/pkg-export-docker/src/util.rs
+++ b/components/pkg-export-docker/src/util.rs
@@ -1,13 +1,19 @@
 use crate::error::Result;
-use habitat_core::package::{PackageIdent,
-                            PackageInstall};
+use habitat_core::{package::{PackageIdent,
+                             PackageInstall},
+                   util::docker};
 use std::{fs::{self,
                File},
           io::Write,
           path::{Path,
-                 PathBuf}};
-
+                 PathBuf},
+          process::Command};
 const BIN_PATH: &str = "/bin";
+
+/// Returns a `Command` for the Docker program.
+pub(crate) fn docker_cmd() -> Command {
+    Command::new(docker::command_path().expect("Unable to locate docker"))
+}
 
 /// Returns the `bin` path used for symlinking programs.
 pub fn bin_path() -> &'static Path { Path::new(BIN_PATH) }


### PR DESCRIPTION
When exporting a container on Windows, the Docker daemon must be in
Windows mode. Previously, this check was buried deep in the logic,
after we had already done a lot of work to pull packages down. Now, we
perform this check first, thereby short circuiting a whole bunch of
unnecessary work, and cleaning up a bunch of logic.

Here, I'm trying to be a bit more intentional in how platform-specific
logic is organized in this crate, in order to make it more clear what
the general interfaces are, as well as what the *exact* platform
differences are, without littering conditional compilation directives
everywhere.

Additionally, in an effort to keep related code together, as well as
to start experimenting with better error organization, the error for a
failed platform check on Windows is actually kept with the platform
checking code itself, and converted into the generic Error we use
across the crate.

Signed-off-by: Christopher Maier <cmaier@chef.io>