### PR TITLE
[REFACTOR] Introduce "Engine" abstraction to `hab pkg export container`

### DIFF
--- a/components/pkg-export-container/src/container.rs
+++ b/components/pkg-export-container/src/container.rs
@@ -120,15 +120,13 @@ impl ImageBuilder {
     ///
     /// * If building the image fails
     pub fn build(self, engine: &Engine) -> Result<ContainerImage> {
-        engine.build(&self.workdir,
-                     &self.expanded_identifiers(),
-                     self.memory.as_deref())?;
+        let id = engine.build(&self.workdir,
+                              &self.expanded_identifiers(),
+                              self.memory.as_deref())?;
 
-        let id = match self.tags.first() {
-            Some(tag) => engine.image_id(&format!("{}:{}", &self.name, tag))?,
-            None => engine.image_id(&self.name)?,
-        };
-
+        // TODO (CM): Once ContainerImage doesn't need access to
+        // workdir, we could just have Engine::build return a
+        // ContainerImage directly, which is appealing.
         Ok(ContainerImage { id,
                             name: self.name,
                             tags: self.tags,

--- a/components/pkg-export-container/src/container.rs
+++ b/components/pkg-export-container/src/container.rs
@@ -1,16 +1,14 @@
 use crate::{build::BuildRoot,
-            error::{Error,
-                    Result},
+            engine::Engine,
+            error::Result,
             naming::Naming,
-            util,
-            Credentials};
+            util};
 use failure::SyncFailure;
 use habitat_common::ui::{Status,
                          UIWriter,
                          UI};
 use habitat_core::package::PackageIdent;
 use handlebars::Handlebars;
-use serde_json;
 use std::{fs,
           path::{Path,
                  PathBuf},
@@ -121,46 +119,20 @@ impl ImageBuilder {
     /// # Errors
     ///
     /// * If building the image fails
-    pub fn build(self) -> Result<ContainerImage> {
-        let mut cmd = util::docker_cmd();
-        cmd.current_dir(&self.workdir)
-           .arg("build")
-           .arg("--force-rm");
-        if let Some(ref mem) = self.memory {
-            cmd.arg("--memory").arg(mem);
-        }
-        for identifier in &self.expanded_identifiers() {
-            cmd.arg("--tag").arg(identifier);
-        }
-        cmd.arg(".");
-        debug!("Running: {:?}", &cmd);
-        let exit_status = cmd.spawn()?.wait()?;
-        if !exit_status.success() {
-            return Err(Error::BuildFailed(exit_status).into());
-        }
+    pub fn build(self, engine: &Engine) -> Result<ContainerImage> {
+        engine.build(&self.workdir,
+                     &self.expanded_identifiers(),
+                     self.memory.as_deref())?;
 
         let id = match self.tags.first() {
-            Some(tag) => self.image_id(&format!("{}:{}", &self.name, tag))?,
-            None => self.image_id(&self.name)?,
+            Some(tag) => engine.image_id(&format!("{}:{}", &self.name, tag))?,
+            None => engine.image_id(&self.name)?,
         };
 
         Ok(ContainerImage { id,
                             name: self.name,
                             tags: self.tags,
                             workdir: self.workdir.to_owned() })
-    }
-
-    fn image_id(&self, image_tag: &str) -> Result<String> {
-        let mut cmd = util::docker_cmd();
-        cmd.arg("images").arg("-q").arg(image_tag);
-        debug!("Running: {:?}", &cmd);
-        let output = cmd.output()?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        match stdout.lines().next() {
-            Some(id) => Ok(id.to_string()),
-            None => Err(Error::DockerImageIdNotFound(image_tag.to_string()).into()),
-        }
     }
 }
 
@@ -183,70 +155,8 @@ impl Identified for ContainerImage {
 }
 
 impl ContainerImage {
-    /// Pushes the image, with all tags, to a remote registry using the provided
-    /// `Credentials`.
-    ///
-    /// # Errors
-    ///
-    /// * If a registry login is not successful
-    /// * If a pushing one or more of the image tags fails
-    /// * If a registry logout is not successful
-    pub fn push(&self,
-                ui: &mut UI,
-                credentials: &Credentials,
-                registry_url: Option<&str>)
-                -> Result<()> {
-        ui.begin(format!("Pushing image '{}' with all tags to remote registry",
-                         self.name))?;
-        self.create_docker_config_file(credentials, registry_url)
-            .unwrap();
-
-        for image_tag in self.expanded_identifiers() {
-            ui.status(Status::Uploading,
-                      format!("image '{}' to remote registry", image_tag))?;
-            let mut cmd = util::docker_cmd();
-            cmd.arg("--config");
-            cmd.arg(self.workdir.to_str().unwrap());
-            cmd.arg("push").arg(&image_tag);
-            debug!("Running: {:?}", &cmd);
-            let exit_status = cmd.spawn()?.wait()?;
-            if !exit_status.success() {
-                return Err(Error::PushImageFailed(exit_status).into());
-            }
-            ui.status(Status::Uploaded, format!("image '{}'", &image_tag))?;
-        }
-
-        ui.end(format!("Image '{}' published with tags: {}",
-                       self.name,
-                       self.tags.join(", "),))?;
-
-        Ok(())
-    }
-
-    /// Removes the image from the local system along with all tags.
-    ///
-    /// # Errors
-    ///
-    /// * If one or more of the image tags cannot be removed
-    pub fn rm(self, ui: &mut UI) -> Result<()> {
-        ui.begin(format!("Removing local image '{}' with all tags", self.name))?;
-
-        for image_tag in self.expanded_identifiers() {
-            ui.status(Status::Deleting, format!("local image '{}'", image_tag))?;
-            let mut cmd = util::docker_cmd();
-            cmd.arg("rmi").arg(image_tag);
-            debug!("Running: {:?}", &cmd);
-            let exit_status = cmd.spawn()?.wait()?;
-            if !exit_status.success() {
-                return Err(Error::RemoveImageFailed(exit_status).into());
-            }
-        }
-
-        ui.end(format!("Local image '{}' with tags: {} cleaned up",
-                       self.name,
-                       self.tags.join(", "),))?;
-        Ok(())
-    }
+    // TODO (CM): temporary; we shouldn't use this at all
+    pub fn workdir(&self) -> &Path { self.workdir.as_path() }
 
     /// Create a build report with image metadata in the given path.
     ///
@@ -313,28 +223,6 @@ impl ContainerImage {
                    old_report.display(),
                    e);
         }
-    }
-
-    pub fn create_docker_config_file(&self,
-                                     credentials: &Credentials,
-                                     registry_url: Option<&str>)
-                                     -> Result<()> {
-        let config = self.workdir.join("config.json");
-        fs::create_dir_all(&self.workdir)?;
-        let registry = match registry_url {
-            Some(url) => url,
-            None => "https://index.docker.io/v1/",
-        };
-        debug!("Using registry: {:?}", registry);
-        let json = json!({
-            "auths": {
-                registry: {
-                    "auth": credentials.token
-                }
-            }
-        });
-        util::write_file(&config, &serde_json::to_string(&json).unwrap())?;
-        Ok(())
     }
 }
 
@@ -466,7 +354,8 @@ impl BuildContext {
     pub fn export(&self,
                   ui: &mut UI,
                   naming: &Naming,
-                  memory: Option<&str>)
+                  memory: Option<&str>,
+                  engine: &Engine)
                   -> Result<ContainerImage> {
         ui.status(Status::Creating, "image")?;
         let ident = self.0.ctx().installed_primary_svc_ident()?;
@@ -483,6 +372,6 @@ impl BuildContext {
         if let Some(memory) = memory {
             builder = builder.memory(memory);
         }
-        builder.build()
+        builder.build(engine)
     }
 }

--- a/components/pkg-export-container/src/engine.rs
+++ b/components/pkg-export-container/src/engine.rs
@@ -1,0 +1,137 @@
+//! Abstractions for dealing with the main behaviors we need when
+//! dealing with container images, while remaining unconcerned about
+//! which underlying tool is actually performing those tasks.
+
+use crate::error::{Error,
+                   Result};
+use habitat_core::fs::find_command;
+use std::{path::{Path,
+                 PathBuf},
+          process::{Command,
+                    ExitStatus}};
+
+#[derive(Debug, Fail)]
+enum EngineError {
+    #[fail(display = "Could not find the container engine executable '{}' on the PATH",
+           _0)]
+    ExecutableNotFound(String),
+}
+
+pub struct Engine {
+    binary: PathBuf,
+}
+
+impl Engine {
+    pub fn new() -> Result<Self> {
+        let binary_name = "docker";
+        let binary =
+            find_command(binary_name).ok_or_else(|| {
+                                         EngineError::ExecutableNotFound(binary_name.to_string())
+                                     })?;
+        Ok(Engine { binary })
+    }
+
+    /// Retrieve the ID of the given image, which is expected to exist.
+    pub fn image_id(&self, image_reference: &str) -> Result<String> {
+        let mut cmd = self.image_id_command(image_reference);
+        debug!("Running: {:?}", cmd);
+        let output = cmd.output()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        match stdout.lines().next() {
+            Some(id) => Ok(id.to_string()),
+            None => Err(Error::DockerImageIdNotFound(image_reference.to_string()).into()),
+        }
+    }
+
+    /// Delete the referenced image in the local image store.
+    pub fn remove_image(&self, image_reference: &str) -> Result<()> {
+        Engine::run(self.image_removal_command(image_reference),
+                    Error::RemoveImageFailed)
+    }
+
+    /// Pushes the specified container image to a remote repository, using
+    /// configuration stored in `config_dir`.
+    // TODO (CM): accept repository URL information
+    // TODO (CM): worth taking credential / repo information and
+    // handling the config directory stuff internally?
+    pub fn push_image(&self, image_reference: &str, config_dir: &Path) -> Result<()> {
+        Engine::run(self.image_push_command(image_reference, config_dir),
+                    Error::PushImageFailed)
+    }
+
+    /// Actually create the image.
+    ///
+    /// `build_context` will serve as the build context directory, and
+    /// a suitable `Dockerfile` is expected to be present in it. The
+    /// image will be tagged with each of `tags`.
+    ///
+    /// `memory` governs how much memory is provided to the build
+    /// process.
+    pub fn build<S: AsRef<str>>(&self,
+                                build_context: &Path,
+                                tags: &[S],
+                                memory: Option<&str>)
+                                -> Result<()> {
+        Engine::run(self.build_command(build_context, tags, memory),
+                    Error::BuildFailed)
+    }
+
+    ////////////////////////////////////////////////////////////////////////
+
+    /// General helper function for actually executing all these commands
+    fn run<F>(mut cmd: Command, err_fn: F) -> Result<()>
+        where F: Fn(ExitStatus) -> Error
+    {
+        debug!("Running: {:?}", &cmd);
+        let exit_status = cmd.spawn()?.wait()?;
+        if !exit_status.success() {
+            return Err(err_fn(exit_status).into());
+        }
+        Ok(())
+    }
+
+    /// `docker images -q mycompany/coolapp`
+    fn image_id_command(&self, image_reference: &str) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&["images", "-q", image_reference]);
+        cmd
+    }
+
+    /// `docker rmi mycompany/coolapp`
+    fn image_removal_command(&self, image_reference: &str) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&["rmi", image_reference]);
+        cmd
+    }
+
+    /// `docker --config /path/to/local/config push mycompany/mycoolapp`
+    fn image_push_command(&self, image_reference: &str, config_dir: &Path) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&["--config",
+                   &config_dir.to_string_lossy(),
+                   "push",
+                   image_reference]);
+        cmd
+    }
+
+    /// `docker build --force-rm --memory MEMORY [--tag TAG] .`
+    fn build_command<S: AsRef<str>>(&self,
+                                    build_context: &Path,
+                                    tags: &[S],
+                                    memory: Option<&str>)
+                                    -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.current_dir(build_context);
+        cmd.arg("build");
+        cmd.arg("--force-rm");
+
+        if let Some(mem) = memory {
+            cmd.arg("--memory").arg(mem);
+        }
+        for tag in tags {
+            cmd.arg("--tag").arg(tag.as_ref());
+        }
+        cmd.arg(".");
+        cmd
+    }
+}

--- a/components/pkg-export-container/src/engine.rs
+++ b/components/pkg-export-container/src/engine.rs
@@ -75,13 +75,20 @@ impl Engine {
     ///
     /// `memory` governs how much memory is provided to the build
     /// process.
+    ///
+    /// Returns the ID of the image that was built.
     pub fn build<S: AsRef<str>>(&self,
                                 build_context: &Path,
                                 tags: &[S],
                                 memory: Option<&str>)
-                                -> Result<()> {
+                                -> Result<String> {
         Engine::run(self.build_command(build_context, tags, memory),
-                    EngineError::BuildFailed)
+                    EngineError::BuildFailed)?;
+
+        let identifier = tags.first()
+                             .expect("There should always be at least one tag")
+                             .as_ref();
+        self.image_id(identifier)
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/components/pkg-export-container/src/error.rs
+++ b/components/pkg-export-container/src/error.rs
@@ -2,8 +2,7 @@ use base64::DecodeError;
 use failure;
 use rusoto_core::RusotoError;
 use rusoto_ecr::GetAuthorizationTokenError;
-use std::{process::ExitStatus,
-          result};
+use std::result;
 
 pub type Result<T> = result::Result<T, failure::Error>;
 
@@ -11,10 +10,6 @@ pub type Result<T> = result::Result<T, failure::Error>;
 pub enum Error {
     #[fail(display = "{}", _0)]
     Base64DecodeError(DecodeError),
-    #[fail(display = "Container image build failed with exit code: {}", _0)]
-    BuildFailed(ExitStatus),
-    #[fail(display = "Could not determine container image ID for: {}", _0)]
-    DockerImageIdNotFound(String),
     #[fail(display = "Invalid registry type: {}", _0)]
     InvalidRegistryType(String),
     #[fail(display = "No ECR Tokens returned")]
@@ -25,9 +20,4 @@ pub enum Error {
                       one package with a run hook must be provided.",
            _0)]
     PrimaryServicePackageNotFound(Vec<String>),
-    #[fail(display = "Container image push failed with exit code: {}", _0)]
-    PushImageFailed(ExitStatus),
-    #[fail(display = "Removing local container images failed with exit code: {}",
-           _0)]
-    RemoveImageFailed(ExitStatus),
 }

--- a/components/pkg-export-container/src/os/check/windows.rs
+++ b/components/pkg-export-container/src/os/check/windows.rs
@@ -1,5 +1,6 @@
-use crate::{error::Result,
-            util};
+use crate::error::Result;
+use habitat_core::util::docker;
+use std::process::Command;
 
 /// Currently when exporting containers on Windows, the Docker daemon
 /// *must* be in Windows mode (i.e., only Windows containers can be
@@ -42,7 +43,7 @@ impl DockerOS {
     /// daemon may report "Windows" or "Linux", depending on what mode
     /// it is currently running in.
     fn current() -> DockerOS {
-        let mut cmd = util::docker_cmd();
+        let mut cmd = Command::new(docker::command_path().expect("Unable to locate docker"));
         cmd.arg("version").arg("--format='{{.Server.Os}}'");
         debug!("Running command: {:?}", cmd);
         let result = cmd.output().expect("Docker command failed to spawn");

--- a/components/pkg-export-container/src/util.rs
+++ b/components/pkg-export-container/src/util.rs
@@ -1,19 +1,12 @@
 use crate::error::Result;
-use habitat_core::{package::{PackageIdent,
-                             PackageInstall},
-                   util::docker};
+use habitat_core::package::{PackageIdent,
+                            PackageInstall};
 use std::{fs::{self,
                File},
           io::Write,
           path::{Path,
-                 PathBuf},
-          process::Command};
+                 PathBuf}};
 const BIN_PATH: &str = "/bin";
-
-/// Returns a `Command` for the Docker program.
-pub(crate) fn docker_cmd() -> Command {
-    Command::new(docker::command_path().expect("Unable to locate docker"))
-}
 
 /// Returns the `bin` path used for symlinking programs.
 pub fn bin_path() -> &'static Path { Path::new(BIN_PATH) }


### PR DESCRIPTION
This is yet another refactor in preparation for more changes in the container exporter. Here, we push all the shelling out to `docker` that we do behind an "Engine" abstraction. No outward-facing changes are present here, but it will make it easier for us to swap something else in for `docker` in the future with minimal disruption to the fundamental logic of the crate.

Please read the commit messages for further detail and background.