### PR TITLE
Add several `ok_***` macros for each logging level

### DIFF
--- a/components/core/src/os/users/linux.rs
+++ b/components/core/src/os/users/linux.rs
@@ -1,6 +1,6 @@
 use crate::{error::{Error,
                     Result},
-            ok_log};
+            ok_warn};
 use nix::unistd::{Group,
                   User};
 use std::path::PathBuf;
@@ -25,33 +25,33 @@ pub fn can_run_services_as_svc_user() -> bool {
 pub fn can_run_services_as_svc_user() -> bool { true }
 
 pub fn get_uid_by_name(owner: &str) -> Option<u32> {
-    ok_log!(User::from_name(owner)).flatten()
-                                   .map(|u| u.uid.as_raw())
+    ok_warn!(User::from_name(owner)).flatten()
+                                    .map(|u| u.uid.as_raw())
 }
 
 pub fn get_gid_by_name(group: &str) -> Option<u32> {
-    ok_log!(Group::from_name(group)).flatten()
-                                    .map(|g| g.gid.as_raw())
+    ok_warn!(Group::from_name(group)).flatten()
+                                     .map(|g| g.gid.as_raw())
 }
 
 /// Any members that fail conversion from OsString to string will be omitted
 pub fn get_members_by_groupname(group: &str) -> Option<Vec<String>> {
-    ok_log!(Group::from_name(group)).flatten().map(|g| g.mem)
+    ok_warn!(Group::from_name(group)).flatten().map(|g| g.mem)
 }
 
 pub fn get_current_username() -> Option<String> {
     let uid = nix::unistd::getuid();
-    ok_log!(User::from_uid(uid)).flatten().map(|u| u.name)
+    ok_warn!(User::from_uid(uid)).flatten().map(|u| u.name)
 }
 
 pub fn get_current_groupname() -> Option<String> {
     let gid = nix::unistd::getgid();
-    ok_log!(Group::from_gid(gid)).flatten().map(|g| g.name)
+    ok_warn!(Group::from_gid(gid)).flatten().map(|g| g.name)
 }
 
 pub fn get_effective_username() -> Option<String> {
     let euid = nix::unistd::geteuid();
-    ok_log!(User::from_uid(euid)).flatten().map(|u| u.name)
+    ok_warn!(User::from_uid(euid)).flatten().map(|u| u.name)
 }
 
 pub fn get_effective_uid() -> u32 { nix::unistd::geteuid().as_raw() }
@@ -60,11 +60,11 @@ pub fn get_effective_gid() -> u32 { nix::unistd::getegid().as_raw() }
 
 pub fn get_effective_groupname() -> Option<String> {
     let egid = nix::unistd::getegid();
-    ok_log!(Group::from_gid(egid)).flatten().map(|g| g.name)
+    ok_warn!(Group::from_gid(egid)).flatten().map(|g| g.name)
 }
 
 pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
-    ok_log!(User::from_name(username)).flatten().map(|u| u.dir)
+    ok_warn!(User::from_name(username)).flatten().map(|u| u.dir)
 }
 
 pub fn root_level_account() -> String { "root".to_string() }

--- a/components/core/src/util.rs
+++ b/components/core/src/util.rs
@@ -10,19 +10,61 @@ use std::mem;
 
 /// Same as `Result::ok()`, but logs the error case. Useful for
 /// ignoring error cases, while still leaving a paper trail.
+#[doc(hidden)]
 #[macro_export]
-macro_rules! ok_log {
-    ($result:expr) => {
+macro_rules! __ok_log {
+    ($log_level:expr, $result:expr) => {
         match $result {
             Ok(val) => Some(val),
             Err(e) => {
-                warn!("Intentionally ignored error ({}:{}): {:?}",
-                      file!(),
-                      line!(),
-                      e);
+                log!($log_level,
+                     "Intentionally ignored error ({}:{}): {:?}",
+                     file!(),
+                     line!(),
+                     e);
                 None
             }
         }
+    };
+}
+
+/// Same as `Result::ok()`, but logs the error case at the `error` level.
+#[macro_export]
+macro_rules! ok_error {
+    ($result:expr) => {
+        $crate::__ok_log!(log::Level::Error, $result)
+    };
+}
+
+/// Same as `Result::ok()`, but logs the error case at the `warn` level.
+#[macro_export]
+macro_rules! ok_warn {
+    ($result:expr) => {
+        $crate::__ok_log!(log::Level::Warn, $result)
+    };
+}
+
+/// Same as `Result::ok()`, but logs the error case at the `info` level.
+#[macro_export]
+macro_rules! ok_info {
+    ($result:expr) => {
+        $crate::__ok_log!(log::Level::Info, $result)
+    };
+}
+
+/// Same as `Result::ok()`, but logs the error case at the `debug` level.
+#[macro_export]
+macro_rules! ok_debug {
+    ($result:expr) => {
+        $crate::__ok_log!(log::Level::Debug, $result)
+    };
+}
+
+/// Same as `Result::ok()`, but logs the error case at the `trace` level.
+#[macro_export]
+macro_rules! ok_trace {
+    ($result:expr) => {
+        $crate::__ok_log!(log::Level::Trace, $result)
     };
 }
 


### PR DESCRIPTION
Rather than logging everything from the `ok_log!` macro at the `warn`
level, we now provide individual macros for each of the five standard
logging levels. This retains the utility of the original `ok_log!`
macro, but adds the ability for consumers to control the resulting
logging level.

Signed-off-by: Christopher Maier <cmaier@chef.io>