### PR TITLE
Add Bulidah as an engine for unprivileged container builds

### DIFF
--- a/components/pkg-export-container/habitat/plan.sh
+++ b/components/pkg-export-container/habitat/plan.sh
@@ -5,6 +5,7 @@ pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 pkg_deps=(
+    core/buildah
     core/docker
 )
 pkg_build_deps=(

--- a/components/pkg-export-container/habitat/plan.sh
+++ b/components/pkg-export-container/habitat/plan.sh
@@ -4,20 +4,22 @@ _pkg_distname=$pkg_name
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-# The result is a portable, static binary. However, we shell out to the
-# Docker command which we need at runtime.
-pkg_deps=(core/docker)
-pkg_build_deps=(core/musl
-                core/zlib-musl
-                core/xz-musl
-                core/bzip2-musl
-                core/libarchive-musl
-                core/openssl-musl
-                core/coreutils
-                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
-                core/gcc
-                core/make
-                core/protobuf)
+pkg_deps=(
+    core/docker
+)
+pkg_build_deps=(
+    core/musl
+    core/zlib-musl
+    core/xz-musl
+    core/bzip2-musl
+    core/libarchive-musl
+    core/openssl-musl
+    core/coreutils
+    core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
+    core/gcc
+    core/make
+    core/protobuf
+)
 pkg_bin_dirs=(bin)
 
 bin=$_pkg_distname

--- a/components/pkg-export-container/src/cli.rs
+++ b/components/pkg-export-container/src/cli.rs
@@ -1,4 +1,5 @@
-use crate::RegistryType;
+use crate::{engine,
+            RegistryType};
 use clap::{App,
            Arg};
 use habitat_common::PROGRAM_NAME;
@@ -23,7 +24,8 @@ pub fn cli<'a, 'b>() -> App<'a, 'b> {
                                        .add_publishing_args()
                                        .add_memory_arg()
                                        .add_layer_arg()
-                                       .add_pkg_ident_arg();
+                                       .add_pkg_ident_arg()
+                                       .add_engine_arg();
     if cfg!(windows) {
         cli = cli.add_base_image_arg();
     }
@@ -321,6 +323,12 @@ impl<'a, 'b> Cli<'a, 'b> {
                                                          specifying this option to add all \
                                                          Habitat packages in a single layer \
                                                          (which is the default behavior)."));
+        Cli { app }
+    }
+
+    fn add_engine_arg(self) -> Self {
+        let arg = engine::cli_arg();
+        let app = self.app.arg(arg);
         Cli { app }
     }
 }

--- a/components/pkg-export-container/src/container.rs
+++ b/components/pkg-export-container/src/container.rs
@@ -255,7 +255,7 @@ impl BuildContext {
                   ui: &mut UI,
                   naming: &Naming,
                   memory: Option<&str>,
-                  engine: &Engine)
+                  engine: &dyn Engine)
                   -> Result<ContainerImage> {
         ui.status(Status::Creating, "image")?;
         let ident = self.0.ctx().installed_primary_svc_ident()?;

--- a/components/pkg-export-container/src/engine.rs
+++ b/components/pkg-export-container/src/engine.rs
@@ -1,13 +1,25 @@
 //! Abstractions for dealing with the main behaviors we need when
 //! dealing with container images, while remaining unconcerned about
 //! which underlying tool is actually performing those tasks.
+//!
+//! This allows us to swap out the `docker` CLI for `buildah` if we
+//! want to create containers as a non-root user, for instance.
 
 use crate::error::Result;
+use clap::{Arg,
+           ArgMatches};
 use habitat_core::fs::find_command;
-use std::{path::{Path,
+use std::{convert::TryFrom,
+          path::{Path,
                  PathBuf},
           process::{Command,
-                    ExitStatus}};
+                    ExitStatus},
+          result::Result as StdResult,
+          str::FromStr};
+
+#[cfg(not(windows))]
+mod buildah;
+mod docker;
 
 #[derive(Debug, Fail)]
 enum EngineError {
@@ -23,24 +35,106 @@ enum EngineError {
     RemoveFailed(ExitStatus),
     #[fail(display = "Container image push failed with exit code: {}", _0)]
     PushFailed(ExitStatus),
+    #[fail(display = "Unknown Container Engine '{}' was specified.", _0)]
+    UnknownEngine(String),
 }
 
-pub struct Engine {
-    binary: PathBuf,
+/// Things that can build containers!
+#[derive(Clone, Copy, Debug)]
+enum EngineKind {
+    Docker,
+    #[cfg(not(windows))]
+    Buildah,
 }
 
-impl Engine {
-    pub fn new() -> Result<Self> {
-        let binary_name = "docker";
-        let binary =
-            find_command(binary_name).ok_or_else(|| {
-                                         EngineError::ExecutableNotFound(binary_name.to_string())
-                                     })?;
-        Ok(Engine { binary })
+impl FromStr for EngineKind {
+    type Err = EngineError;
+
+    fn from_str(s: &str) -> StdResult<Self, Self::Err> {
+        match s {
+            "docker" => Ok(EngineKind::Docker),
+            #[cfg(not(windows))]
+            "buildah" => Ok(EngineKind::Buildah),
+            _ => Err(EngineError::UnknownEngine(s.to_string())),
+        }
     }
+}
+
+/// Define the CLAP CLI argument for specifying a container build
+/// engine to use.
+#[rustfmt::skip] // otherwise the long_help formatting goes crazy
+pub fn cli_arg<'a, 'b>() -> Arg<'a, 'b> {
+    let arg =
+        Arg::with_name("ENGINE").value_name("ENGINE")
+        .long("engine")
+        .required(true)
+        .takes_value(true)
+        .multiple(false)
+        .default_value("docker")
+        .help("The name of the container creation engine to use.");
+
+    // TODO (CM): Find a way to tie this more closely to the
+    // Engine enum values.
+    if cfg!(windows) {
+        // Since there is effectively no choice of engine for
+        // Windows, we hide the CLI option and don't document it
+        // any further.
+        arg.possible_values(&["docker"]).hidden(true)
+    } else {
+        arg.long_help(
+"Using the `docker` engine allows you to use Docker to create
+your container images. You must ensure that a Docker daemon
+is running on the host where this command is executed, and
+that the user executing the command has permission to access
+the Docker socket.
+
+Using the `buildah` engine allows you to create container images
+as an unprivileged user, and without having to use a Docker
+daemon. This is the recommended engine for use in CI systems and
+other environments where security is of particular concern.
+Please see https://buildah.io for more details.
+
+Both engines create equivalent container images.
+",
+        )
+            .possible_values(&["docker", "buildah"])
+    }
+}
+
+impl TryFrom<&ArgMatches<'_>> for Box<dyn Engine> {
+    type Error = failure::Error;
+
+    fn try_from(value: &ArgMatches) -> StdResult<Self, Self::Error> {
+        let engine_kind =
+            clap::value_t!(value, "ENGINE", EngineKind).expect("ENGINE is a required option");
+        match engine_kind {
+            EngineKind::Docker => Ok(Box::new(docker::DockerEngine::new()?)),
+            #[cfg(not(windows))]
+            EngineKind::Buildah => Ok(Box::new(buildah::BuildahEngine::new()?)),
+        }
+    }
+}
+
+pub trait Engine {
+    /// A command that takes a container image reference and returns
+    /// the ID of that image on the first line of standard output.
+    fn image_id_command(&self, image_reference: &str) -> Command;
+
+    /// A command that removes the specified local container image;
+    fn image_removal_command(&self, image_reference: &str) -> Command;
+
+    /// A command that pushes the specified container image, using
+    /// configuration stored in `config_dir`.
+    // TODO (CM): accept repository URL information
+    // TODO (CM): worth taking credential / repo information and
+    // handling the config directory stuff internally?
+    fn image_push_command(&self, image_reference: &str, config_dir: &Path) -> Command;
+
+    fn build_command(&self, build_context: &Path, tags: &[String], memory: Option<&str>)
+                     -> Command;
 
     /// Retrieve the ID of the given image, which is expected to exist.
-    pub fn image_id(&self, image_reference: &str) -> Result<String> {
+    fn image_id(&self, image_reference: &str) -> Result<String> {
         let mut cmd = self.image_id_command(image_reference);
         debug!("Running: {:?}", cmd);
         let output = cmd.output()?;
@@ -52,9 +146,9 @@ impl Engine {
     }
 
     /// Delete the referenced image in the local image store.
-    pub fn remove_image(&self, image_reference: &str) -> Result<()> {
-        Engine::run(self.image_removal_command(image_reference),
-                    EngineError::RemoveFailed)
+    fn remove_image(&self, image_reference: &str) -> Result<()> {
+        run(self.image_removal_command(image_reference),
+            EngineError::RemoveFailed)
     }
 
     /// Pushes the specified container image to a remote repository, using
@@ -62,9 +156,9 @@ impl Engine {
     // TODO (CM): accept repository URL information
     // TODO (CM): worth taking credential / repo information and
     // handling the config directory stuff internally?
-    pub fn push_image(&self, image_reference: &str, config_dir: &Path) -> Result<()> {
-        Engine::run(self.image_push_command(image_reference, config_dir),
-                    EngineError::PushFailed)
+    fn push_image(&self, image_reference: &str, config_dir: &Path) -> Result<()> {
+        run(self.image_push_command(image_reference, config_dir),
+            EngineError::PushFailed)
     }
 
     /// Actually create the image.
@@ -77,76 +171,33 @@ impl Engine {
     /// process.
     ///
     /// Returns the ID of the image that was built.
-    pub fn build<S: AsRef<str>>(&self,
-                                build_context: &Path,
-                                tags: &[S],
-                                memory: Option<&str>)
-                                -> Result<String> {
-        Engine::run(self.build_command(build_context, tags, memory),
-                    EngineError::BuildFailed)?;
+    fn build(&self, build_context: &Path, tags: &[String], memory: Option<&str>) -> Result<String> {
+        run(self.build_command(build_context, tags, memory),
+            EngineError::BuildFailed)?;
 
         let identifier = tags.first()
-                             .expect("There should always be at least one tag")
-                             .as_ref();
+                             .expect("There should always be at least one tag");
         self.image_id(identifier)
     }
+}
 
-    ////////////////////////////////////////////////////////////////////////
-
-    /// General helper function for actually executing all these commands
-    fn run<F>(mut cmd: Command, err_fn: F) -> Result<()>
-        where F: Fn(ExitStatus) -> EngineError
-    {
-        debug!("Running: {:?}", &cmd);
-        let exit_status = cmd.spawn()?.wait()?;
-        if !exit_status.success() {
-            return Err(err_fn(exit_status).into());
-        }
-        Ok(())
+/// General helper function for actually executing all these commands.
+///
+/// Not part of the trait because nobody need to be calling this from
+/// outside.
+fn run<F>(mut cmd: Command, err_fn: F) -> Result<()>
+    where F: Fn(ExitStatus) -> EngineError
+{
+    debug!("Running: {:?}", &cmd);
+    let exit_status = cmd.spawn()?.wait()?;
+    if !exit_status.success() {
+        return Err(err_fn(exit_status).into());
     }
+    Ok(())
+}
 
-    /// `docker images -q mycompany/coolapp`
-    fn image_id_command(&self, image_reference: &str) -> Command {
-        let mut cmd = Command::new(&self.binary);
-        cmd.args(&["images", "-q", image_reference]);
-        cmd
-    }
-
-    /// `docker rmi mycompany/coolapp`
-    fn image_removal_command(&self, image_reference: &str) -> Command {
-        let mut cmd = Command::new(&self.binary);
-        cmd.args(&["rmi", image_reference]);
-        cmd
-    }
-
-    /// `docker --config /path/to/local/config push mycompany/mycoolapp`
-    fn image_push_command(&self, image_reference: &str, config_dir: &Path) -> Command {
-        let mut cmd = Command::new(&self.binary);
-        cmd.args(&["--config",
-                   &config_dir.to_string_lossy(),
-                   "push",
-                   image_reference]);
-        cmd
-    }
-
-    /// `docker build --force-rm --memory MEMORY [--tag TAG] .`
-    fn build_command<S: AsRef<str>>(&self,
-                                    build_context: &Path,
-                                    tags: &[S],
-                                    memory: Option<&str>)
-                                    -> Command {
-        let mut cmd = Command::new(&self.binary);
-        cmd.current_dir(build_context);
-        cmd.arg("build");
-        cmd.arg("--force-rm");
-
-        if let Some(mem) = memory {
-            cmd.arg("--memory").arg(mem);
-        }
-        for tag in tags {
-            cmd.arg("--tag").arg(tag.as_ref());
-        }
-        cmd.arg(".");
-        cmd
-    }
+fn resolve_engine_binary(binary_name: &str) -> StdResult<PathBuf, EngineError> {
+    find_command(binary_name).ok_or_else(|| {
+                                 EngineError::ExecutableNotFound(binary_name.to_string())
+                             })
 }

--- a/components/pkg-export-container/src/engine.rs
+++ b/components/pkg-export-container/src/engine.rs
@@ -88,6 +88,7 @@ pub fn cli_arg<'a, 'b>() -> Arg<'a, 'b> {
         Arg::with_name("ENGINE").value_name("ENGINE")
         .long("engine")
         .required(true)
+        .env("HAB_PKG_EXPORT_CONTAINER_ENGINE")
         .takes_value(true)
         .multiple(false)
         .default_value("docker")

--- a/components/pkg-export-container/src/engine/buildah.rs
+++ b/components/pkg-export-container/src/engine/buildah.rs
@@ -1,0 +1,77 @@
+use super::{resolve_engine_binary,
+            Engine,
+            EngineError};
+use std::{path::{Path,
+                 PathBuf},
+          process::Command,
+          result::Result};
+
+#[derive(Debug)]
+pub(super) struct BuildahEngine {
+    binary: PathBuf,
+}
+
+impl BuildahEngine {
+    pub fn new() -> Result<Self, EngineError> {
+        let binary = resolve_engine_binary("buildah")?;
+        Ok(BuildahEngine { binary })
+    }
+}
+
+impl Engine for BuildahEngine {
+    /// `buildah images -q mycompany/coolapp`
+    fn image_id_command(&self, image_reference: &str) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&["images", "-q", image_reference]);
+        cmd
+    }
+
+    /// `buildah rmi mycompany/coolapp`
+    fn image_removal_command(&self, image_reference: &str) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&["rmi", image_reference]);
+        cmd
+    }
+
+    /// `buildah push --authfile=/path/to/local/config.json push mycompany/mycoolapp`
+    fn image_push_command(&self, image_reference: &str, config_dir: &Path) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&["push",
+                   "--authfile",
+                   &config_dir.join("config.json").to_string_lossy(),
+                   image_reference]);
+        cmd
+    }
+
+    fn build_command(&self,
+                     build_context: &Path,
+                     tags: &[String],
+                     memory: Option<&str>)
+                     -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.current_dir(build_context);
+
+        cmd.arg("build-using-dockerfile")
+           .arg("--layers")
+           .arg("--force-rm");
+
+        // Need this (Buildah's default format is OCI) because
+        // apparently DockerHub has problems with OCI images.
+        //
+        // https://github.com/docker/hub-feedback/issues/1871
+        //
+        // (This is only really a problem when *pushing* images, but
+        // since DockerHub is the 800 lb gorilla, we'll defer to it
+        // for now.)
+        cmd.args(&["--format", "docker"]);
+
+        if let Some(mem) = memory {
+            cmd.arg("--memory").arg(mem);
+        }
+        for tag in tags {
+            cmd.arg("--tag").arg(&tag);
+        }
+        cmd.arg(".");
+        cmd
+    }
+}

--- a/components/pkg-export-container/src/engine/docker.rs
+++ b/components/pkg-export-container/src/engine/docker.rs
@@ -1,0 +1,66 @@
+use super::{resolve_engine_binary,
+            Engine,
+            EngineError};
+use std::{path::{Path,
+                 PathBuf},
+          process::Command,
+          result::Result};
+
+#[derive(Debug)]
+pub(super) struct DockerEngine {
+    binary: PathBuf,
+}
+
+impl DockerEngine {
+    pub fn new() -> Result<Self, EngineError> {
+        let binary = resolve_engine_binary("docker")?;
+        Ok(DockerEngine { binary })
+    }
+}
+
+impl Engine for DockerEngine {
+    /// `docker images -q mycompany/coolapp`
+    fn image_id_command(&self, image_reference: &str) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&["images", "-q", image_reference]);
+        cmd
+    }
+
+    /// `docker rmi mycompany/coolapp`
+    fn image_removal_command(&self, image_reference: &str) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&["rmi", image_reference]);
+        cmd
+    }
+
+    /// `docker --config /path/to/local/config push mycompany/mycoolapp`
+    fn image_push_command(&self, image_reference: &str, config_dir: &Path) -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.args(&["--config",
+                   &config_dir.to_string_lossy(),
+                   "push",
+                   image_reference]);
+        cmd
+    }
+
+    /// `docker build --force-rm --memory MEMORY [--tag TAG] .`
+    fn build_command(&self,
+                     build_context: &Path,
+                     tags: &[String],
+                     memory: Option<&str>)
+                     -> Command {
+        let mut cmd = Command::new(&self.binary);
+        cmd.current_dir(build_context);
+        cmd.arg("build");
+        cmd.arg("--force-rm");
+
+        if let Some(mem) = memory {
+            cmd.arg("--memory").arg(mem);
+        }
+        for tag in tags {
+            cmd.arg("--tag").arg(&tag);
+        }
+        cmd.arg(".");
+        cmd
+    }
+}

--- a/components/pkg-export-container/src/lib.rs
+++ b/components/pkg-export-container/src/lib.rs
@@ -12,7 +12,8 @@ pub use crate::{build::BuildSpec,
                 cli::cli,
                 container::{BuildContext,
                             ContainerImage},
-                engine::Engine,
+                engine::{fail_if_buildah_and_multilayer,
+                         Engine},
                 error::{Error,
                         Result}};
 use habitat_common::ui::{Status,
@@ -147,6 +148,8 @@ pub async fn export_for_cli_matches(ui: &mut UI,
                                     matches: &clap::ArgMatches<'_>)
                                     -> Result<Option<ContainerImage>> {
     os::ensure_proper_docker_platform()?;
+
+    fail_if_buildah_and_multilayer(matches)?;
 
     let spec = BuildSpec::try_from(matches)?;
     let naming = Naming::from(matches);

--- a/test/end-to-end/test_container_exporter.ps1
+++ b/test/end-to-end/test_container_exporter.ps1
@@ -161,3 +161,14 @@ Describe "hab pkg export container --multi-layer" {
         }
     }
 }
+
+if ($IsLinux) {
+    # TODO: Try to run the container when we have a core/podman package
+    Describe "hab pkg export container --engine=buildah" {
+        It "Runs successfully" {
+            $tag = New-CustomTag
+            hab pkg export container core/nginx --engine=buildah --tag-custom="$tag"
+            hab pkg exec core/buildah buildah rmi "core/nginx:$tag"
+        }
+    }
+}


### PR DESCRIPTION
Buildah (https://buildah.io) is another tool that can be used to
create container images. While it has several interesting
capabilities (like an alternative imperative, non-Dockerfile-driven
build process), the main one that interests us is the ability to build
images without having to use a Docker daemon.

This allows ordinary unprivileged users to export Habitat container
images.

As Buildah only works on Linux, this ability is thus necessarily
limited to Linux platforms. To enable this functionality, use the new
`--engine` option:

```sh
hab pkg export container core/redis --engine=buildah
```

The default engine remains Docker. While the `--engine` option *is*
technically available on Windows, `docker` is the only allowed value.

One important thing to note is that Docker and Buildah store their
local images in different locations. This means that, despite the
tools creating compatible images, you will not be able to (directly)
run a Buildah-built container under Docker, in contrast to what your
typical "export a container, run that container" development
workflow. There are two options, though.

First, use `podman` (https://podman.io). Podman and Buildah are sister
projects in an overall effort to split apart the features of the
Docker monolith. While Buildah handles construction of images, Podman
handles the running of those images as containers (that is, `buildah`
is to `docker build` as `podman` is to `docker run`). As such, Podman
looks for images in the same place that Buildah creates them. Like
Buildah, Podman also does not require a privileged account to
run. And, as a bonus, you can essentially use `podman` as an alias for
`docker`.

The second alternative is to use `buildah` to export your image to
your Docker daemon. This effectively copies your image from "Buildah
space" to "Docker space".

```sh
hab pkg exec core/buildah buildah push core/redis:TAG docker-daemon:core/redis:TAG
```

Since this command does interact with a Docker daemon, you will
require suitable privileges to execute this operation.

It should be noted that these approaches are not required if you wish
to export a container and push the generated images to a remote
repository as part of the same `hab pkg export container`
invocation. The Buildah engine implementation knows how to push to
remote repositories without any additional effort on the part of the
user.

As an implementation note, the previous `Engine` struct was converted
into a trait, with an implementation each for Docker and Buildah. The
trait defines both the commands needed to perform the various
operations of an Engine, as well as the methods to execute those
commands. Implementors of the trait only have to define the base
commands; execution is provided in the trait definition itself.

Then, an instance is created based on user input and
used throughout. The broader exporter code knows nothing of any
concrete implementation (indeed, those are left intentionally private
within the `engine` module), instead operating only in terms of the
`Engine` abstraction.

![](https://media.giphy.com/media/Ys7XSrCxhbk8E/giphy.gif)