### PR TITLE
Feature/windows logging

### DIFF
--- a/components/windows-service/README.md
+++ b/components/windows-service/README.md
@@ -28,7 +28,7 @@ This will stop the service if it is running and uninstall it from the Windows Se
 
 ## Supervisor Logs
 
-The Habitat Supervisor logs will be located in `$env:systemdrive\hab\svc\windows-service\logs`. The log will rotate every 100MB and will archive up to 10 log files. These rotation settings are configurable (see below).
+The Habitat Supervisor logs will be located in `$env:systemdrive\hab\svc\windows-service\logs`. The log will rotate every 10MB and will archive up to 10 log files. These rotation settings are configurable (see below).
 
 ## Configuring the Habitat service
 

--- a/components/windows-service/log4net.xml
+++ b/components/windows-service/log4net.xml
@@ -9,7 +9,7 @@
         <appendToFile value="true" />
         <rollingStyle value="Size" />
         <maxSizeRollBackups value="10" />
-        <maximumFileSize value="100MB" />
+        <maximumFileSize value="10MB" />
         <staticLogFileName value="true" />
         <layout type="log4net.Layout.PatternLayout">
         <conversionPattern value="%date - %message%newline" />


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

Windows-service logging update

### Description
Updates windows-service default log size to 10MB instead of 100MB (default consumes 1GB of space with very large log files).

### Issues Resolved

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

