### PR TITLE
Cleanup health checking

### DIFF
--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -844,8 +844,8 @@ impl Service {
             let initialization_state_for_err = Arc::clone(&self.initialization_state);
             let f = async move {
                 match hook_runner.into_future().await {
-                    Ok((maybe_exit_value, _)) => {
-                        *initialization_state.write() = if maybe_exit_value.unwrap_or(false) {
+                    Ok((exit_value, _)) => {
+                        *initialization_state.write() = if exit_value {
                             InitializationState::InitializerFinished
                         } else {
                             InitializationState::Uninitialized

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -1,12 +1,14 @@
 use crate::{error::Error,
-            manager::{event::{self,
-                              ServiceMetadata as ServiceEventMetadata},
+            manager::{event::ServiceMetadata as ServiceEventMetadata,
                       service::{hook_runner,
                                 hooks::HealthCheckHook,
                                 supervisor::Supervisor,
                                 ProcessOutput,
                                 ProcessState},
                       sync::GatewayState}};
+use futures::future::{self,
+                      AbortHandle,
+                      FutureExt};
 use habitat_common::{outputln,
                      templating::package::Pkg};
 use habitat_core::service::{HealthCheckInterval,
@@ -16,11 +18,13 @@ use std::{convert::TryFrom,
           sync::{Arc,
                  Mutex},
           time::Duration};
-use tokio::time;
+use tokio::{sync::mpsc::{self,
+                         UnboundedReceiver},
+            time};
 
 static LOGKEY: &str = "HK";
 
-/// The possible results of running a health check hook.
+/// The possible service health result from the status of running the health check.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize)]
 pub enum HealthCheckResult {
     Ok,
@@ -29,7 +33,7 @@ pub enum HealthCheckResult {
     Unknown,
 }
 
-/// Convert health check hook exit codes into `HealthCheckResult` statuses.
+/// Convert health check hook exit codes into `HealthCheckResult`.
 impl TryFrom<i32> for HealthCheckResult {
     type Error = Error;
 
@@ -56,6 +60,7 @@ impl fmt::Display for HealthCheckResult {
     }
 }
 
+/// The possible statuses from running a health check hook.
 pub enum HealthCheckHookStatus {
     Ran(ProcessOutput, Duration),
     FailedToRun(Duration),
@@ -65,176 +70,126 @@ pub enum HealthCheckHookStatus {
 
 impl HealthCheckHookStatus {
     pub fn maybe_duration(&self) -> Option<Duration> {
-        match &self {
-            Self::Ran(_, duration) => Some(*duration),
-            Self::FailedToRun(duration) => Some(*duration),
-            Self::FailedToStart | Self::NoHook => None,
+        if let Self::Ran(_, duration) | Self::FailedToRun(duration) = self {
+            Some(*duration)
+        } else {
+            None
         }
     }
 
     pub fn maybe_process_output(self) -> Option<ProcessOutput> {
-        match self {
-            Self::Ran(process_output, _) => Some(process_output),
-            Self::FailedToRun(_) | Self::FailedToStart | Self::NoHook => None,
+        if let Self::Ran(output, _) = self {
+            Some(output)
+        } else {
+            None
         }
     }
 }
 
-/// All state needed for checking the health of a service over time.
-#[derive(Clone)]
-pub struct State {
-    // All hooks currently need these
-    hook:                   Option<Arc<HealthCheckHook>>,
-    service_group:          ServiceGroup,
-    package:                Pkg,
-    svc_encrypted_password: Option<String>,
-
-    service_event_metadata: ServiceEventMetadata,
-
-    /// A reference to the process supervisor for the service. This is
-    /// used to create a "proxy health check" for services that do not
-    /// provide their own health check hook.
-    supervisor: Arc<Mutex<Supervisor>>,
-
-    /// The configured interval at which to run health checks for this
-    /// service. The interval actually used may differ based on the
-    /// previous health check result.
-    nominal_interval: HealthCheckInterval,
-
-    /// A reference to the service's current health check status. We
-    /// store the result of the health check here.
-    service_health_result: Arc<Mutex<HealthCheckResult>>,
-
-    /// A reference to the Supervisor's gateway state. We also store
-    /// the status in here for making it available via the HTTP
-    /// gateway.
-    gateway_state: Arc<GatewayState>,
+/// The complete set of information from running a health check
+///
+/// `status` is the raw result from running the health check hook.
+/// `result` is a computed value from `status` and other conditions (eg supervisor status if there
+/// is not a health check hook)
+/// `interval` the computed interval to wait until running the next health check
+pub struct HealthCheckBundle {
+    pub status:   HealthCheckHookStatus,
+    pub result:   HealthCheckResult,
+    pub interval: HealthCheckInterval,
 }
 
-impl State {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(hook: Option<Arc<HealthCheckHook>>,
+/// Run the health check hook and get the hook status and result.
+async fn check(supervisor: Arc<Mutex<Supervisor>>,
+               hook: Option<Arc<HealthCheckHook>>,
                service_group: ServiceGroup,
                package: Pkg,
-               svc_encrypted_password: Option<String>,
-               service_event_metadata: ServiceEventMetadata,
-               supervisor: Arc<Mutex<Supervisor>>,
-               nominal_interval: HealthCheckInterval,
-               service_health_result: Arc<Mutex<HealthCheckResult>>,
-               gateway_state: Arc<GatewayState>)
-               -> Self {
-        State { hook,
-                service_group,
-                package,
-                svc_encrypted_password,
-                service_event_metadata,
-                supervisor,
-                nominal_interval,
-                service_health_result,
-                gateway_state }
-    }
-
-    // Initialize the gateway_state for this health check to Unknown.
-    //
-    // # Locking (see locking.md)
-    // # `GatewayState::inner` (write)
-    pub fn init_gateway_state_gsw(self) {
-        self.gateway_state
-            .lock_gsw()
-            .set_health_of(self.service_group, HealthCheckResult::Unknown);
-    }
-
-    /// Run the health check hook and get the hook status and result.
-    async fn health_check(supervisor: Arc<Mutex<Supervisor>>,
-                          hook: Option<Arc<HealthCheckHook>>,
-                          service_group: ServiceGroup,
-                          package: Pkg,
-                          password: Option<String>)
-                          -> (HealthCheckHookStatus, HealthCheckResult) {
-        let status = if let Some(hook) = hook {
-            let result = hook_runner::HookRunner::new(hook,
-                                                      service_group.clone(),
-                                                      package.clone(),
-                                                      password).into_future()
-                                                               .await;
-            match result {
-                Ok((output, duration)) => HealthCheckHookStatus::Ran(output, duration),
-                Err(Error::WithDuration(e, duration)) => {
-                    error!("Error running health check hook for {}: {:?}",
-                           service_group, e);
-                    HealthCheckHookStatus::FailedToRun(duration)
-                }
-                Err(e) => {
-                    error!("Error starting health check hook for {}: {:?}",
-                           service_group, e);
-                    HealthCheckHookStatus::FailedToStart
-                }
+               password: Option<String>)
+               -> (HealthCheckHookStatus, HealthCheckResult) {
+    let status = if let Some(hook) = hook {
+        let result = hook_runner::HookRunner::new(hook,
+                                                  service_group.clone(),
+                                                  package.clone(),
+                                                  password).into_future()
+                                                           .await;
+        match result {
+            Ok((output, duration)) => HealthCheckHookStatus::Ran(output, duration),
+            Err(Error::WithDuration(e, duration)) => {
+                error!("Error running health check hook for {}: {:?}",
+                       service_group, e);
+                HealthCheckHookStatus::FailedToRun(duration)
             }
-        } else {
-            HealthCheckHookStatus::NoHook
-        };
+            Err(e) => {
+                error!("Error starting health check hook for {}: {:?}",
+                       service_group, e);
+                HealthCheckHookStatus::FailedToStart
+            }
+        }
+    } else {
+        HealthCheckHookStatus::NoHook
+    };
 
-        let result = match &status {
-            HealthCheckHookStatus::Ran(output, _) => {
-                // The hook ran. Try and convert its exit status to a `HealthCheckResult`.
-                output.exit_status()
-                      .code()
-                      .and_then(|code| {
-                          let result = HealthCheckResult::try_from(code);
-                          if let Err(e) = &result {
-                              let pkg_name = &package.name;
-                              outputln!(preamble pkg_name,
+    let result = match &status {
+        HealthCheckHookStatus::Ran(output, _) => {
+            // The hook ran. Try and convert its exit status to a `HealthCheckResult`.
+            output.exit_status()
+                  .code()
+                  .and_then(|code| {
+                      let result = HealthCheckResult::try_from(code);
+                      if let Err(e) = &result {
+                          let pkg_name = &package.name;
+                          outputln!(preamble pkg_name,
                                              "Health check exited with an unknown status code, {}",
                                              e);
-                          }
-                          result.ok()
-                      })
-                      .unwrap_or(HealthCheckResult::Unknown)
+                      }
+                      result.ok()
+                  })
+                  .unwrap_or(HealthCheckResult::Unknown)
+        }
+        HealthCheckHookStatus::FailedToRun(_) | HealthCheckHookStatus::FailedToStart => {
+            // There was a hook but it did not successfully run. The health check result is
+            // unknown.
+            HealthCheckResult::Unknown
+        }
+        HealthCheckHookStatus::NoHook => {
+            //  There was no hook to run. Use the supervisor status as a healthcheck.
+            match supervisor.lock()
+                            .expect("couldn't unlock supervisor")
+                            .status()
+            {
+                ProcessState::Up => HealthCheckResult::Ok,
+                ProcessState::Down => HealthCheckResult::Critical,
             }
-            HealthCheckHookStatus::FailedToRun(_) | HealthCheckHookStatus::FailedToStart => {
-                // There was a hook but it did not successfully run. The health check result is
-                // unknown.
-                HealthCheckResult::Unknown
-            }
-            HealthCheckHookStatus::NoHook => {
-                //  There was no hook to run. Use the supervisor status as a healthcheck.
-                match supervisor.lock()
-                                .expect("couldn't unlock supervisor")
-                                .status()
-                {
-                    ProcessState::Up => HealthCheckResult::Ok,
-                    ProcessState::Down => HealthCheckResult::Critical,
-                }
-            }
-        };
+        }
+    };
 
-        (status, result)
-    }
+    (status, result)
+}
 
-    /// Repeatedly check the health, followed by an appropriate delay, forever.
-    /// # Locking for the returned Future (see locking.md)
-    /// * `GatewayState::inner` (write)
-    pub async fn check_repeatedly_gsw(self) {
-        // TODO (CM): If we wanted to keep track of how many times
-        // a health check has failed in the past X executions, or
-        // do similar historical tracking, here's where we'd do
-        // it.
+/// Start a task to repeatedly check the service health, followed by an appropriate delay, forever.
+/// The function returns a channel receiver as a stream of `HealthCheckBundle`s and an
+/// `AbortHandle` which can be used to stop the checks.
+pub fn check_repeatedly(supervisor: Arc<Mutex<Supervisor>>,
+                        hook: Option<Arc<HealthCheckHook>>,
+                        nominal_interval: HealthCheckInterval,
+                        service_group: ServiceGroup,
+                        package: Pkg,
+                        password: Option<String>)
+                        -> (UnboundedReceiver<HealthCheckBundle>, AbortHandle) {
+    // TODO (CM): If we wanted to keep track of how many times
+    // a health check has failed in the past X executions, or
+    // do similar historical tracking, here's where we'd do
+    // it.
+
+    let service_group_clone = service_group.clone();
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    let f = async move {
         loop {
-            let State { hook,
-                        service_group,
-                        package,
-                        svc_encrypted_password,
-                        service_event_metadata,
-                        supervisor,
-                        nominal_interval,
-                        service_health_result,
-                        gateway_state, } = self.clone();
-
-            let (status, result) = Self::health_check(supervisor,
-                                                      hook,
-                                                      service_group.clone(),
-                                                      package,
-                                                      svc_encrypted_password).await;
+            let (status, result) = check(Arc::clone(&supervisor),
+                                         hook.as_ref().map(Arc::clone),
+                                         service_group.clone(),
+                                         package.clone(),
+                                         password.clone()).await;
 
             let interval = if result == HealthCheckResult::Ok {
                 // routine health check
@@ -244,18 +199,26 @@ impl State {
                 HealthCheckInterval::default()
             };
 
-            event::health_check(service_event_metadata, result, status, interval);
-
-            debug!("Caching HealthCheckResult = '{}' for '{}'",
-                   result, service_group);
-            *service_health_result.lock()
-                                  .expect("Could not unlock service_health_result") = result;
-            gateway_state.lock_gsw()
-                         .set_health_of(service_group.clone(), result);
+            // TODO (DM): This can only fail if the receiving end is closed or dorpped. With that
+            // said, instead of returning an `AbortHandle` we could have the caller drop the
+            // receiving end and use that to break from this loop, but this would require reworking
+            // of the manger.
+            tx.send(HealthCheckBundle { status,
+                                        result,
+                                        interval })
+              .ok();
 
             trace!("Next health check for {} in {}", service_group, interval);
 
             time::delay_for(interval.into()).await;
         }
-    }
+    };
+
+    let (f, handle) = future::abortable(f);
+    let f = f.map(move |_| {
+                 outputln!(preamble service_group_clone, "Health checking has been stopped");
+             });
+    tokio::spawn(f);
+
+    (rx, handle)
 }


### PR DESCRIPTION
Running health check hooks and taking actions on the result of those hooks used to be very tightly coupled. Essentially, any action that needed to be taken had to be threaded down into the internals of the code that executed the health checks ([here](https://github.com/habitat-sh/habitat/blob/10df837a9e3dc5109831409cbe850be956ee610c/components/sup/src/manager/service/health.rs#L230)). This PR turns this around. Instead of passing down the things necessary to perform an action on a health check result, the result is passed back up via a channel.

This PR is in preparation for including service health in the gossip protocol. It would have been ugly to pass the butterfly server all the way down into the health check execution code. 