### PR TITLE
Revert ZMQ Update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,11 +4408,9 @@ checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 
 [[package]]
 name = "zmq"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aad98a7a617d608cd9e1127147f630d24af07c7cd95ba1533246d96cbdd76c66"
+version = "0.8.3"
+source = "git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed#20a73b9225b3903778420c3211d8e9439bb73a2a"
 dependencies = [
- "bitflags",
  "libc",
  "log 0.4.8",
  "zmq-sys",
@@ -4420,9 +4418,8 @@ dependencies = [
 
 [[package]]
 name = "zmq-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d33a2c51dde24d5b451a2ed4b488266df221a5eaee2ee519933dc46b9a9b3648"
+version = "0.8.3"
+source = "git+https://github.com/habitat-sh/rust-zmq?branch=v0.8-symlinks-removed#20a73b9225b3903778420c3211d8e9439bb73a2a"
 dependencies = [
  "libc",
  "metadeps",

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -31,7 +31,7 @@ tempfile = "*"
 threadpool = "*"
 toml = { version = "*", default-features = false }
 uuid = { version = "*", features = ["v4"] }
-zmq = { version = "*" }
+zmq = { git = "https://github.com/habitat-sh/rust-zmq", branch = "v0.8-symlinks-removed" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "*", features = ["handleapi", "winbase"] }


### PR DESCRIPTION
This reverts commit 2fd15387383a5c1ec7877cad14f9c1c8958ff8ef, reversing
changes made to eaf6781f5e83e2fa198f21e58648390d7d83c152.

We've noticed deadlocks in our testing environment as a result of this
change, so we're backing out for the time being.