### PR TITLE
[CI] Fix e2e test that broke after the core plans refresh

### DIFF
--- a/test/end-to-end/test_pkg_download.ps1
+++ b/test/end-to-end/test_pkg_download.ps1
@@ -37,9 +37,10 @@ function Test-GzipIdent {
     Test-IdentDownloaded "core-pcre"
     Test-IdentDownloaded "core-less"
     Test-IdentDownloaded "core-ncurses"
+    Test-IdentDownloaded "core-zlib"
 
-    if((Get-ChildItem (Join-Path $cacheDir "artifacts") -File).Count -ne 8) {
-        Write-Error "did not find 8 gzip artifacts"
+    if((Get-ChildItem (Join-Path $cacheDir "artifacts") -File).Count -ne 9) {
+        Write-Error "did not find 9 gzip artifacts"
     }
 }
 


### PR DESCRIPTION
Our `hab pkg download` test downloads `core/gzip` and then makes
assertions that all that package's transitive dependencies are also
downloaded. Because we don't yet have a great way to programmatically
extract that information from the artifact itself, the test hard-codes
knowledge of the dependencies.

After the most recent core plans refresh, the `core/gzip` package
gained a `core/zlib` dependency. The test didn't know about that, so
it ended up failing.

Here is `core/gzip` [before][1] the refresh, and here it is
[after][2].

(While we *can* extract the `TDEPS` file from the hart file with some
shell scripting, this really needs to be part of `hab pkg info`; it
would be more worthwhile to devote effort there. Thus, this PR takes
the expedient route in order to get the pipeline flowing again.)

[1]:https://bldr.habitat.sh/#/pkgs/core/gzip/1.9/20190115013612
[2]:https://bldr.habitat.sh/#/pkgs/core/gzip/1.10/20200306002325

Signed-off-by: Christopher Maier <cmaier@chef.io>