### PR TITLE
allow hook extentions in plan

### DIFF
--- a/components/habitat-chef-io/content/habitat/application-lifecycle-hooks.md
+++ b/components/habitat-chef-io/content/habitat/application-lifecycle-hooks.md
@@ -13,7 +13,9 @@ description = "Control service runtime actions with application lifecycle hooks"
 
 Each plan can specify lifecycle event handlers, or hooks, to perform certain actions during a service's runtime. Each hook is a script with a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) defined at the top to specify the interpreter to be used. On Windows, Powershell Core is the only interpreter ever used.
 
-To define a hook, simply create a bash file of the same name in `/my_plan_name/hooks/`, for example, `/postgresql/hooks/health-check`.
+To define a hook, simply create a file of the same name in `/my_plan_name/hooks/`, for example, `/postgresql/hooks/health-check`.
+
+Optionally you may add an extension to the hook file. For example, you might create `/postgresql/hooks/health-check.sh` which can be useful in some editors to automatically take advantage of syntax highlighting. Note that having two files for the same hook but with different extensions is not permitted. For example you might create a `run.sh` and `run.ps1` to support both Linux and Windows packages. If you would like to create different hooks for different platforms, you must use [target directories](/docs/developing-packages/#plan-targets).
 
 > **Important** You cannot block the thread in a hook unless it is in the `run` hook. Never call `hab` or `sleep` in a hook that is not the `run` hook.
 

--- a/test/end-to-end/test_studio_can_build_packages.ps1
+++ b/test/end-to-end/test_studio_can_build_packages.ps1
@@ -38,6 +38,18 @@ Describe "Studio build" {
 
         $pkg_name | Should -Be "target_plan"
     }
+
+    It "strips hook extension" {
+        Invoke-BuildAndInstall hook-extension-plan
+        . ./results/last_build.ps1
+
+        "/hab/pkgs/$pkg_ident/hooks/install" | Should -Exist
+    }
+
+    It "fails when there are multiple extensions" {
+        hab pkg build test/fixtures/bad-hook-extension-plan
+        $LASTEXITCODE | Should -Not -Be 0
+    }
 }
 
 Describe "working after success callback" {

--- a/test/fixtures/bad-hook-extension-plan/hooks/install
+++ b/test/fixtures/bad-hook-extension-plan/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/bash
+# install
+set -euo pipefail
+
+echo "install hook {{pkg.name}}"

--- a/test/fixtures/bad-hook-extension-plan/hooks/install.ps1
+++ b/test/fixtures/bad-hook-extension-plan/hooks/install.ps1
@@ -1,0 +1,3 @@
+# install.ps1
+
+Write-Output "install hook {{pkg.name}}"

--- a/test/fixtures/bad-hook-extension-plan/hooks/install.sh
+++ b/test/fixtures/bad-hook-extension-plan/hooks/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# install.sh
+set -euo pipefail
+
+echo "install hook {{pkg.name}}"

--- a/test/fixtures/bad-hook-extension-plan/plan.ps1
+++ b/test/fixtures/bad-hook-extension-plan/plan.ps1
@@ -1,0 +1,5 @@
+$pkg_name="hook-extension-plan"
+$pkg_origin="habitat-testing"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_version="0.0.0"
+

--- a/test/fixtures/bad-hook-extension-plan/plan.sh
+++ b/test/fixtures/bad-hook-extension-plan/plan.sh
@@ -1,0 +1,7 @@
+pkg_name="hook-extension-plan"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+
+do_build() { :; }
+do_install() { :; }

--- a/test/fixtures/hook-extension-plan/x86_64-linux/hooks/install.sh
+++ b/test/fixtures/hook-extension-plan/x86_64-linux/hooks/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# install.sh
+set -euo pipefail
+
+echo "install hook {{pkg.name}}"

--- a/test/fixtures/hook-extension-plan/x86_64-linux/plan.sh
+++ b/test/fixtures/hook-extension-plan/x86_64-linux/plan.sh
@@ -1,0 +1,7 @@
+pkg_name="hook-extension-plan"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+
+do_build() { :; }
+do_install() { :; }

--- a/test/fixtures/hook-extension-plan/x86_64-windows/hooks/install.ps1
+++ b/test/fixtures/hook-extension-plan/x86_64-windows/hooks/install.ps1
@@ -1,0 +1,3 @@
+# install.ps1
+
+Write-Output "install hook {{pkg.name}}"

--- a/test/fixtures/hook-extension-plan/x86_64-windows/plan.ps1
+++ b/test/fixtures/hook-extension-plan/x86_64-windows/plan.ps1
@@ -1,0 +1,5 @@
+$pkg_name="hook-extension-plan"
+$pkg_origin="habitat-testing"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_version="0.0.0"
+

--- a/www/source/docs/reference.html.md.erb
+++ b/www/source/docs/reference.html.md.erb
@@ -783,7 +783,9 @@ Delegates most of the implementation to the `do_default_build_server()` function
 
 Each plan can specify lifecycle event handlers, or hooks, to perform certain actions during a service's runtime. Each hook is a script with a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) defined at the top to specify the interpreter to be used. On Windows, Powershell Core is the only interpreter ever used.
 
-To define a hook, simply create a bash file of the same name in `/my_plan_name/hooks/`, for example, `/postgresql/hooks/health-check`.
+To define a hook, simply create a file of the same name in `/my_plan_name/hooks/`, for example, `/postgresql/hooks/health-check`.
+
+Optionally you may add an extension to the hook file. For example, you might create `/postgresql/hooks/health-check.sh` which can be useful in some editors to automatically take advantage of syntax highlighting. Note that having two files for the same hook but with different extensions is not permitted. For example you might create a `run.sh` and `run.ps1` to support both Linux and Windows packages. If you would like to create different hooks for different platforms, you must use [target directories](/docs/developing-packages/#plan-targets).
 
 > **Important** You cannot block the thread in a hook unless it is in the `run` hook. Never call `hab` or `sleep` in a hook that is not the `run` hook.
 


### PR DESCRIPTION
closes #7535 

This allows one to have file extensions for hook files in their plan. The file is copied to the package without the extension so supervisor behavior remains unchanged. This could potentially get tricky if one has multiple extentions for a hook. For example, a `run.ps1` amd a `run.sh`. The motivation might be to handle building for different platforms from the same plan. The most explicit and best way to handle that scenario would be with package target directories. However for convenience we use this logic when there are multiple extensions for a single target:

Windows:
`.ps1` files have the highest precedence followed by an extensionless file. Any other extension is ignored since powershell is the only possible interpreter one can use on windows.

Linux:
`.sh` takes precedence.  If there is no .sh hook then it will just use whatever the last file exists for the given hook. This becomes unreliable if there were a `.ps1` and a `.py` extension for the same hook. However one can argue that this is where one should be using target folders.
Signed-off-by: mwrock <matt@mattwrock.com>