### PR TITLE
Add environment variables for setting the update periods

### DIFF
--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -185,10 +185,16 @@ pub struct SupRun {
     #[structopt(long = "auto-update", short = "A")]
     pub auto_update: bool,
     /// The period of time in seconds between Supervisor update checks
-    #[structopt(long = "auto-update-period", default_value = "60")]
+    #[structopt(long = "auto-update-period",
+                // TODO (DM): This is seconds not really milliseconds
+                env = "HAB_SUP_UPDATE_MS",
+                default_value = "60")]
     pub auto_update_period: DurationProxy,
     /// The period of time in seconds between service update checks
-    #[structopt(long = "service-update-period", default_value = "60")]
+    #[structopt(long = "service-update-period",
+                // TODO (DM): This is seconds not really milliseconds
+                env = "HAB_UPDATE_STRATEGY_FREQUENCY_MS",
+                default_value = "60")]
     pub service_update_period: DurationProxy,
     /// The private key for HTTP Gateway TLS encryption
     ///


### PR DESCRIPTION
This adds back the `HAB_SUP_UPDATE_MS` and `HAB_UPDATE_STRATEGY_FREQUENCY_MS`. However, the units are currently wrong (seconds instead of milliseconds). Should we change the cli and config file units as well? If we were not worried about backward compatibility I think these env vars would be removed? The naming of them is also unfortunate can we change the names?

Signed-off-by: David McNeil <mcneil.david2@gmail.com>