### PR TITLE
Add a signature policy file for Buildah exports

### DIFF
--- a/components/pkg-export-container/defaults/containers-policy.json
+++ b/components/pkg-export-container/defaults/containers-policy.json
@@ -1,0 +1,7 @@
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ]
+}

--- a/components/pkg-export-container/src/engine.rs
+++ b/components/pkg-export-container/src/engine.rs
@@ -39,6 +39,8 @@ enum EngineError {
     UnknownEngine(String),
     #[fail(display = "Cannot use `--engine=buildah` with `--multi-layer` due to https://github.com/containers/buildah/issues/2215. Please use `--engine=docker` or remove `--multi-layer`.")]
     BuildahIncompatibleWithMultiLayer,
+    #[fail(display = "{}", _0)]
+    EngineSpecificError(failure::Error),
 }
 
 /// Due to a bug in Buildah, any layers that we create in a

--- a/components/pkg-export-container/src/engine/buildah.rs
+++ b/components/pkg-export-container/src/engine/buildah.rs
@@ -1,20 +1,62 @@
 use super::{resolve_engine_binary,
             Engine,
             EngineError};
-use std::{path::{Path,
+use std::{io::Write,
+          path::{Path,
                  PathBuf},
           process::Command,
           result::Result};
+use tempfile::TempPath;
+
+/// Contents of the signature policy file used by Buildah (normally
+/// present at /etc/containers/policy.json.)
+///
+/// Our policy will be to default to accepting everything (which is
+/// also the default given by RPM installations of buildah).
+///
+/// See https://www.mankier.com/5/containers-policy.json for further
+/// information.
+const SIGNATURE_POLICY: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"),
+                                                    "/defaults/containers-policy.json"));
 
 #[derive(Debug)]
 pub(super) struct BuildahEngine {
     binary: PathBuf,
+
+    /// Path to a signature policy file that we control, not
+    /// `/etc/containers/policy.json`.
+    ///
+    /// The file will be removed when this struct is dropped.
+    policy: TempPath,
+}
+
+#[derive(Debug, Fail)]
+enum BuildahError {
+    #[fail(display = "Could not create signature policy file for Buildah: {}", _0)]
+    SignaturePolicyError(std::io::Error),
+}
+
+impl From<BuildahError> for EngineError {
+    fn from(b: BuildahError) -> EngineError { EngineError::EngineSpecificError(b.into()) }
 }
 
 impl BuildahEngine {
     pub fn new() -> Result<Self, EngineError> {
         let binary = resolve_engine_binary("buildah")?;
-        Ok(BuildahEngine { binary })
+        let policy = Self::signature_policy()?;
+        Ok(BuildahEngine { binary, policy })
+    }
+
+    /// Write out a permissive default signature policy to a temporary
+    /// file, and return the path to that file.
+    ///
+    /// The file will be removed when that `TempPath` is dropped.
+    fn signature_policy() -> Result<TempPath, BuildahError> {
+        let mut policy =
+            tempfile::NamedTempFile::new().map_err(BuildahError::SignaturePolicyError)?;
+        policy.write_all(SIGNATURE_POLICY.as_bytes())
+              .map_err(BuildahError::SignaturePolicyError)?;
+        Ok(policy.into_temp_path())
     }
 }
 
@@ -64,6 +106,11 @@ impl Engine for BuildahEngine {
         // since DockerHub is the 800 lb gorilla, we'll defer to it
         // for now.)
         cmd.args(&["--format", "docker"]);
+
+        // Have to override the policy file location because we don't
+        // control /etc/containers/policy.json
+        cmd.arg("--signature-policy");
+        cmd.arg(&self.policy);
 
         if let Some(mem) = memory {
             cmd.arg("--memory").arg(mem);

--- a/test/end-to-end/test_container_exporter.ps1
+++ b/test/end-to-end/test_container_exporter.ps1
@@ -167,8 +167,8 @@ if ($IsLinux) {
     Describe "hab pkg export container --engine=buildah" {
         It "Runs successfully" {
             $tag = New-CustomTag
-            hab pkg export container core/nginx --engine=buildah --tag-custom="$tag"
-            hab pkg exec core/buildah buildah rmi "core/nginx:$tag"
+            Invoke-NativeCommand hab pkg export container core/nginx --engine=buildah --tag-custom="$tag"
+            Invoke-NativeCommand hab pkg exec core/buildah buildah rmi "core/nginx:$tag"
         }
     }
 }


### PR DESCRIPTION
Buildah normally requires access to `/etc/containers/policy.json`, a
configuration file that describes signature policies for deciding
whether to use a particular image during a build. (See
https://www.mankier.com/5/containers-policy.json for additional
background.) This is not a path that we have control over in a Habitat
context, though.

To get around this, we invoke `buildah` with the `--signature-policy`
option. Concretely, the engine creates and manages a temporary file
that contains a permissive default policy, and our build command uses
that file for policy decisions. This is the same policy you would get
if you installed `buildah` or `podman` from an RPM or `deb` file.

This PR also continues the efforts at error modularization within the
container exporter by confining the new Buildah-specific errors to the
buildah module, and explicitly mapping general IO errors to a more
context-carrying `SignaturePolicyError` error instance (rather than
implementing a blanket `From<std::io::Error>`). On the other hand, we
now have a general `EngineError::EngineSpecificError` variant that
simply serves to integrate any engine-specific errors into the overall
error structure of the crate. Here, a `From<BuildahError> for
EngineError` implementation makes a bit more sense.

Also fixes the end-to-end test that should have caught the fact that
the Buildah engine wasn't working in the absence of
`/etc/containers/policy.json`. That, plus the fact that I had the file
on my workstation by virtue of my previous vetting of `buildah` and
subsequent implementation of the feature, is why this snuck through
undetected until now. Mea culpa.

Signed-off-by: Christopher Maier <cmaier@chef.io>