### PR TITLE
fix e2e failures

### DIFF
--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -27,7 +27,18 @@ pub fn temp_package_directory(path: &Path) -> Result<TempDir> {
         )
                              })?;
     fs::create_dir_all(base)?;
+
+    // If this temp directory is being used for installs, we will be untarring archives
+    // into the directory. Depending on the length of the paths included in the archives
+    // and the length of this temp directory, the final paths may be over 260 characters.
+    // In most cases on Windows, this is the maximum allowable length of a path. We can
+    // canonicalize the base path which will prepend a `\\?\` to the path on windows
+    // causing windows APIs to treat the path as an extended length path permitting 32,767
+    // characters in the path. Now thats a whole lot of path! Note that this is a new
+    // concern since migrating from libarchive to tar-rs where libarchive performed this
+    // path prepending operation and tar-rs does not.
     let cannon_base = base.canonicalize()?;
+
     let temp_install_prefix =
         path.file_name()
             .and_then(OsStr::to_str)

--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -27,6 +27,7 @@ pub fn temp_package_directory(path: &Path) -> Result<TempDir> {
         )
                              })?;
     fs::create_dir_all(base)?;
+    let cannon_base = base.canonicalize()?;
     let temp_install_prefix =
         path.file_name()
             .and_then(OsStr::to_str)
@@ -37,7 +38,7 @@ pub fn temp_package_directory(path: &Path) -> Result<TempDir> {
                                                       .to_owned())
             })?;
     Ok(Builder::new().prefix(&temp_install_prefix)
-                     .tempdir_in(base)?)
+                     .tempdir_in(cannon_base)?)
 }
 
 /// Returns a list of package structs built from the contents of the given directory.
@@ -343,7 +344,8 @@ mod test {
         let temp_dir = temp_package_directory(p.path()).unwrap();
         let temp_path = temp_dir.path();
 
-        assert_eq!(&p.path().parent(), &temp_path.parent());
+        assert_eq!(&p.path().parent().unwrap().canonicalize().unwrap(),
+                   &temp_path.parent().unwrap());
     }
 
     #[test]

--- a/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
+++ b/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
@@ -12,7 +12,7 @@ Describe "Service PIDs from Launcher feature" {
 
     Context "Supervisor is restarted" {
         $supProc = Get-Process hab-sup
-        $redisProc = Get-Process redis-server*
+        $redisProc = Get-Process "redis-server *:6379"
 
         # Write a bogus PID to the file; the Supervisor should not
         # think this is the actual PID of the service.
@@ -28,7 +28,7 @@ Describe "Service PIDs from Launcher feature" {
         Restart-Supervisor
         Wait-Process redis-server -Timeout 10
         $newSupProc = Get-Process hab-sup
-        $newRedisProc = Get-Process redis-server*
+        $newRedisProc = Get-Process "redis-server *:6379"
 
         It "starts a new supervisor process" {
             $supProc.Id | Should -Not -Be $newSupProc.Id

--- a/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
+++ b/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
@@ -28,7 +28,7 @@ Describe "Service PIDs from Launcher feature" {
         Restart-Supervisor
         Wait-Process redis-server -Timeout 10
         $newSupProc = Get-Process hab-sup
-        $newRedisProc = Get-Process redis-server
+        $newRedisProc = Get-Process redis-server*
 
         It "starts a new supervisor process" {
             $supProc.Id | Should -Not -Be $newSupProc.Id

--- a/test/end-to-end/test_service_pids_written_to_file_using_old_launcher.ps1
+++ b/test/end-to-end/test_service_pids_written_to_file_using_old_launcher.ps1
@@ -17,11 +17,11 @@ Describe "Using a Launcher that cannot provide service PIDs" {
 
     Context "Supervisor is restarted" {
         $supProc = Get-Process hab-sup
-        $redisProc = Get-Process redis-server*
+        $redisProc = Get-Process "redis-server *:6379"
         Restart-Supervisor
         Wait-Process redis-server -Timeout 10
         $newSupProc = Get-Process hab-sup
-        $newRedisProc = Get-Process redis-server*
+        $newRedisProc = Get-Process "redis-server *:6379"
 
         It "starts a new supervisor process" {
             $supProc.Id | Should -Not -Be $newSupProc.Id

--- a/test/end-to-end/test_service_pids_written_to_file_using_old_launcher.ps1
+++ b/test/end-to-end/test_service_pids_written_to_file_using_old_launcher.ps1
@@ -21,7 +21,7 @@ Describe "Using a Launcher that cannot provide service PIDs" {
         Restart-Supervisor
         Wait-Process redis-server -Timeout 10
         $newSupProc = Get-Process hab-sup
-        $newRedisProc = Get-Process redis-server
+        $newRedisProc = Get-Process redis-server*
 
         It "starts a new supervisor process" {
             $supProc.Id | Should -Not -Be $newSupProc.Id

--- a/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
+++ b/test/end-to-end/test_studio_with_ssl_cert_file_envvar_set.ps1
@@ -11,7 +11,7 @@ hab origin key generate "$env:HAB_ORIGIN"
 
 $tempdir = New-TemporaryDirectory
 $e2e_certname = "e2e-ssl.pem"
-hab pkg install core/openssl
+hab pkg install core/openssl --channel stable
 hab pkg exec core/openssl openssl req -newkey rsa:2048 -batch -nodes -keyout key.pem -x509 -days 365 -out (Join-Path $tempdir $e2e_certname)
 
 if($IsLinux) {


### PR DESCRIPTION
This should fix all e2e failures in the pipeline right now. There are 3 fixes included:

* Powershell 7 is appending the port to the redis-server process name similar to how `ps` behaves. I had previously patched a couple usages but this catches 2 that got away.
* There is no windows openssl package in the `dev` channel (not sure if there ever was?). This installs that package from `stable`
* It appears that the `tar-rs` crate fails when unpacking a path over 260 characters on windows. Libarchive would prepend paths with `\\?\` which forces windows APIs to treat the path as an extended-length path that can be 32k. See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file. This canonicalizes the temp_package_directory which will perform the same prepending. I have also submitted https://github.com/alexcrichton/tar-rs/pull/230 which would allow the `tar-rs` crate to do it.