### PR TITLE
[REFACTOR]  Factor out an Identified trait for DockerBuilder and DockerImage

### DIFF
--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -177,9 +177,6 @@ impl DockerImage {
         Ok(())
     }
 
-    /// Returns the ID of this image.
-    pub fn id(&self) -> &str { self.id.as_str() }
-
     /// Returns the name of this image.
     pub fn name(&self) -> &str { self.name.as_str() }
 

--- a/components/pkg-export-docker/src/docker.rs
+++ b/components/pkg-export-docker/src/docker.rs
@@ -27,6 +27,50 @@ const DOCKERFILE: &str = include_str!("../defaults/Dockerfile_win.hbs");
 /// The build report template.
 const BUILD_REPORT: &str = include_str!("../defaults/last_docker_export.env.hbs");
 
+// TODO (CM): public temporarily
+pub(crate) trait Identified {
+    /// The base name of an image.
+    fn name(&self) -> String;
+
+    /// The possibly-empty list of tags for an image.
+    fn tags(&self) -> Vec<String>;
+
+    /// Returns a non-empty collection of names this image is known
+    /// by.
+    ///
+    /// If an image has no tags, it includes just the name. If it
+    /// *does* have tags, it includes the tags prepended with the
+    /// name.
+    ///
+    /// Thus, you could get as little as:
+    ///
+    /// core/redis
+    ///
+    /// or as much as:
+    ///
+    /// core/redis:latest
+    /// core/redis:4.0.14
+    /// core/redis:4.0.14-20190319155852
+    /// core/redis:latest
+    /// core/redis:my-custom-tag
+    fn expanded_identifiers(&self) -> Vec<String> {
+        let mut ids = vec![];
+
+        let tags = self.tags();
+        let name = self.name();
+
+        if tags.is_empty() {
+            ids.push(name);
+        } else {
+            for tag in tags {
+                ids.push(format!("{}:{}", name, tag));
+            }
+        }
+
+        ids
+    }
+}
+
 /// A builder used to create a Docker image.
 pub struct DockerBuilder {
     /// The base workdir which hosts the root file system.
@@ -37,6 +81,12 @@ pub struct DockerBuilder {
     tags:    Vec<String>,
     /// Optional memory limit to pass to pass to the docker build
     memory:  Option<String>,
+}
+
+impl Identified for DockerBuilder {
+    fn name(&self) -> String { self.name.clone() }
+
+    fn tags(&self) -> Vec<String> { self.tags.clone() }
 }
 
 impl DockerBuilder {
@@ -72,12 +122,8 @@ impl DockerBuilder {
         if let Some(ref mem) = self.memory {
             cmd.arg("--memory").arg(mem);
         }
-        if self.tags.is_empty() {
-            cmd.arg("--tag").arg(&self.name);
-        } else {
-            for tag in &self.tags {
-                cmd.arg("--tag").arg(format!("{}:{}", &self.name, tag));
-            }
+        for identifier in &self.expanded_identifiers() {
+            cmd.arg("--tag").arg(identifier);
         }
         cmd.arg(".");
         debug!("Running: {:?}", &cmd);
@@ -123,6 +169,12 @@ pub struct DockerImage {
     workdir: PathBuf,
 }
 
+impl Identified for DockerImage {
+    fn name(&self) -> String { self.name.clone() }
+
+    fn tags(&self) -> Vec<String> { self.tags.clone() }
+}
+
 impl DockerImage {
     /// Pushes the Docker image, with all tags, to a remote registry using the provided
     /// `Credentials`.
@@ -138,19 +190,17 @@ impl DockerImage {
                 registry_url: Option<&str>)
                 -> Result<()> {
         ui.begin(format!("Pushing Docker image '{}' with all tags to remote registry",
-                         self.name()))?;
+                         self.name))?;
         self.create_docker_config_file(credentials, registry_url)
             .unwrap();
-        if self.tags.is_empty() {
-            self.push_image(ui, None)?;
-        } else {
-            for tag in &self.tags {
-                self.push_image(ui, Some(tag))?;
-            }
+
+        for identifier in self.expanded_identifiers() {
+            self.push_image(ui, &identifier)?;
         }
+
         ui.end(format!("Docker image '{}' published with tags: {}",
-                       self.name(),
-                       self.tags().join(", "),))?;
+                       self.name,
+                       self.tags.join(", "),))?;
 
         Ok(())
     }
@@ -162,26 +212,17 @@ impl DockerImage {
     /// * If one or more of the image tags cannot be removed
     pub fn rm(self, ui: &mut UI) -> Result<()> {
         ui.begin(format!("Cleaning up local Docker image '{}' with all tags",
-                         self.name()))?;
-        if self.tags.is_empty() {
-            self.rm_image(ui, None)?;
-        } else {
-            for tag in &self.tags {
-                self.rm_image(ui, Some(tag))?;
-            }
-        }
-        ui.end(format!("Local Docker image '{}' with tags: {} cleaned up",
-                       self.name(),
-                       self.tags().join(", "),))?;
+                         self.name))?;
 
+        for identifier in self.expanded_identifiers() {
+            self.rm_image(ui, &identifier)?;
+        }
+
+        ui.end(format!("Local Docker image '{}' with tags: {} cleaned up",
+                       self.name,
+                       self.tags.join(", "),))?;
         Ok(())
     }
-
-    /// Returns the name of this image.
-    pub fn name(&self) -> &str { self.name.as_str() }
-
-    /// Returns the list of tags for this image.
-    pub fn tags(&self) -> &[String] { &self.tags }
 
     /// Create a build report with image metadata in the given path.
     ///
@@ -232,17 +273,13 @@ impl DockerImage {
         Ok(())
     }
 
-    fn push_image(&self, ui: &mut UI, tag: Option<&str>) -> Result<()> {
-        let image_tag = match tag {
-            Some(tag) => format!("{}:{}", &self.name, tag),
-            None => self.name.to_string(),
-        };
+    fn push_image(&self, ui: &mut UI, image_tag: &str) -> Result<()> {
         ui.status(Status::Uploading,
-                  format!("image '{}' to remote registry", &image_tag))?;
+                  format!("image '{}' to remote registry", image_tag))?;
         let mut cmd = util::docker_cmd();
         cmd.arg("--config");
         cmd.arg(self.workdir.to_str().unwrap());
-        cmd.arg("push").arg(&image_tag);
+        cmd.arg("push").arg(image_tag);
         debug!("Running: {:?}", &cmd);
         let exit_status = cmd.spawn()?.wait()?;
         if !exit_status.success() {
@@ -253,14 +290,10 @@ impl DockerImage {
         Ok(())
     }
 
-    fn rm_image(&self, ui: &mut UI, tag: Option<&str>) -> Result<()> {
-        let image_tag = match tag {
-            Some(tag) => format!("{}:{}", &self.name, tag),
-            None => self.name.to_string(),
-        };
-        ui.status(Status::Deleting, format!("local image '{}'", &image_tag))?;
+    fn rm_image(&self, ui: &mut UI, image_tag: &str) -> Result<()> {
+        ui.status(Status::Deleting, format!("local image '{}'", image_tag))?;
         let mut cmd = util::docker_cmd();
-        cmd.arg("rmi").arg(&image_tag);
+        cmd.arg("rmi").arg(image_tag);
         debug!("Running: {:?}", &cmd);
         let exit_status = cmd.spawn()?.wait()?;
         if !exit_status.success() {

--- a/components/pkg-export-docker/src/lib.rs
+++ b/components/pkg-export-docker/src/lib.rs
@@ -7,13 +7,14 @@ extern crate log;
 #[macro_use]
 extern crate serde_json;
 
-use crate::naming::Naming;
 pub use crate::{build::BuildSpec,
                 cli::cli,
                 docker::{DockerBuildRoot,
                          DockerImage},
                 error::{Error,
                         Result}};
+use crate::{docker::Identified,
+            naming::Naming};
 use habitat_common::ui::{UIWriter,
                          UI};
 use habitat_core::url::default_bldr_url;


### PR DESCRIPTION
Both `DockerBuilder` and `DockerImage` had repeated logic for creating
the tags they use when creating an image, as well as when pushing and
deleting one.

One way to cut out the repetition is to factor the logic into a new
`Identified` trait that both structs can implement. It's admittedly
not the greatest name, but I suspect that it will ultimately be a
short-lived trait, pending some more work in progress.

(There are some other minor supporting refactors in this PR, broken out into separate commits. Please read commit messages for further details.)
