### PR TITLE
Statically compile the Launcher on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,6 +680,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+dependencies = [
+ "crossbeam-utils 0.6.6",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+dependencies = [
+ "cfg-if",
+ "lazy_static 1.4.0",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,7 +1228,7 @@ dependencies = [
  "habitat-launcher-protocol",
  "habitat_common",
  "habitat_core",
- "ipc-channel",
+ "ipc-channel 0.12.0",
  "libc",
  "log 0.4.8",
  "prost",
@@ -1226,7 +1245,7 @@ dependencies = [
  "habitat-launcher-protocol",
  "habitat_common",
  "habitat_core",
- "ipc-channel",
+ "ipc-channel 0.9.0",
  "libc",
  "log 0.4.8",
  "prost",
@@ -1774,6 +1793,24 @@ dependencies = [
  "serde",
  "uuid 0.5.1",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "ipc-channel"
+version = "0.12.0"
+source = "git+https://github.com/habitat-sh/ipc-channel?branch=PR-233-angelortiz1007-windows#24a22072d83ded9ed86999bb51eac8038d4628a1"
+dependencies = [
+ "bincode 1.2.1",
+ "crossbeam-channel",
+ "fnv",
+ "lazy_static 1.4.0",
+ "libc",
+ "mio",
+ "rand 0.6.5",
+ "serde",
+ "tempfile",
+ "uuid 0.7.4",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -3151,7 +3188,7 @@ dependencies = [
  "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -17,7 +17,12 @@ habitat_common = { path = "../common" }
 # put these things behind a feature flag so we can statically compile the launcher.
 habitat_core = { path = "../core" }
 habitat-launcher-protocol = { path = "../launcher-protocol" }
-ipc-channel = { git = "https://github.com/habitat-sh/ipc-channel", branch = "hbt-windows" }
+# As suggested by the name, this branch corresponds to
+# https://github.com/servo/ipc-channel/pull/233, requesting to merge
+# https://github.com/angelortiz1007/ipc-channel/tree/windows to master.
+#
+# This is currently the most up-to-date work for Windows compatibility.
+ipc-channel = { git = "https://github.com/habitat-sh/ipc-channel", branch = "PR-233-angelortiz1007-windows" }
 libc = "*"
 log = "*"
 prost = "*"

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -3,15 +3,19 @@ pkg_name=hab-launcher
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/glibc
-          core/gcc-libs
-          core/libarchive
-          core/openssl)
-pkg_build_deps=(core/coreutils
-                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
-                core/gcc
-                core/git
-                core/protobuf)
+pkg_deps=(
+    core/glibc
+    core/gcc-libs
+    core/libarchive
+    core/openssl
+)
+pkg_build_deps=(
+    core/coreutils
+    core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
+    core/gcc
+    core/git
+    core/protobuf
+)
 pkg_bin_dirs=(bin)
 bin="hab-launch"
 

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -3,13 +3,14 @@ pkg_name=hab-launcher
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(
-    core/glibc
-    core/gcc-libs
-    core/libarchive
-    core/openssl
-)
 pkg_build_deps=(
+    core/musl
+    core/zlib-musl
+    core/xz-musl
+    core/bzip2-musl
+    core/libarchive-musl
+    core/openssl-musl
+
     core/coreutils
     core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
     core/gcc
@@ -35,20 +36,35 @@ do_prepare() {
   # Can be either `--release` or `--debug` to determine cargo build strategy
   build_line "Building artifacts with \`${cargo_build_mode#--}' mode"
 
-  export rustc_target="x86_64-unknown-linux-gnu"
+  export rustc_target="x86_64-unknown-linux-musl"
   build_line "Setting rustc_target=$rustc_target"
 
   # Used by Cargo to use a pristine, isolated directory for all compilation
   export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
-  
+
   export PLAN_VERSION="${pkg_version}/${pkg_release}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
-  export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive)/lib
-  export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive)/include
-  export OPENSSL_LIB_DIR=$(pkg_path_for openssl)/lib
-  export OPENSSL_INCLUDE_DIR=$(pkg_path_for openssl)/include
+  la_ldflags="-L$(pkg_path_for zlib-musl)/lib -lz"
+  la_ldflags="$la_ldflags -L$(pkg_path_for xz-musl)/lib -llzma"
+  la_ldflags="$la_ldflags -L$(pkg_path_for bzip2-musl)/lib -lbz2"
+  la_ldflags="$la_ldflags -L$(pkg_path_for openssl-musl)/lib -lssl -lcrypto"
+
+  export LIBARCHIVE_LIB_DIR=$(pkg_path_for libarchive-musl)/lib
+  export LIBARCHIVE_INCLUDE_DIR=$(pkg_path_for libarchive-musl)/include
+  export LIBARCHIVE_LDFLAGS="$la_ldflags"
+  export LIBARCHIVE_STATIC=true
+  export OPENSSL_LIB_DIR=$(pkg_path_for openssl-musl)/lib
+  export OPENSSL_INCLUDE_DIR=$(pkg_path_for openssl-musl)/include
+  export OPENSSL_STATIC=true
+
+  # Used to find libgcc_s.so.1 when compiling `build.rs` in
+  # dependencies (`log`, in particular). Since this used only at build
+  # time, we will use the version found in the gcc package proper--it
+  # won't find its way into the final binaries.
+  export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
+  build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 
   # Prost (our Rust protobuf library) embeds a `protoc` binary, but
   # it's dynamically linked, which means it won't work in a


### PR DESCRIPTION
This copies over most of the static compilation machinery from the `core/hab` plan.

The big thing here is updating our very old `ipc-channel` crate to the latest work being done for Windows support. Without this, our old `ipc-channel` crate doesn't compile properly.

![](https://media.giphy.com/media/ZKTNelSY55g4w/giphy.gif)