### PR TITLE
Supervisor update config

### DIFF
--- a/components/core/src/util.rs
+++ b/components/core/src/util.rs
@@ -163,7 +163,12 @@ impl DurationWithSplay {
     }
 
     pub fn delay(&self) -> Duration {
-        let splay = rand::thread_rng().gen_range(0.0, self.max_splay.as_secs_f64());
+        let max_splay = self.max_splay.as_secs_f64();
+        let splay = if max_splay > 0.0 {
+            rand::thread_rng().gen_range(0.0, max_splay)
+        } else {
+            0.0
+        };
         self.period + Duration::from_secs_f64(splay)
     }
 }
@@ -297,5 +302,7 @@ mod tests {
             assert!(delay >= period);
             assert!(delay <= period + splay);
         }
+        let duration_without_splay = DurationWithSplay::new_without_splay(period);
+        assert_eq!(duration_without_splay.delay(), period);
     }
 }

--- a/components/core/src/util.rs
+++ b/components/core/src/util.rs
@@ -6,9 +6,11 @@ pub mod sys;
 #[cfg(windows)]
 pub mod win_perm;
 
+use rand::Rng;
 use std::{io::{self,
                BufRead},
-          mem};
+          mem,
+          time::Duration};
 
 /// Same as `Result::ok()`, but logs the error case. Useful for
 /// ignoring error cases, while still leaving a paper trail.
@@ -136,6 +138,40 @@ pub trait BufReadLossy: BufRead {
 // Implement `BufReadLossy` for all types that implement `BufRead`
 impl<T: BufRead> BufReadLossy for T {}
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DurationWithSplay {
+    period:    Duration,
+    max_splay: Duration,
+}
+
+impl DurationWithSplay {
+    pub fn new(period: Duration, max_splay: Duration) -> Self { Self { period, max_splay } }
+
+    pub fn new_without_splay(period: Duration) -> Self {
+        Self { period,
+               max_splay: Duration::default() }
+    }
+
+    pub fn from_secs(period: u64, max_splay: u64) -> Self {
+        Self { period:    Duration::from_secs(period),
+               max_splay: Duration::from_secs(max_splay), }
+    }
+
+    pub fn from_secs_f64(period: f64, max_splay: f64) -> Self {
+        Self { period:    Duration::from_secs_f64(period),
+               max_splay: Duration::from_secs_f64(max_splay), }
+    }
+
+    pub fn delay(&self) -> Duration {
+        let splay = rand::thread_rng().gen_range(0.0, self.max_splay.as_secs_f64());
+        self.period + Duration::from_secs_f64(splay)
+    }
+}
+
+impl From<Duration> for DurationWithSplay {
+    fn from(d: Duration) -> Self { Self::new_without_splay(d) }
+}
+
 /// Provide a way to convert numeric types safely to i64
 pub trait ToI64 {
     fn to_i64(self) -> i64;
@@ -249,5 +285,17 @@ mod tests {
         assert_eq!(str_vec[0], "line 1");
         assert_eq!(str_vec[1], "line � 2");
         assert_eq!(str_vec[2], "line 3");
+    }
+
+    #[test]
+    fn duration_with_splay() {
+        let period = Duration::from_secs(10);
+        let splay = Duration::from_secs_f64(0.5);
+        let duration_with_splay = DurationWithSplay::new(period, splay);
+        for _ in 0..100 {
+            let delay = duration_with_splay.delay();
+            assert!(delay >= period);
+            assert!(delay <= period + splay);
+        }
     }
 }

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -184,9 +184,12 @@ pub struct SupRun {
     /// Enable automatic updates for the Supervisor itself
     #[structopt(long = "auto-update", short = "A")]
     pub auto_update: bool,
-    /// The period of time in seconds between checks for a Supervisor update
+    /// The period of time in seconds between Supervisor update checks
     #[structopt(long = "auto-update-period", default_value = "60")]
     pub auto_update_period: DurationProxy,
+    /// The period of time in seconds between service update checks
+    #[structopt(long = "service-update-period", default_value = "60")]
+    pub service_update_period: DurationProxy,
     /// The private key for HTTP Gateway TLS encryption
     ///
     /// Read the private key from KEY_FILE. This should be an RSA private key or PKCS8-encoded

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -187,9 +187,6 @@ pub struct SupRun {
     /// The period of time in seconds between checks for a Supervisor update
     #[structopt(long = "auto-update-period", default_value = "60")]
     pub auto_update_period: DurationProxy,
-    /// The max duration of random splay in seconds added to the Supervisor update period
-    #[structopt(long = "auto-update-splay", default_value = "5")]
-    pub auto_update_splay: DurationProxy,
     /// The private key for HTTP Gateway TLS encryption
     ///
     /// Read the private key from KEY_FILE. This should be an RSA private key or PKCS8-encoded

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -4,6 +4,7 @@ use super::{svc::{ConfigOptSharedLoad,
                    CacheKeyPath,
                    ConfigOptCacheKeyPath,
                    ConfigOptRemoteSup,
+                   DurationProxy,
                    RemoteSup}};
 use crate::VERSION;
 use configopt::{self,
@@ -183,6 +184,9 @@ pub struct SupRun {
     /// Enable automatic updates for the Supervisor itself
     #[structopt(long = "auto-update", short = "A")]
     pub auto_update: bool,
+    /// The period of time between checks for a Supervisor update
+    #[structopt(long = "auto-update-period", default_value = "60")]
+    pub auto_update_period: DurationProxy,
     /// The private key for HTTP Gateway TLS encryption
     ///
     /// Read the private key from KEY_FILE. This should be an RSA private key or PKCS8-encoded

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -184,10 +184,10 @@ pub struct SupRun {
     /// Enable automatic updates for the Supervisor itself
     #[structopt(long = "auto-update", short = "A")]
     pub auto_update: bool,
-    /// The period of time between checks for a Supervisor update
+    /// The period of time in seconds between checks for a Supervisor update
     #[structopt(long = "auto-update-period", default_value = "60")]
     pub auto_update_period: DurationProxy,
-    /// The max duration of random splay added to the Supervisor update period
+    /// The max duration of random splay in seconds added to the Supervisor update period
     #[structopt(long = "auto-update-splay", default_value = "5")]
     pub auto_update_splay: DurationProxy,
     /// The private key for HTTP Gateway TLS encryption

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -187,6 +187,9 @@ pub struct SupRun {
     /// The period of time between checks for a Supervisor update
     #[structopt(long = "auto-update-period", default_value = "60")]
     pub auto_update_period: DurationProxy,
+    /// The max duration of random splay added to the Supervisor update period
+    #[structopt(long = "auto-update-splay", default_value = "5")]
+    pub auto_update_splay: DurationProxy,
     /// The private key for HTTP Gateway TLS encryption
     ///
     /// Read the private key from KEY_FILE. This should be an RSA private key or PKCS8-encoded

--- a/components/hab/src/cli/hab/util.rs
+++ b/components/hab/src/cli/hab/util.rs
@@ -9,7 +9,7 @@ use std::{fmt,
           io,
           net::{SocketAddr,
                 ToSocketAddrs},
-          num::ParseFloatError,
+          num::ParseIntError,
           path::PathBuf,
           str::FromStr,
           time::Duration};
@@ -106,15 +106,15 @@ pub fn socket_addrs_with_default_port<I>(addrs: I, default_port: u16) -> io::Res
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(from = "f64", into = "f64")]
+#[serde(from = "u64", into = "u64")]
 pub struct DurationProxy(Duration);
 
-impl From<DurationProxy> for f64 {
-    fn from(d: DurationProxy) -> Self { d.0.as_secs_f64() }
+impl From<DurationProxy> for u64 {
+    fn from(d: DurationProxy) -> Self { d.0.as_secs() }
 }
 
-impl From<f64> for DurationProxy {
-    fn from(f: f64) -> Self { Self(Duration::from_secs_f64(f)) }
+impl From<u64> for DurationProxy {
+    fn from(n: u64) -> Self { Self(Duration::from_secs(n)) }
 }
 
 impl From<DurationProxy> for Duration {
@@ -126,13 +126,13 @@ impl From<Duration> for DurationProxy {
 }
 
 impl FromStr for DurationProxy {
-    type Err = ParseFloatError;
+    type Err = ParseIntError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> { Ok(s.parse::<f64>()?.into()) }
+    fn from_str(s: &str) -> Result<Self, Self::Err> { Ok(s.parse::<u64>()?.into()) }
 }
 
 impl fmt::Display for DurationProxy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", f64::from(*self)) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", u64::from(*self)) }
 }
 
 #[cfg(test)]

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -97,7 +97,6 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
                             String::from("HAB_STUDIO_NOPROFILE"),
                             String::from("HAB_STUDIO_NOSTUDIORC"),
                             String::from("HAB_STUDIO_SUP"),
-                            String::from("HAB_UPDATE_STRATEGY_FREQUENCY_MS"),
                             String::from("http_proxy"),
                             String::from("https_proxy"),
                             String::from("RUST_LOG"),

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -321,6 +321,7 @@ fn split_apart_sup_run(sup_run: SupRun,
     };
 
     let cfg = ManagerConfig { auto_update: sup_run.auto_update,
+                              auto_update_period: sup_run.auto_update_period.into(),
                               custom_state_path: None, // remove entirely?
                               cache_key_path: sup_run.cache_key_path.cache_key_path,
                               update_url: bldr_url(shared_load.bldr_url.as_ref()),
@@ -502,7 +503,8 @@ mod test {
                   io::Write,
                   iter::FromIterator,
                   path::PathBuf,
-                  str::FromStr};
+                  str::FromStr,
+                  time::Duration};
 
         locked_env_var!(HAB_CACHE_KEY_PATH, lock_var);
 
@@ -759,6 +761,7 @@ gpoVMSncu2jMIDZX63IkQII=
 
             let config = config_from_cmd_str("hab-sup run");
             assert_eq!(ManagerConfig { auto_update:          false,
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -833,13 +836,13 @@ gpoVMSncu2jMIDZX63IkQII=
             let ca_cert_path_str = ca_cert_path.to_str().unwrap();
             File::create(&ca_cert_path).unwrap();
 
-            let args = format!("hab-sup run --listen-gossip=1.2.3.4:4321 \
-                                --listen-http=5.5.5.5:11111 --http-disable \
-                                --listen-ctl=7.8.9.1:12 --org=MY_ORG --peer 1.1.1.1:1111 \
-                                2.2.2.2:2222 3.3.3.3 --permanent-peer --ring tester \
-                                --cache-key-path={} --auto-update --key={} --certs={} --ca-certs \
-                                {} --keep-latest-packages=5 --sys-ip-address 7.8.9.0",
-                               temp_dir_str, key_path_str, cert_path_str, ca_cert_path_str);
+            let args =
+                format!("hab-sup run --listen-gossip=1.2.3.4:4321 --listen-http=5.5.5.5:11111 \
+                         --http-disable --listen-ctl=7.8.9.1:12 --org=MY_ORG --peer 1.1.1.1:1111 \
+                         2.2.2.2:2222 3.3.3.3 --permanent-peer --ring tester --cache-key-path={} \
+                         --auto-update --auto-update-period 90.54321 --key={} --certs={} \
+                         --ca-certs {} --keep-latest-packages=5 --sys-ip-address 7.8.9.0",
+                        temp_dir_str, key_path_str, cert_path_str, ca_cert_path_str);
 
             let gossip_peers = vec!["1.1.1.1:1111".parse().unwrap(),
                                     "2.2.2.2:2222".parse().unwrap(),
@@ -848,6 +851,7 @@ gpoVMSncu2jMIDZX63IkQII=
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update: true,
+                                       auto_update_period: Duration::from_secs_f64(90.54321),
                                        custom_state_path: None,
                                        cache_key_path: PathBuf::from(temp_dir_str),
                                        update_url: String::from("https://bldr.habitat.sh"),
@@ -884,6 +888,7 @@ gpoVMSncu2jMIDZX63IkQII=
 
             let config = config_from_cmd_str(args);
             assert_eq!(ManagerConfig { auto_update:          false,
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       PathBuf::from("/cache/key/path"),
                                        update_url:
@@ -916,6 +921,7 @@ gpoVMSncu2jMIDZX63IkQII=
 
             let config = config_from_cmd_str(args);
             assert_eq!(ManagerConfig { auto_update:          false,
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -980,6 +986,7 @@ gpoVMSncu2jMIDZX63IkQII=
             meta.insert(String::from("key2"), String::from("val2"));
             meta.insert(String::from("keyA"), String::from("valA"));
             assert_eq!(ManagerConfig { auto_update:          false,
+                auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -1151,6 +1158,7 @@ sys_ip_address = "7.8.9.0"
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update: true,
+                                       auto_update_period: Duration::from_secs(60),
                                        custom_state_path: None,
                                        cache_key_path: PathBuf::from(temp_dir_str),
                                        update_url: String::from("https://bldr.habitat.sh"),
@@ -1196,6 +1204,7 @@ sys_ip_address = "7.8.9.0"
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update:          false,
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       PathBuf::from("/cache/key/path"),
                                        update_url:
@@ -1237,6 +1246,7 @@ sys_ip_address = "7.8.9.0"
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update:          false,
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -1338,6 +1348,7 @@ event_stream_server_certificate = "{}"
             meta.insert(String::from("key2"), String::from("val2"));
             meta.insert(String::from("keyA"), String::from("valA"));
             assert_eq!(ManagerConfig { auto_update:          false,
+                auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -1518,6 +1529,7 @@ organization = "MY_ORG_FROM_SECOND_CONFG"
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update:          false,
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -322,6 +322,7 @@ fn split_apart_sup_run(sup_run: SupRun,
 
     let cfg = ManagerConfig { auto_update: sup_run.auto_update,
                               auto_update_period: sup_run.auto_update_period.into(),
+                              service_update_period: sup_run.service_update_period.into(),
                               custom_state_path: None, // remove entirely?
                               cache_key_path: sup_run.cache_key_path.cache_key_path,
                               update_url: bldr_url(shared_load.bldr_url.as_ref()),
@@ -760,27 +761,29 @@ gpoVMSncu2jMIDZX63IkQII=
             lock.unset();
 
             let config = config_from_cmd_str("hab-sup run");
-            assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   Duration::from_secs(60),
-                                       custom_state_path:    None,
-                                       cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
+            assert_eq!(ManagerConfig { auto_update:           false,
+                                       auto_update_period:    Duration::from_secs(60),
+                                       service_update_period: Duration::from_secs(60),
+                                       custom_state_path:     None,
+                                       cache_key_path:        (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
                                            String::from("https://bldr.habitat.sh"),
-                                       update_channel:       ChannelIdent::default(),
-                                       gossip_listen:        GossipListenAddr::default(),
-                                       ctl_listen:           ListenCtlAddr::default(),
-                                       http_listen:          HttpListenAddr::default(),
-                                       http_disable:         false,
-                                       gossip_peers:         vec![],
-                                       gossip_permanent:     false,
-                                       ring_key:             None,
-                                       organization:         None,
-                                       watch_peer_file:      None,
-                                       tls_config:           None,
-                                       feature_flags:        FeatureFlag::empty(),
-                                       event_stream_config:  None,
-                                       keep_latest_packages: None,
-                                       sys_ip:               habitat_core::util::sys::ip().unwrap(), },
+                                       update_channel:        ChannelIdent::default(),
+                                       gossip_listen:         GossipListenAddr::default(),
+                                       ctl_listen:            ListenCtlAddr::default(),
+                                       http_listen:           HttpListenAddr::default(),
+                                       http_disable:          false,
+                                       gossip_peers:          vec![],
+                                       gossip_permanent:      false,
+                                       ring_key:              None,
+                                       organization:          None,
+                                       watch_peer_file:       None,
+                                       tls_config:            None,
+                                       feature_flags:         FeatureFlag::empty(),
+                                       event_stream_config:   None,
+                                       keep_latest_packages:  None,
+                                       sys_ip:
+                                           habitat_core::util::sys::ip().unwrap(), },
                        config);
 
             let health_check_interval = sup_proto::types::HealthCheckInterval { seconds: 30 };
@@ -836,13 +839,14 @@ gpoVMSncu2jMIDZX63IkQII=
             let ca_cert_path_str = ca_cert_path.to_str().unwrap();
             File::create(&ca_cert_path).unwrap();
 
-            let args =
-                format!("hab-sup run --listen-gossip=1.2.3.4:4321 --listen-http=5.5.5.5:11111 \
-                         --http-disable --listen-ctl=7.8.9.1:12 --org=MY_ORG --peer 1.1.1.1:1111 \
-                         2.2.2.2:2222 3.3.3.3 --permanent-peer --ring tester --cache-key-path={} \
-                         --auto-update --auto-update-period 90 --key={} --certs={} --ca-certs {} \
-                         --keep-latest-packages=5 --sys-ip-address 7.8.9.0",
-                        temp_dir_str, key_path_str, cert_path_str, ca_cert_path_str);
+            let args = format!("hab-sup run --listen-gossip=1.2.3.4:4321 \
+                                --listen-http=5.5.5.5:11111 --http-disable \
+                                --listen-ctl=7.8.9.1:12 --org=MY_ORG --peer 1.1.1.1:1111 \
+                                2.2.2.2:2222 3.3.3.3 --permanent-peer --ring tester \
+                                --cache-key-path={} --auto-update --auto-update-period 90 \
+                                --service-update-period 30 --key={} --certs={} --ca-certs {} \
+                                --keep-latest-packages=5 --sys-ip-address 7.8.9.0",
+                               temp_dir_str, key_path_str, cert_path_str, ca_cert_path_str);
 
             let gossip_peers = vec!["1.1.1.1:1111".parse().unwrap(),
                                     "2.2.2.2:2222".parse().unwrap(),
@@ -852,6 +856,7 @@ gpoVMSncu2jMIDZX63IkQII=
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update: true,
                                        auto_update_period: Duration::from_secs(90),
+                                       service_update_period: Duration::from_secs(30),
                                        custom_state_path: None,
                                        cache_key_path: PathBuf::from(temp_dir_str),
                                        update_url: String::from("https://bldr.habitat.sh"),
@@ -887,28 +892,30 @@ gpoVMSncu2jMIDZX63IkQII=
             let args = "hab-sup run --local-gossip-mode";
 
             let config = config_from_cmd_str(args);
-            assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   Duration::from_secs(60),
-                                       custom_state_path:    None,
-                                       cache_key_path:       PathBuf::from("/cache/key/path"),
+            assert_eq!(ManagerConfig { auto_update:           false,
+                                       auto_update_period:    Duration::from_secs(60),
+                                       service_update_period: Duration::from_secs(60),
+                                       custom_state_path:     None,
+                                       cache_key_path:        PathBuf::from("/cache/key/path"),
                                        update_url:
                                            String::from("https://bldr.habitat.sh"),
-                                       update_channel:       ChannelIdent::default(),
+                                       update_channel:        ChannelIdent::default(),
                                        gossip_listen:
                                            GossipListenAddr::from_str("127.0.0.2:9638").unwrap(),
-                                       ctl_listen:           ListenCtlAddr::default(),
-                                       http_listen:          HttpListenAddr::default(),
-                                       http_disable:         false,
-                                       gossip_peers:         vec![],
-                                       gossip_permanent:     false,
-                                       ring_key:             None,
-                                       organization:         None,
-                                       watch_peer_file:      None,
-                                       tls_config:           None,
-                                       feature_flags:        FeatureFlag::empty(),
-                                       event_stream_config:  None,
-                                       keep_latest_packages: None,
-                                       sys_ip:               habitat_core::util::sys::ip().unwrap(), },
+                                       ctl_listen:            ListenCtlAddr::default(),
+                                       http_listen:           HttpListenAddr::default(),
+                                       http_disable:          false,
+                                       gossip_peers:          vec![],
+                                       gossip_permanent:      false,
+                                       ring_key:              None,
+                                       organization:          None,
+                                       watch_peer_file:       None,
+                                       tls_config:            None,
+                                       feature_flags:         FeatureFlag::empty(),
+                                       event_stream_config:   None,
+                                       keep_latest_packages:  None,
+                                       sys_ip:
+                                           habitat_core::util::sys::ip().unwrap(), },
                        config);
         }
 
@@ -920,27 +927,29 @@ gpoVMSncu2jMIDZX63IkQII=
             let args = "hab-sup run --peer-watch-file=/some/path";
 
             let config = config_from_cmd_str(args);
-            assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   Duration::from_secs(60),
-                                       custom_state_path:    None,
-                                       cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
+            assert_eq!(ManagerConfig { auto_update:           false,
+                                       auto_update_period:    Duration::from_secs(60),
+                                       service_update_period: Duration::from_secs(60),
+                                       custom_state_path:     None,
+                                       cache_key_path:        (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
                                            String::from("https://bldr.habitat.sh"),
-                                       update_channel:       ChannelIdent::default(),
-                                       gossip_listen:        GossipListenAddr::default(),
-                                       ctl_listen:           ListenCtlAddr::default(),
-                                       http_listen:          HttpListenAddr::default(),
-                                       http_disable:         false,
-                                       gossip_peers:         vec![],
-                                       gossip_permanent:     false,
-                                       ring_key:             None,
-                                       organization:         None,
-                                       watch_peer_file:      Some(String::from("/some/path")),
-                                       tls_config:           None,
-                                       feature_flags:        FeatureFlag::empty(),
-                                       event_stream_config:  None,
-                                       keep_latest_packages: None,
-                                       sys_ip:               habitat_core::util::sys::ip().unwrap(), },
+                                       update_channel:        ChannelIdent::default(),
+                                       gossip_listen:         GossipListenAddr::default(),
+                                       ctl_listen:            ListenCtlAddr::default(),
+                                       http_listen:           HttpListenAddr::default(),
+                                       http_disable:          false,
+                                       gossip_peers:          vec![],
+                                       gossip_permanent:      false,
+                                       ring_key:              None,
+                                       organization:          None,
+                                       watch_peer_file:       Some(String::from("/some/path")),
+                                       tls_config:            None,
+                                       feature_flags:         FeatureFlag::empty(),
+                                       event_stream_config:   None,
+                                       keep_latest_packages:  None,
+                                       sys_ip:
+                                           habitat_core::util::sys::ip().unwrap(), },
                        config);
         }
 
@@ -987,6 +996,7 @@ gpoVMSncu2jMIDZX63IkQII=
             meta.insert(String::from("keyA"), String::from("valA"));
             assert_eq!(ManagerConfig { auto_update:          false,
                 auto_update_period:   Duration::from_secs(60),
+                service_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -1133,6 +1143,8 @@ permanent_peer = true
 ring = "tester"
 cache_key_path = "{}"
 auto_update = true
+auto_update_period = 3600
+service_update_period = 1_000
 key_file = "{}"
 cert_file = "{}"
 ca_cert_file = "{}"
@@ -1158,7 +1170,8 @@ sys_ip_address = "7.8.9.0"
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update: true,
-                                       auto_update_period: Duration::from_secs(60),
+                                       auto_update_period: Duration::from_secs(3600),
+                                       service_update_period: Duration::from_secs(1_000),
                                        custom_state_path: None,
                                        cache_key_path: PathBuf::from(temp_dir_str),
                                        update_url: String::from("https://bldr.habitat.sh"),
@@ -1203,28 +1216,30 @@ sys_ip_address = "7.8.9.0"
             let args = format!("hab-sup run --config-files {}", config_path_str);
 
             let config = config_from_cmd_str(&args);
-            assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   Duration::from_secs(60),
-                                       custom_state_path:    None,
-                                       cache_key_path:       PathBuf::from("/cache/key/path"),
+            assert_eq!(ManagerConfig { auto_update:           false,
+                                       auto_update_period:    Duration::from_secs(60),
+                                       service_update_period: Duration::from_secs(60),
+                                       custom_state_path:     None,
+                                       cache_key_path:        PathBuf::from("/cache/key/path"),
                                        update_url:
                                            String::from("https://bldr.habitat.sh"),
-                                       update_channel:       ChannelIdent::default(),
+                                       update_channel:        ChannelIdent::default(),
                                        gossip_listen:
                                            GossipListenAddr::from_str("127.0.0.2:9638").unwrap(),
-                                       ctl_listen:           ListenCtlAddr::default(),
-                                       http_listen:          HttpListenAddr::default(),
-                                       http_disable:         false,
-                                       gossip_peers:         vec![],
-                                       gossip_permanent:     false,
-                                       ring_key:             None,
-                                       organization:         None,
-                                       watch_peer_file:      None,
-                                       tls_config:           None,
-                                       feature_flags:        FeatureFlag::empty(),
-                                       event_stream_config:  None,
-                                       keep_latest_packages: None,
-                                       sys_ip:               habitat_core::util::sys::ip().unwrap(), },
+                                       ctl_listen:            ListenCtlAddr::default(),
+                                       http_listen:           HttpListenAddr::default(),
+                                       http_disable:          false,
+                                       gossip_peers:          vec![],
+                                       gossip_permanent:      false,
+                                       ring_key:              None,
+                                       organization:          None,
+                                       watch_peer_file:       None,
+                                       tls_config:            None,
+                                       feature_flags:         FeatureFlag::empty(),
+                                       event_stream_config:   None,
+                                       keep_latest_packages:  None,
+                                       sys_ip:
+                                           habitat_core::util::sys::ip().unwrap(), },
                        config);
         }
 
@@ -1245,27 +1260,29 @@ sys_ip_address = "7.8.9.0"
             let args = format!("hab-sup run --config-files {}", config_path_str);
 
             let config = config_from_cmd_str(&args);
-            assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   Duration::from_secs(60),
-                                       custom_state_path:    None,
-                                       cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
+            assert_eq!(ManagerConfig { auto_update:           false,
+                                       auto_update_period:    Duration::from_secs(60),
+                                       service_update_period: Duration::from_secs(60),
+                                       custom_state_path:     None,
+                                       cache_key_path:        (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
                                            String::from("https://bldr.habitat.sh"),
-                                       update_channel:       ChannelIdent::default(),
-                                       gossip_listen:        GossipListenAddr::default(),
-                                       ctl_listen:           ListenCtlAddr::default(),
-                                       http_listen:          HttpListenAddr::default(),
-                                       http_disable:         false,
-                                       gossip_peers:         vec![],
-                                       gossip_permanent:     false,
-                                       ring_key:             None,
-                                       organization:         None,
-                                       watch_peer_file:      Some(String::from("/some/path")),
-                                       tls_config:           None,
-                                       feature_flags:        FeatureFlag::empty(),
-                                       event_stream_config:  None,
-                                       keep_latest_packages: None,
-                                       sys_ip:               habitat_core::util::sys::ip().unwrap(), },
+                                       update_channel:        ChannelIdent::default(),
+                                       gossip_listen:         GossipListenAddr::default(),
+                                       ctl_listen:            ListenCtlAddr::default(),
+                                       http_listen:           HttpListenAddr::default(),
+                                       http_disable:          false,
+                                       gossip_peers:          vec![],
+                                       gossip_permanent:      false,
+                                       ring_key:              None,
+                                       organization:          None,
+                                       watch_peer_file:       Some(String::from("/some/path")),
+                                       tls_config:            None,
+                                       feature_flags:         FeatureFlag::empty(),
+                                       event_stream_config:   None,
+                                       keep_latest_packages:  None,
+                                       sys_ip:
+                                           habitat_core::util::sys::ip().unwrap(), },
                        config);
         }
 
@@ -1349,6 +1366,7 @@ event_stream_server_certificate = "{}"
             meta.insert(String::from("keyA"), String::from("valA"));
             assert_eq!(ManagerConfig { auto_update:          false,
                 auto_update_period:   Duration::from_secs(60),
+                service_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -1528,31 +1546,33 @@ organization = "MY_ORG_FROM_SECOND_CONFG"
                                config1_path_str, config2_path_str);
 
             let config = config_from_cmd_str(&args);
-            assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   Duration::from_secs(60),
-                                       custom_state_path:    None,
-                                       cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
+            assert_eq!(ManagerConfig { auto_update:           false,
+                                       auto_update_period:    Duration::from_secs(60),
+                                       service_update_period: Duration::from_secs(60),
+                                       custom_state_path:     None,
+                                       cache_key_path:        (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
                                            String::from("https://bldr.habitat.sh"),
-                                       update_channel:       ChannelIdent::default(),
+                                       update_channel:        ChannelIdent::default(),
                                        gossip_listen:
                                            GossipListenAddr::from_str("1.2.3.4:4321").unwrap(),
                                        ctl_listen:
                                            ListenCtlAddr::from_str("7.7.7.7:7777").unwrap(),
                                        http_listen:
                                            HttpListenAddr::from_str("3.3.3.3:3333").unwrap(),
-                                       http_disable:         false,
-                                       gossip_peers:         vec![],
-                                       gossip_permanent:     false,
-                                       ring_key:             None,
+                                       http_disable:          false,
+                                       gossip_peers:          vec![],
+                                       gossip_permanent:      false,
+                                       ring_key:              None,
                                        organization:
                                            Some(String::from("MY_ORG_FROM_SECOND_CONFG")),
-                                       watch_peer_file:      None,
-                                       tls_config:           None,
-                                       feature_flags:        FeatureFlag::empty(),
-                                       event_stream_config:  None,
-                                       keep_latest_packages: None,
-                                       sys_ip:               habitat_core::util::sys::ip().unwrap(), },
+                                       watch_peer_file:       None,
+                                       tls_config:            None,
+                                       feature_flags:         FeatureFlag::empty(),
+                                       event_stream_config:   None,
+                                       keep_latest_packages:  None,
+                                       sys_ip:
+                                           habitat_core::util::sys::ip().unwrap(), },
                        config);
         }
 

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -840,8 +840,8 @@ gpoVMSncu2jMIDZX63IkQII=
                 format!("hab-sup run --listen-gossip=1.2.3.4:4321 --listen-http=5.5.5.5:11111 \
                          --http-disable --listen-ctl=7.8.9.1:12 --org=MY_ORG --peer 1.1.1.1:1111 \
                          2.2.2.2:2222 3.3.3.3 --permanent-peer --ring tester --cache-key-path={} \
-                         --auto-update --auto-update-period 90.54321 --key={} --certs={} \
-                         --ca-certs {} --keep-latest-packages=5 --sys-ip-address 7.8.9.0",
+                         --auto-update --auto-update-period 90 --key={} --certs={} --ca-certs {} \
+                         --keep-latest-packages=5 --sys-ip-address 7.8.9.0",
                         temp_dir_str, key_path_str, cert_path_str, ca_cert_path_str);
 
             let gossip_peers = vec!["1.1.1.1:1111".parse().unwrap(),
@@ -851,7 +851,7 @@ gpoVMSncu2jMIDZX63IkQII=
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update: true,
-                                       auto_update_period: Duration::from_secs_f64(90.54321),
+                                       auto_update_period: Duration::from_secs(90),
                                        custom_state_path: None,
                                        cache_key_path: PathBuf::from(temp_dir_str),
                                        update_url: String::from("https://bldr.habitat.sh"),

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -44,7 +44,6 @@ use habitat_core::{self,
                             SymKey},
                    os::signals,
                    url::default_bldr_url,
-                   util::DurationWithSplay,
                    ChannelIdent};
 use habitat_launcher_client::{LauncherCli,
                               ERR_NO_RETRY_EXCODE,
@@ -322,9 +321,7 @@ fn split_apart_sup_run(sup_run: SupRun,
     };
 
     let cfg = ManagerConfig { auto_update: sup_run.auto_update,
-                              auto_update_period:
-                                  DurationWithSplay::new(sup_run.auto_update_period.into(),
-                                                         sup_run.auto_update_splay.into()),
+                              auto_update_period: sup_run.auto_update_period.into(),
                               custom_state_path: None, // remove entirely?
                               cache_key_path: sup_run.cache_key_path.cache_key_path,
                               update_url: bldr_url(shared_load.bldr_url.as_ref()),
@@ -500,14 +497,14 @@ mod test {
         use habitat_common::types::EventStreamConnectMethod;
         #[cfg(windows)]
         use habitat_core::crypto::dpapi::decrypt;
-        use habitat_core::{fs::CACHE_KEY_PATH,
-                           util::DurationWithSplay};
+        use habitat_core::fs::CACHE_KEY_PATH;
         use std::{collections::HashMap,
                   fs::File,
                   io::Write,
                   iter::FromIterator,
                   path::PathBuf,
-                  str::FromStr};
+                  str::FromStr,
+                  time::Duration};
 
         locked_env_var!(HAB_CACHE_KEY_PATH, lock_var);
 
@@ -764,7 +761,7 @@ gpoVMSncu2jMIDZX63IkQII=
 
             let config = config_from_cmd_str("hab-sup run");
             assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   DurationWithSplay::from_secs(60, 5),
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -839,14 +836,13 @@ gpoVMSncu2jMIDZX63IkQII=
             let ca_cert_path_str = ca_cert_path.to_str().unwrap();
             File::create(&ca_cert_path).unwrap();
 
-            let args = format!("hab-sup run --listen-gossip=1.2.3.4:4321 \
-                                --listen-http=5.5.5.5:11111 --http-disable \
-                                --listen-ctl=7.8.9.1:12 --org=MY_ORG --peer 1.1.1.1:1111 \
-                                2.2.2.2:2222 3.3.3.3 --permanent-peer --ring tester \
-                                --cache-key-path={} --auto-update --auto-update-period 90.54321 \
-                                --auto-update-splay 0.12345 --key={} --certs={} --ca-certs {} \
-                                --keep-latest-packages=5 --sys-ip-address 7.8.9.0",
-                               temp_dir_str, key_path_str, cert_path_str, ca_cert_path_str);
+            let args =
+                format!("hab-sup run --listen-gossip=1.2.3.4:4321 --listen-http=5.5.5.5:11111 \
+                         --http-disable --listen-ctl=7.8.9.1:12 --org=MY_ORG --peer 1.1.1.1:1111 \
+                         2.2.2.2:2222 3.3.3.3 --permanent-peer --ring tester --cache-key-path={} \
+                         --auto-update --auto-update-period 90.54321 --key={} --certs={} \
+                         --ca-certs {} --keep-latest-packages=5 --sys-ip-address 7.8.9.0",
+                        temp_dir_str, key_path_str, cert_path_str, ca_cert_path_str);
 
             let gossip_peers = vec!["1.1.1.1:1111".parse().unwrap(),
                                     "2.2.2.2:2222".parse().unwrap(),
@@ -855,8 +851,7 @@ gpoVMSncu2jMIDZX63IkQII=
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update: true,
-                                       auto_update_period:
-                                           DurationWithSplay::from_secs_f64(90.54321, 0.12345),
+                                       auto_update_period: Duration::from_secs_f64(90.54321),
                                        custom_state_path: None,
                                        cache_key_path: PathBuf::from(temp_dir_str),
                                        update_url: String::from("https://bldr.habitat.sh"),
@@ -893,7 +888,7 @@ gpoVMSncu2jMIDZX63IkQII=
 
             let config = config_from_cmd_str(args);
             assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   DurationWithSplay::from_secs(60, 5),
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       PathBuf::from("/cache/key/path"),
                                        update_url:
@@ -926,7 +921,7 @@ gpoVMSncu2jMIDZX63IkQII=
 
             let config = config_from_cmd_str(args);
             assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   DurationWithSplay::from_secs(60, 5),
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -991,7 +986,7 @@ gpoVMSncu2jMIDZX63IkQII=
             meta.insert(String::from("key2"), String::from("val2"));
             meta.insert(String::from("keyA"), String::from("valA"));
             assert_eq!(ManagerConfig { auto_update:          false,
-                auto_update_period:   DurationWithSplay::from_secs(60, 5),
+                auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -1163,7 +1158,7 @@ sys_ip_address = "7.8.9.0"
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update: true,
-                                       auto_update_period: DurationWithSplay::from_secs(60, 5),
+                                       auto_update_period: Duration::from_secs(60),
                                        custom_state_path: None,
                                        cache_key_path: PathBuf::from(temp_dir_str),
                                        update_url: String::from("https://bldr.habitat.sh"),
@@ -1209,7 +1204,7 @@ sys_ip_address = "7.8.9.0"
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   DurationWithSplay::from_secs(60, 5),
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       PathBuf::from("/cache/key/path"),
                                        update_url:
@@ -1251,7 +1246,7 @@ sys_ip_address = "7.8.9.0"
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   DurationWithSplay::from_secs(60, 5),
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -1353,7 +1348,7 @@ event_stream_server_certificate = "{}"
             meta.insert(String::from("key2"), String::from("val2"));
             meta.insert(String::from("keyA"), String::from("valA"));
             assert_eq!(ManagerConfig { auto_update:          false,
-                auto_update_period:   DurationWithSplay::from_secs(60, 5),
+                auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:
@@ -1534,7 +1529,7 @@ organization = "MY_ORG_FROM_SECOND_CONFG"
 
             let config = config_from_cmd_str(&args);
             assert_eq!(ManagerConfig { auto_update:          false,
-                                       auto_update_period:   DurationWithSplay::from_secs(60, 5),
+                                       auto_update_period:   Duration::from_secs(60),
                                        custom_state_path:    None,
                                        cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                                        update_url:

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -262,6 +262,7 @@ impl FsCfg {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ManagerConfig {
     pub auto_update:          bool,
+    pub auto_update_period:   Duration,
     pub custom_state_path:    Option<PathBuf>,
     pub cache_key_path:       PathBuf,
     pub update_url:           String,
@@ -627,8 +628,7 @@ impl Manager {
                 Some(SelfUpdater::new(&*THIS_SUPERVISOR_IDENT,
                                       cfg.update_url,
                                       cfg.update_channel,
-                                      //   TODO (DM): dont hardcode this
-                                      Duration::from_secs(60)))
+                                      cfg.auto_update_period))
             } else {
                 warn!("Supervisor version not fully qualified, unable to start self-updater");
                 None
@@ -1966,6 +1966,7 @@ mod test {
     impl Default for ManagerConfig {
         fn default() -> Self {
             ManagerConfig { auto_update:          false,
+                            auto_update_period:   Duration::from_secs(60),
                             custom_state_path:    None,
                             cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                             update_url:           "".to_string(),

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1966,7 +1966,7 @@ mod test {
     impl Default for ManagerConfig {
         fn default() -> Self {
             ManagerConfig { auto_update:          false,
-                            auto_update_period:   Duration::from_secs(60).into(),
+                            auto_update_period:   Duration::from_secs(60),
                             custom_state_path:    None,
                             cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                             update_url:           "".to_string(),

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -624,7 +624,11 @@ impl Manager {
         let cfg_static = cfg.clone();
         let self_updater = if cfg.auto_update {
             if THIS_SUPERVISOR_IDENT.fully_qualified() {
-                Some(SelfUpdater::new(&*THIS_SUPERVISOR_IDENT, cfg.update_url, cfg.update_channel))
+                Some(SelfUpdater::new(&*THIS_SUPERVISOR_IDENT,
+                                      cfg.update_url,
+                                      cfg.update_channel,
+                                      //   TODO (DM): dont hardcode this
+                                      Duration::from_secs(60)))
             } else {
                 warn!("Supervisor version not fully qualified, unable to start self-updater");
                 None

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -72,7 +72,8 @@ use habitat_core::{crypto::SymKey,
                              PackageIdent,
                              PackageInstall},
                    service::ServiceGroup,
-                   util::ToI64,
+                   util::{DurationWithSplay,
+                          ToI64},
                    ChannelIdent};
 use habitat_launcher_client::{LauncherCli,
                               LAUNCHER_LOCK_CLEAN_ENV,
@@ -262,7 +263,7 @@ impl FsCfg {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ManagerConfig {
     pub auto_update:          bool,
-    pub auto_update_period:   Duration,
+    pub auto_update_period:   DurationWithSplay,
     pub custom_state_path:    Option<PathBuf>,
     pub cache_key_path:       PathBuf,
     pub update_url:           String,
@@ -1966,7 +1967,7 @@ mod test {
     impl Default for ManagerConfig {
         fn default() -> Self {
             ManagerConfig { auto_update:          false,
-                            auto_update_period:   Duration::from_secs(60),
+                            auto_update_period:   Duration::from_secs(60).into(),
                             custom_state_path:    None,
                             cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
                             update_url:           "".to_string(),

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -261,29 +261,30 @@ impl FsCfg {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ManagerConfig {
-    pub auto_update:          bool,
-    pub auto_update_period:   Duration,
-    pub custom_state_path:    Option<PathBuf>,
-    pub cache_key_path:       PathBuf,
-    pub update_url:           String,
-    pub update_channel:       ChannelIdent,
-    pub gossip_listen:        GossipListenAddr,
-    pub ctl_listen:           ListenCtlAddr,
-    pub http_listen:          HttpListenAddr,
-    pub http_disable:         bool,
-    pub gossip_peers:         Vec<SocketAddr>,
-    pub gossip_permanent:     bool,
-    pub ring_key:             Option<SymKey>,
-    pub organization:         Option<String>,
-    pub watch_peer_file:      Option<String>,
-    pub tls_config:           Option<TLSConfig>,
-    pub feature_flags:        FeatureFlag,
-    pub event_stream_config:  Option<EventStreamConfig>,
+    pub auto_update:           bool,
+    pub auto_update_period:    Duration,
+    pub service_update_period: Duration,
+    pub custom_state_path:     Option<PathBuf>,
+    pub cache_key_path:        PathBuf,
+    pub update_url:            String,
+    pub update_channel:        ChannelIdent,
+    pub gossip_listen:         GossipListenAddr,
+    pub ctl_listen:            ListenCtlAddr,
+    pub http_listen:           HttpListenAddr,
+    pub http_disable:          bool,
+    pub gossip_peers:          Vec<SocketAddr>,
+    pub gossip_permanent:      bool,
+    pub ring_key:              Option<SymKey>,
+    pub organization:          Option<String>,
+    pub watch_peer_file:       Option<String>,
+    pub tls_config:            Option<TLSConfig>,
+    pub feature_flags:         FeatureFlag,
+    pub event_stream_config:   Option<EventStreamConfig>,
     /// If this field is `Some`, keep the indicated number of latest packages and uninstall all
     /// others during service start. If this field is `None`, automatic package cleanup is
     /// disabled.
-    pub keep_latest_packages: Option<usize>,
-    pub sys_ip:               IpAddr,
+    pub keep_latest_packages:  Option<usize>,
+    pub sys_ip:                IpAddr,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -689,7 +690,8 @@ impl Manager {
                      self_updater,
                      service_updater:
                          Arc::new(Mutex::new(ServiceUpdater::new(server.clone(),
-                                                                 Arc::clone(&census_ring)))),
+                                                                 Arc::clone(&census_ring),
+                                                                 cfg.service_update_period))),
                      census_ring,
                      butterfly: server,
                      launcher,
@@ -1965,26 +1967,27 @@ mod test {
     // code, so only implement it under test configuration.
     impl Default for ManagerConfig {
         fn default() -> Self {
-            ManagerConfig { auto_update:          false,
-                            auto_update_period:   Duration::from_secs(60),
-                            custom_state_path:    None,
-                            cache_key_path:       (&*CACHE_KEY_PATH).to_path_buf(),
-                            update_url:           "".to_string(),
-                            update_channel:       ChannelIdent::default(),
-                            gossip_listen:        GossipListenAddr::default(),
-                            ctl_listen:           ListenCtlAddr::default(),
-                            http_listen:          HttpListenAddr::default(),
-                            http_disable:         false,
-                            gossip_peers:         vec![],
-                            gossip_permanent:     false,
-                            ring_key:             None,
-                            organization:         None,
-                            watch_peer_file:      None,
-                            tls_config:           None,
-                            feature_flags:        FeatureFlag::empty(),
-                            event_stream_config:  None,
-                            keep_latest_packages: None,
-                            sys_ip:               IpAddr::V4(Ipv4Addr::LOCALHOST), }
+            ManagerConfig { auto_update:           false,
+                            auto_update_period:    Duration::from_secs(60),
+                            service_update_period: Duration::from_secs(60),
+                            custom_state_path:     None,
+                            cache_key_path:        (&*CACHE_KEY_PATH).to_path_buf(),
+                            update_url:            "".to_string(),
+                            update_channel:        ChannelIdent::default(),
+                            gossip_listen:         GossipListenAddr::default(),
+                            ctl_listen:            ListenCtlAddr::default(),
+                            http_listen:           HttpListenAddr::default(),
+                            http_disable:          false,
+                            gossip_peers:          vec![],
+                            gossip_permanent:      false,
+                            ring_key:              None,
+                            organization:          None,
+                            watch_peer_file:       None,
+                            tls_config:            None,
+                            feature_flags:         FeatureFlag::empty(),
+                            event_stream_config:   None,
+                            keep_latest_packages:  None,
+                            sys_ip:                IpAddr::V4(Ipv4Addr::LOCALHOST), }
         }
     }
 

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -72,8 +72,7 @@ use habitat_core::{crypto::SymKey,
                              PackageIdent,
                              PackageInstall},
                    service::ServiceGroup,
-                   util::{DurationWithSplay,
-                          ToI64},
+                   util::ToI64,
                    ChannelIdent};
 use habitat_launcher_client::{LauncherCli,
                               LAUNCHER_LOCK_CLEAN_ENV,
@@ -263,7 +262,7 @@ impl FsCfg {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ManagerConfig {
     pub auto_update:          bool,
-    pub auto_update_period:   DurationWithSplay,
+    pub auto_update_period:   Duration,
     pub custom_state_path:    Option<PathBuf>,
     pub cache_key_path:       PathBuf,
     pub update_url:           String,

--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -77,11 +77,10 @@ impl SelfUpdater {
                      update_url,
                      update_channel,
                      period, } = runner;
-        let splay =
-            Duration::from_secs_f64(rand::thread_rng().gen_range(0.0, period.as_secs_f64()));
+        let splay = Duration::from_secs(rand::thread_rng().gen_range(0, period.as_secs()));
         debug!("Starting self updater with current package {} in {}s",
                current,
-               splay.as_secs_f64());
+               splay.as_secs());
         tokiotime::delay_for(splay).await;
         loop {
             match util::pkg::install_no_ui(&update_url, &install_source, &update_channel).await {
@@ -99,7 +98,7 @@ impl SelfUpdater {
                     warn!("Self updater failed to get latest, {}", err);
                 }
             }
-            trace!("Self updater delaying for {}s", period.as_secs_f64());
+            trace!("Self updater delaying for {}s", period.as_secs());
             tokiotime::delay_for(period).await;
         }
     }

--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -6,7 +6,8 @@ use habitat_common::command::package::install::InstallSource;
 use habitat_core::{package::{PackageIdent,
                              PackageInstall},
                    ChannelIdent};
-use std::time::Duration;
+use std::{borrow::Borrow,
+          time::Duration};
 use tokio::{self,
             sync::oneshot::{self,
                             error::TryRecvError,
@@ -15,52 +16,67 @@ use tokio::{self,
             time as tokiotime};
 
 pub const SUP_PKG_IDENT: &str = "core/hab-sup";
-const DEFAULT_PERIOD: Duration = Duration::from_secs(60);
-
-habitat_core::env_config_duration!(
-    /// Represents how far apart checks for updates are, in milliseconds.
-    SelfUpdatePeriod,
-    HAB_SUP_UPDATE_MS => from_millis,
-    DEFAULT_PERIOD);
 
 pub struct SelfUpdater {
     rx:             Receiver<PackageInstall>,
     current:        PackageIdent,
     update_url:     String,
     update_channel: ChannelIdent,
+    period:         Duration,
 }
 
-// TODO (CM): Want to use the Periodic trait here, but can't due to
-// how things are currently structured (The service updater had a worker)
+/// The subset of data from `SelfUpdater` needed to spawn the updater task.
+struct Runner {
+    current:        PackageIdent,
+    update_url:     String,
+    update_channel: ChannelIdent,
+    period:         Duration,
+}
+
+impl<T: Borrow<SelfUpdater>> From<T> for Runner {
+    fn from(other: T) -> Self {
+        let other = other.borrow();
+        Self { current:        other.current.clone(),
+               update_url:     other.update_url.clone(),
+               update_channel: other.update_channel.clone(),
+               period:         other.period, }
+    }
+}
 
 impl SelfUpdater {
-    pub fn new(current: &PackageIdent, update_url: String, update_channel: ChannelIdent) -> Self {
-        let rx = Self::init(current.clone(), update_url.clone(), update_channel.clone());
+    pub fn new(current: &PackageIdent,
+               update_url: String,
+               update_channel: ChannelIdent,
+               period: Duration)
+               -> Self {
+        let runner = Runner { current: current.clone(),
+                              update_url: update_url.clone(),
+                              update_channel: update_channel.clone(),
+                              period };
+        let rx = Self::init(runner);
         SelfUpdater { rx,
                       current: current.clone(),
                       update_url,
-                      update_channel }
+                      update_channel,
+                      period }
     }
 
-    /// Spawn a new Supervisor updater thread.
-    fn init(current: PackageIdent,
-            update_url: String,
-            update_channel: ChannelIdent)
-            -> Receiver<PackageInstall> {
+    /// Spawn a new Supervisor updater task.
+    fn init(runner: Runner) -> Receiver<PackageInstall> {
         let (tx, rx) = oneshot::channel();
-        tokio::spawn(Self::run(tx, current, update_url, update_channel));
+        tokio::spawn(Self::run(tx, runner));
         rx
     }
 
-    async fn run(tx: Sender<PackageInstall>,
-                 current: PackageIdent,
-                 update_url: String,
-                 update_channel: ChannelIdent) {
-        debug!("Self updater current package, {}", current);
+    async fn run(tx: Sender<PackageInstall>, runner: Runner) {
+        debug!("Self updater current package, {}", runner.current);
         // SUP_PKG_IDENT will always parse as a valid PackageIdent,
         // and thus a valid InstallSource
         let install_source: InstallSource = SUP_PKG_IDENT.parse().unwrap();
-        let delay = SelfUpdatePeriod::configured_value().into();
+        let Runner { current,
+                     update_url,
+                     update_channel,
+                     period, } = runner;
         loop {
             match util::pkg::install_no_ui(&update_url, &install_source, &update_channel).await {
                 Ok(package) => {
@@ -77,7 +93,7 @@ impl SelfUpdater {
                     warn!("Self updater failed to get latest, {}", err);
                 }
             }
-            tokiotime::delay_for(delay).await;
+            tokiotime::delay_for(period).await;
         }
     }
 
@@ -87,9 +103,7 @@ impl SelfUpdater {
             Err(TryRecvError::Empty) => None,
             Err(TryRecvError::Closed) => {
                 debug!("Self updater has died, restarting...");
-                self.rx = Self::init(self.current.clone(),
-                                     self.update_url.clone(),
-                                     self.update_channel.clone());
+                self.rx = Self::init(self.into());
                 None
             }
         }

--- a/components/sup/src/manager/service_updater/package_update_worker.rs
+++ b/components/sup/src/manager/service_updater/package_update_worker.rs
@@ -1,43 +1,15 @@
 use crate::{manager::service::Service,
             util};
-use habitat_core::{env,
-                   package::{FullyQualifiedPackageIdent,
+use habitat_core::{package::{FullyQualifiedPackageIdent,
                              PackageIdent},
                    service::ServiceGroup,
                    ChannelIdent};
 use habitat_sup_protocol::types::UpdateCondition;
+use rand::Rng;
 use std::{self,
           time::Duration};
 use tokio::{self,
             time};
-
-// TODO (CM): Yes, the variable value should be "period" and not
-// "frequency"... we need to fix that.
-const PERIOD_BYPASS_CHECK_ENVVAR: &str = "HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK";
-
-habitat_core::env_config_duration!(
-    /// Represents how far apart checks for updates to individual services
-    /// are, in milliseconds.
-    PackageUpdateWorkerPeriod,
-    // TODO (CM): Yes, the variable value should be "period" and not
-    // "frequency"... we need to fix that.
-    HAB_UPDATE_STRATEGY_FREQUENCY_MS => from_millis,
-    PackageUpdateWorkerPeriod::MIN_ALLOWED);
-
-impl PackageUpdateWorkerPeriod {
-    const MIN_ALLOWED: Duration = Duration::from_secs(60);
-
-    fn get() -> Duration {
-        let val = PackageUpdateWorkerPeriod::configured_value().into();
-        if val >= PackageUpdateWorkerPeriod::MIN_ALLOWED
-           || env::var(PERIOD_BYPASS_CHECK_ENVVAR).is_ok()
-        {
-            val
-        } else {
-            PackageUpdateWorkerPeriod::MIN_ALLOWED
-        }
-    }
-}
 
 /// When `run`, a `PackageUpdateWorker` returns a future that continuously checks for a change in
 /// version of the package being run by a service. If a change is detected, the package is installed
@@ -49,16 +21,18 @@ pub struct PackageUpdateWorker {
     update_condition: UpdateCondition,
     channel:          ChannelIdent,
     builder_url:      String,
+    period:           Duration,
 }
 
-impl From<&Service> for PackageUpdateWorker {
-    fn from(service: &Service) -> Self {
-        Self { service_group:    service.service_group.clone(),
-               ident:            service.spec_ident.clone(),
-               full_ident:       service.pkg.ident.clone(),
+impl PackageUpdateWorker {
+    pub fn new(service: &Service, period: Duration) -> Self {
+        Self { service_group: service.service_group.clone(),
+               ident: service.spec_ident.clone(),
+               full_ident: service.pkg.ident.clone(),
                update_condition: service.update_condition,
-               channel:          service.channel.clone(),
-               builder_url:      service.bldr_url.clone(), }
+               channel: service.channel.clone(),
+               builder_url: service.bldr_url.clone(),
+               period }
     }
 }
 
@@ -69,7 +43,11 @@ impl PackageUpdateWorker {
     /// package is found.
     // TODO (DM): The returned package ident should use FullyQualifiedPackageIdent.
     pub async fn update_to(&self, ident: PackageIdent) -> PackageIdent {
-        let delay = PackageUpdateWorkerPeriod::get();
+        let splay = Duration::from_secs(rand::thread_rng().gen_range(0, self.period.as_secs()));
+        debug!("Starting package update worker for {} in {}s",
+               ident,
+               splay.as_secs());
+        time::delay_for(splay).await;
         loop {
             let package_result = match self.update_condition {
                 UpdateCondition::Latest => {
@@ -107,107 +85,13 @@ impl PackageUpdateWorker {
                           self.service_group, self.ident, self.channel, err)
                 }
             }
-            time::delay_for(delay).await;
+            trace!("Package update worker for {} delaying for {}s",
+                   ident,
+                   self.period.as_secs());
+            time::delay_for(self.period).await;
         }
     }
 
     /// Use the service spec's package ident to search for packages.
     pub async fn update(&self) -> PackageIdent { self.update_to(self.ident.clone()).await }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use habitat_core::locked_env_var;
-
-    #[test]
-    fn worker_period_default_is_equal_to_minimum_allowed_value() {
-        assert_eq!(PackageUpdateWorkerPeriod::default().0,
-                   PackageUpdateWorkerPeriod::MIN_ALLOWED);
-    }
-
-    locked_env_var!(HAB_UPDATE_STRATEGY_FREQUENCY_MS, lock_period_var);
-    locked_env_var!(HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK, lock_bypass_var);
-
-    #[test]
-    fn worker_period_must_be_positive() {
-        use std::str::FromStr as _;
-        assert!(PackageUpdateWorkerPeriod::from_str("-123").is_err());
-        assert!(PackageUpdateWorkerPeriod::from_str("0").is_ok());
-        assert!(PackageUpdateWorkerPeriod::from_str("5").is_ok());
-    }
-
-    #[test]
-    fn worker_period_must_be_bypassed_by_non_empty_value() {
-        let period = lock_period_var();
-        let bypass = lock_bypass_var();
-
-        period.set("123");
-        bypass.set(""); // empty string isn't allowed
-
-        assert_ne!(PackageUpdateWorkerPeriod::get(), Duration::from_millis(123));
-        assert_eq!(PackageUpdateWorkerPeriod::default().0,
-                   PackageUpdateWorkerPeriod::get());
-    }
-
-    #[test]
-    fn worker_period_defaults_properly() {
-        let period = lock_period_var();
-        let bypass = lock_bypass_var();
-
-        period.unset();
-        bypass.unset();
-
-        assert_eq!(PackageUpdateWorkerPeriod::default().0,
-                   PackageUpdateWorkerPeriod::get());
-    }
-
-    #[test]
-    fn worker_period_can_be_overridden_by_env_var() {
-        let period = lock_period_var();
-        let bypass = lock_bypass_var();
-
-        period.set("120000");
-        bypass.unset();
-        let expected_period: PackageUpdateWorkerPeriod =
-            PackageUpdateWorkerPeriod(Duration::from_millis(120_000));
-        assert!(expected_period.0 >= PackageUpdateWorkerPeriod::MIN_ALLOWED);
-        assert_eq!(expected_period.0, PackageUpdateWorkerPeriod::get());
-    }
-
-    #[test]
-    fn worker_period_cannot_be_overridden_to_a_very_small_value_by_default() {
-        let period = lock_period_var();
-        let bypass = lock_bypass_var();
-
-        period.set("1"); // This is TOO low
-        bypass.unset();
-        assert!(Duration::from_millis(1) < PackageUpdateWorkerPeriod::MIN_ALLOWED);
-        assert_eq!(PackageUpdateWorkerPeriod::default().0,
-                   PackageUpdateWorkerPeriod::get());
-    }
-
-    #[test]
-    fn worker_period_cannot_be_overridden_by_a_non_number() {
-        let period = lock_period_var();
-        let bypass = lock_bypass_var();
-
-        period.set("this is not a number");
-        bypass.unset();
-        assert_eq!(PackageUpdateWorkerPeriod::default().0,
-                   PackageUpdateWorkerPeriod::get());
-    }
-
-    #[test]
-    fn worker_period_can_be_overridden_by_a_small_value_with_bypass_var() {
-        let period = lock_period_var();
-        let bypass = lock_bypass_var();
-
-        period.set("5000");
-        bypass.set("1");
-        let expected_period: PackageUpdateWorkerPeriod =
-            PackageUpdateWorkerPeriod(Duration::from_millis(5000));
-        assert!(expected_period.0 < PackageUpdateWorkerPeriod::MIN_ALLOWED);
-        assert_eq!(expected_period.0, PackageUpdateWorkerPeriod::get());
-    }
 }

--- a/components/sup/src/manager/service_updater/rolling_update_worker.rs
+++ b/components/sup/src/manager/service_updater/rolling_update_worker.rs
@@ -61,11 +61,12 @@ pub struct RollingUpdateWorker {
 impl RollingUpdateWorker {
     pub fn new(service: &Service,
                census_ring: Arc<RwLock<CensusRing>>,
-               butterfly: habitat_butterfly::Server)
+               butterfly: habitat_butterfly::Server,
+               period: Duration)
                -> Self {
         Self { service_group: service.service_group.clone(),
                topology: service.topology,
-               package_update_worker: PackageUpdateWorker::from(service),
+               package_update_worker: PackageUpdateWorker::new(service, period),
                census_ring,
                butterfly }
     }


### PR DESCRIPTION
Resolves #7723 

This PR adds `--auto-update-period` ~~and `--auto-update-splay`~~ options to give control over the Supervisor update behavior. It also remove the `HAB_SUP_UPDATE_MS` environment variable which is a breaking change, but I think it is acceptable in this case because it is an undocumented internal envar.

The trickiest part of this PR was settling on the ui/ux. There are a lot of possibilities. Some possible changes:

* Currently, the units are in seconds with the value represented as a ~~`f64` allowing fractional seconds~~ `u64`. Should we allow fractional seconds?
* We could have a single flag `--auto-update` that takes the period as an optional value, but this leads to complications with the config file
* I completely removed the ability to set this value with an environment variable. Was this the right choice? How do we decide which options should have an environment variable?
* ~~We could have a special syntax for specifying period and splay in a single option. Something like `60+5` (ie 60 second period with 5 seconds of splay). This seemed too obscure.~~
* ~~Represent the splay as a percentage of the period~~
* Allow the user to specify splay

I tried to favor simplicity and explicitness in the implementation I chose but would love to hear other thoughts.

**[Update]** Thanks to [this comment](https://github.com/habitat-sh/habitat/pull/7733#pullrequestreview-423874201) this PR has been drastically simplified. Instead of allowing user-defined splay with `--auto-update-splay`, we add an offset to the start of the update checks by waiting a random amount of time between 0 and the configured `--auto-update-period`.

**[Update]** This PR adds the `--service-update-period` option to give control over the Supervisor update behavior. The `HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK` and `HAB_UPDATE_STRATEGY_FREQUENCY_MS` have been removed. Random splay between 0 and the configured `--service-update-period` has been added to the package update worker startup.