### PR TITLE
Remove duplicated serialization logic in SvcMember

### DIFF
--- a/components/sup/doc/render_context_schema.json
+++ b/components/sup/doc/render_context_schema.json
@@ -100,6 +100,10 @@
                     "description": "The identifier of the release the member is running",
                     "$ref": "#/definitions/package_identifier"
                 },
+                "package": {
+                    "description": "The package identifier",
+                    "type": "string"
+                  },
                 "sys": {
                     "description": "An abbreviated version of the top-level {{sys}} object, containing networking information for the member.",
                     "type": "object",

--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -553,9 +553,7 @@ impl Serialize for CensusGroup {
         strukt.end()
     }
 }
-// NOTE: This is exposed to users in templates. Any public member is
-// accessible to users, so change this interface with care.
-//
+
 // User-facing documentation is available at
 // https://www.habitat.sh/docs/reference/#template-data; update that
 // as required.


### PR DESCRIPTION
Both the [`SvcMember`](https://github.com/habitat-sh/habitat/blob/4c10302b0c3f8aeb04fb2739580472c257e03ee7/components/sup/src/manager/service/context.rs#L376) and [`CensusMemberProxy`](https://github.com/habitat-sh/habitat/blob/4c10302b0c3f8aeb04fb2739580472c257e03ee7/components/sup/src/census.rs#L671) acted as a serialization proxy for [`CensusMember`](https://github.com/habitat-sh/habitat/blob/4c10302b0c3f8aeb04fb2739580472c257e03ee7/components/sup/src/census.rs#L563). This lead to significant duplication of code. This PR makes `SvcMember` an alias of `CensusMemberProxy` removing the duplication. The one difference between the two serialization methods was the [`package`](https://github.com/habitat-sh/habitat/blob/2d4d374c7eb19c5c01d9adadfa3d4d7bedaf50f0/components/sup/doc/render_context_schema.json#L103) field. I think it is ok to add this field. There was even a [todo comment](https://github.com/habitat-sh/habitat/blob/4c10302b0c3f8aeb04fb2739580472c257e03ee7/components/sup/src/manager/service/context.rs#L444) to add it. This PR also moves the `Cow` into the `CensusMemberProxy` type reducing the need to clutter `Cow`s everywhere and increasing encapsulation.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>