### PR TITLE
Use docker executor for kernel2 verify

### DIFF
--- a/.expeditor/scripts/verify/build_package.sh
+++ b/.expeditor/scripts/verify/build_package.sh
@@ -22,4 +22,4 @@ HAB_CACHE_KEY_PATH="$JOB_TEMP_ROOT/keys"
 echo "--- :key: Generating fake origin key"
 ${hab_binary} origin key generate
 echo "--- :hab: Running hab pkg build for $package_path"
-${hab_binary} pkg build -D "$package_path"
+${hab_binary} pkg build "$package_path"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -571,7 +571,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh test-services/test-probe
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -586,7 +586,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/backline
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -600,7 +600,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/hab
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -614,7 +614,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/launcher
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -629,7 +629,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/pkg-cfize
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -643,7 +643,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/pkg-export-container
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -657,7 +657,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/pkg-export-tar
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -671,7 +671,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/pkg-mesosize
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -685,7 +685,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/plan-build
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -699,7 +699,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/studio
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:
@@ -713,7 +713,7 @@ steps:
       - .expeditor/scripts/verify/build_package.sh components/sup
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
     retry:
       automatic:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -732,7 +732,7 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
 
   - label: "[build] :linux: :two: build hab-plan-build"
@@ -743,7 +743,7 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
 
   - label: "[build] :linux: :two: build hab-backline"
@@ -755,7 +755,7 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
 
   - label: "[build] :linux: :two: build hab-studio"
@@ -766,7 +766,7 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
 
   - label: "[build] :linux: :two: build launcher"
@@ -777,7 +777,7 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
 
   - label: "[build] :linux: :two: build hab-sup"
@@ -788,7 +788,7 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
 
   - label: "[build] :linux: :two: build hab-pkg-export-tar"
@@ -799,7 +799,7 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
     expeditor:
       executor:
-        linux:
+        docker:
           privileged: true
 
 #######################################################################


### PR DESCRIPTION
The kernel2 verify steps mutate the CI host by installing the kernel2  hab cli, so we should use disposable infrastructure for these steps.
 
Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>