### PR TITLE
[REFACTOR] Remove some lifetimes to simplify Docker exporter

### DIFF
--- a/components/pkg-export-docker/src/build.rs
+++ b/components/pkg-export-docker/src/build.rs
@@ -342,7 +342,7 @@ impl BuildSpec {
                      &self.url,
                      &self.channel,
                      fs_root_path,
-                     self.auth.as_ref().map(String::as_str)) //eww
+                     self.auth.as_deref())
             .await
     }
 

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -174,7 +174,7 @@ impl Credentials {
 /// * If building the Docker image fails
 /// * If destroying the temporary build root directory fails
 pub async fn export<'a>(ui: &'a mut UI,
-                        build_spec: BuildSpec<'a>,
+                        build_spec: BuildSpec,
                         naming: &'a Naming<'a>,
                         memory: Option<&'a str>)
                         -> Result<DockerImage> {


### PR DESCRIPTION
These lifetime parameters were added to allow us to hold onto `str`
references from our Clap `ArgMatches`. However, this ends up
implicitly coupling all of our types to choices made by our CLI
library. Also, there's no real benefit to not allocating a few extra
Strings in a short-lived CLI application like this, so there's no
reason to carry around the extra cognitive overhead.

Signed-off-by: Christopher Maier <cmaier@chef.io>