### PR TITLE
[REFACTOR] Store service spec in Service struct

### DIFF
--- a/components/sup/src/event/types.rs
+++ b/components/sup/src/event/types.rs
@@ -53,7 +53,7 @@ impl Service {
         };
 
         Some(UpdateConfig { strategy: strategy.into(),
-                            channel:  self.channel.to_string(), })
+                            channel:  self.channel().to_string(), })
     }
 }
 

--- a/components/sup/src/event/types.rs
+++ b/components/sup/src/event/types.rs
@@ -44,7 +44,7 @@ impl Service {
     /// coupled with the channel from which the Supervisor pulls
     /// updates.
     fn update_config(&self) -> Option<UpdateConfig> {
-        let strategy = match self.update_strategy {
+        let strategy = match self.update_strategy() {
             DomainUpdateStrategy::None => {
                 return None;
             }

--- a/components/sup/src/event/types.rs
+++ b/components/sup/src/event/types.rs
@@ -32,7 +32,7 @@ impl Service {
     // cloning the entire service for eventing.
     pub fn to_service_metadata(&self) -> ServiceMetadata {
         ServiceMetadata { package_ident: self.pkg.ident.to_string(),
-                          spec_ident:    self.spec_ident.to_string(),
+                          spec_ident:    self.spec_ident().to_string(),
                           service_group: self.service_group.to_string(),
                           update_config: self.update_config(), }
     }

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -855,7 +855,7 @@ impl Manager {
         }
 
         self.gossip_latest_service_rumor_rsw_mlw_rhw(&service);
-        if service.topology == Topology::Leader {
+        if service.topology() == Topology::Leader {
             self.butterfly
                 .start_election_rsw_mlr_rhw_msr(&service.service_group, 0);
         }

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1619,7 +1619,7 @@ impl Manager {
     fn compute_service_operations_msr(&mut self) -> Vec<ServiceOperation> {
         // First, figure out what's currently running.
         let service_map = self.state.services.lock_msr();
-        let currently_running_specs = service_map.services().map(Service::to_spec);
+        let currently_running_specs = service_map.services().map(Service::spec);
 
         // Now, figure out what we should compare against, ignoring
         // any services that are currently doing something

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -222,7 +222,7 @@ pub struct ShutdownConfig {
 impl ShutdownConfig {
     fn new(shutdown_input: Option<&ShutdownInput>, service: &Service) -> Self {
         let timeout = shutdown_input.and_then(|si| si.timeout).unwrap_or_else(|| {
-                                                                  service.shutdown_timeout
+                                                                  service.shutdown_timeout()
                                                                .unwrap_or(service.pkg
                                                                                  .shutdown_timeout)
                                                               });

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -177,7 +177,10 @@ enum InitializationState {
 pub struct Service {
     spec:                    ServiceSpec,
     pub service_group:       ServiceGroup,
-    pub spec_file:           PathBuf,
+    // TODO: `spec_file` is only used for serialization; unsure if
+    // that's even useful, given that it's always the same value for a
+    // given service.
+    spec_file:               PathBuf,
     pub spec_ident:          PackageIdent,
     pub topology:            Topology,
     pub update_strategy:     UpdateStrategy,

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -68,8 +68,7 @@ use habitat_core::{crypto::hash,
                    package::{metadata::Bind,
                              PackageIdent,
                              PackageInstall},
-                   service::{HealthCheckInterval,
-                             ServiceBind,
+                   service::{ServiceBind,
                              ServiceGroup},
                    ChannelIdent};
 use habitat_launcher_client::LauncherCli;
@@ -229,7 +228,6 @@ pub struct Service {
     manager_fs_cfg:         Arc<FsCfg>,
     supervisor:             Arc<Mutex<Supervisor>>,
     svc_encrypted_password: Option<String>,
-    health_check_interval:  HealthCheckInterval,
 
     gateway_state: Arc<GatewayState>,
 
@@ -298,7 +296,6 @@ impl Service {
                      spec_file,
                      config_from: spec.config_from,
                      svc_encrypted_password: spec.svc_encrypted_password,
-                     health_check_interval: spec.health_check_interval,
                      gateway_state,
                      health_check_handle: None,
                      post_run_handle: None,
@@ -409,7 +406,7 @@ impl Service {
         debug!("Starting health checks for {}", self.pkg.ident);
         let mut rx = health::check_repeatedly(Arc::clone(&self.supervisor),
                                               self.hooks.health_check.clone(),
-                                              self.health_check_interval,
+                                              self.spec.health_check_interval,
                                               self.service_group.clone(),
                                               self.pkg.clone(),
                                               self.svc_encrypted_password.clone());
@@ -626,7 +623,7 @@ impl Service {
         if let Some(ref password) = self.svc_encrypted_password {
             spec.svc_encrypted_password = Some(password.clone())
         }
-        spec.health_check_interval = self.health_check_interval;
+        spec.health_check_interval = self.spec.health_check_interval;
         spec.shutdown_timeout = self.spec.shutdown_timeout;
         spec
     }
@@ -1285,7 +1282,7 @@ impl<'a> Serialize for ServiceProxy<'a> {
         strukt.serialize_field("spec_ident", &s.spec.ident)?;
         strukt.serialize_field("spec_identifier", &s.spec.ident.to_string())?;
         strukt.serialize_field("svc_encrypted_password", &s.svc_encrypted_password)?;
-        strukt.serialize_field("health_check_interval", &s.health_check_interval)?;
+        strukt.serialize_field("health_check_interval", &s.spec.health_check_interval)?;
         strukt.serialize_field("sys", &s.sys)?;
         strukt.serialize_field("topology", &s.spec.topology)?;
         strukt.serialize_field("update_strategy", &s.spec.update_strategy)?;

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -181,7 +181,6 @@ pub struct Service {
     // that's even useful, given that it's always the same value for a
     // given service.
     spec_file:               PathBuf,
-    pub update_condition:    UpdateCondition,
     pub cfg:                 Cfg,
     pub pkg:                 Pkg,
     pub sys:                 Arc<Sys>,
@@ -260,6 +259,8 @@ impl Service {
 
     pub(crate) fn update_strategy(&self) -> UpdateStrategy { self.spec.update_strategy }
 
+    pub(crate) fn update_condition(&self) -> UpdateCondition { self.spec.update_condition }
+
     #[allow(clippy::too_many_arguments)]
     async fn with_package(sys: Arc<Sys>,
                           package: &PackageInstall,
@@ -302,7 +303,6 @@ impl Service {
                      unsatisfied_binds: HashSet::new(),
                      binding_mode: spec.binding_mode,
                      spec_file,
-                     update_condition: spec.update_condition,
                      config_from: spec.config_from,
                      svc_encrypted_password: spec.svc_encrypted_password,
                      health_check_interval: spec.health_check_interval,
@@ -627,7 +627,7 @@ impl Service {
         spec.channel = self.spec.channel.clone();
         spec.topology = self.spec.topology;
         spec.update_strategy = self.spec.update_strategy;
-        spec.update_condition = self.update_condition;
+        spec.update_condition = self.spec.update_condition;
         spec.binds = self.binds.clone();
         spec.binding_mode = self.binding_mode;
         spec.config_from = self.config_from.clone();
@@ -1296,7 +1296,7 @@ impl<'a> Serialize for ServiceProxy<'a> {
         strukt.serialize_field("sys", &s.sys)?;
         strukt.serialize_field("topology", &s.spec.topology)?;
         strukt.serialize_field("update_strategy", &s.spec.update_strategy)?;
-        strukt.serialize_field("update_condition", &s.update_condition)?;
+        strukt.serialize_field("update_condition", &s.spec.update_condition)?;
         strukt.serialize_field("user_config_updated", &s.user_config_updated)?;
         strukt.end()
     }

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -185,7 +185,6 @@ pub struct Service {
     pub pkg:                 Pkg,
     pub sys:                 Arc<Sys>,
     pub user_config_updated: bool,
-    pub shutdown_timeout:    Option<ShutdownTimeout>,
     // TODO (DM): This flag is a temporary hack to signal to the `Manager` that this service needs
     // to be restarted. As we continue refactoring lifecycle hooks this flag should be removed.
     pub needs_restart:       bool,
@@ -261,6 +260,8 @@ impl Service {
 
     pub(crate) fn update_condition(&self) -> UpdateCondition { self.spec.update_condition }
 
+    pub(crate) fn shutdown_timeout(&self) -> Option<ShutdownTimeout> { self.spec.shutdown_timeout }
+
     #[allow(clippy::too_many_arguments)]
     async fn with_package(sys: Arc<Sys>,
                           package: &PackageInstall,
@@ -309,8 +310,7 @@ impl Service {
                      gateway_state,
                      health_check_handle: None,
                      post_run_handle: None,
-                     initialize_handle: None,
-                     shutdown_timeout: spec.shutdown_timeout })
+                     initialize_handle: None })
     }
 
     // And now prepare yourself for a little horribleness...Ready?
@@ -635,7 +635,7 @@ impl Service {
             spec.svc_encrypted_password = Some(password.clone())
         }
         spec.health_check_interval = self.health_check_interval;
-        spec.shutdown_timeout = self.shutdown_timeout;
+        spec.shutdown_timeout = self.spec.shutdown_timeout;
         spec
     }
 

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -181,7 +181,6 @@ pub struct Service {
     // that's even useful, given that it's always the same value for a
     // given service.
     spec_file:               PathBuf,
-    pub spec_ident:          PackageIdent,
     pub topology:            Topology,
     pub update_strategy:     UpdateStrategy,
     pub update_condition:    UpdateCondition,
@@ -257,6 +256,8 @@ impl Service {
 
     pub(crate) fn channel(&self) -> ChannelIdent { self.spec.channel.clone() }
 
+    pub(crate) fn spec_ident(&self) -> PackageIdent { self.spec.ident.clone() }
+
     #[allow(clippy::too_many_arguments)]
     async fn with_package(sys: Arc<Sys>,
                           package: &PackageInstall,
@@ -298,7 +299,6 @@ impl Service {
                      all_pkg_binds,
                      unsatisfied_binds: HashSet::new(),
                      binding_mode: spec.binding_mode,
-                     spec_ident: spec.ident,
                      spec_file,
                      topology: spec.topology,
                      update_strategy: spec.update_strategy,
@@ -620,7 +620,8 @@ impl Service {
     }
 
     pub fn to_spec(&self) -> ServiceSpec {
-        let mut spec = ServiceSpec::new(self.spec_ident.clone());
+        // TODO (CM): eventually just return a copy of self.spec
+        let mut spec = ServiceSpec::new(self.spec.ident.clone());
         spec.group = self.service_group.group().to_string();
         spec.bldr_url = self.spec.bldr_url.clone();
         spec.channel = self.spec.channel.clone();
@@ -1287,8 +1288,9 @@ impl<'a> Serialize for ServiceProxy<'a> {
                                 .deref())?;
         strukt.serialize_field("service_group", &s.service_group)?;
         strukt.serialize_field("spec_file", &s.spec_file)?;
-        strukt.serialize_field("spec_ident", &s.spec_ident)?;
-        strukt.serialize_field("spec_identifier", &s.spec_ident.to_string())?;
+        // Deprecated field; use spec_identifier instead
+        strukt.serialize_field("spec_ident", &s.spec.ident)?;
+        strukt.serialize_field("spec_identifier", &s.spec.ident.to_string())?;
         strukt.serialize_field("svc_encrypted_password", &s.svc_encrypted_password)?;
         strukt.serialize_field("health_check_interval", &s.health_check_interval)?;
         strukt.serialize_field("sys", &s.sys)?;

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -212,9 +212,6 @@ pub struct Service {
     /// current state of the census; once you get into the actual
     /// running of the service, the distinction is immaterial.
     all_pkg_binds:          Vec<Bind>,
-    /// Controls how the presence or absence of bound service groups
-    /// impacts the service's start-up.
-    binding_mode:           BindingMode,
     /// Binds specified by the user that are currently mapped to
     /// service groups that do _not_ satisfy the bind's contract, as
     /// defined in the service's current package.
@@ -298,7 +295,6 @@ impl Service {
                      service_group,
                      all_pkg_binds,
                      unsatisfied_binds: HashSet::new(),
-                     binding_mode: spec.binding_mode,
                      spec_file,
                      config_from: spec.config_from,
                      svc_encrypted_password: spec.svc_encrypted_password,
@@ -538,7 +534,7 @@ impl Service {
         // We may need to block the service from starting until all
         // its binds are satisfied
         if !self.initialized() {
-            match self.binding_mode {
+            match self.spec.binding_mode {
                 BindingMode::Relaxed => (),
                 BindingMode::Strict => {
                     self.validate_binds(census_ring);
@@ -625,7 +621,7 @@ impl Service {
         spec.update_strategy = self.spec.update_strategy;
         spec.update_condition = self.spec.update_condition;
         spec.binds = self.spec.binds.clone();
-        spec.binding_mode = self.binding_mode;
+        spec.binding_mode = self.spec.binding_mode;
         spec.config_from = self.config_from.clone();
         if let Some(ref password) = self.svc_encrypted_password {
             spec.svc_encrypted_password = Some(password.clone())
@@ -1258,7 +1254,7 @@ impl<'a> Serialize for ServiceProxy<'a> {
         let s = &self.service;
         let mut strukt = serializer.serialize_struct("service", num_fields)?;
         strukt.serialize_field("all_pkg_binds", &s.all_pkg_binds)?;
-        strukt.serialize_field("binding_mode", &s.binding_mode)?;
+        strukt.serialize_field("binding_mode", &s.spec.binding_mode)?;
         strukt.serialize_field("binds", &s.spec.binds)?;
         strukt.serialize_field("bldr_url", &s.spec.bldr_url)?;
 

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -175,6 +175,7 @@ enum InitializationState {
 
 #[derive(Debug)]
 pub struct Service {
+    spec:                    ServiceSpec,
     pub service_group:       ServiceGroup,
     pub bldr_url:            String,
     pub channel:             ChannelIdent,
@@ -266,11 +267,13 @@ impl Service {
         let all_pkg_binds = package.all_binds()?;
         let pkg = Self::resolve_pkg(&package, &spec).await?;
         let spec_file = manager_fs_cfg.specs_path.join(spec.file());
-        let service_group = ServiceGroup::new(&pkg.name, spec.group, organization)?;
+        let service_group = ServiceGroup::new(&pkg.name, &spec.group, organization)?;
         let config_root = Self::config_root(&pkg, spec.config_from.as_ref());
         let hooks_root = Self::hooks_root(&pkg, spec.config_from.as_ref());
-        Ok(Service { sys,
-                     cfg: Cfg::new(&pkg, spec.config_from.as_ref())?,
+        let cfg = Cfg::new(&pkg, spec.config_from.as_ref())?;
+        Ok(Service { spec,
+                     sys,
+                     cfg,
                      config_renderer: CfgRenderer::new(&config_root)?,
                      bldr_url: spec.bldr_url,
                      channel: spec.channel,

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -177,7 +177,6 @@ enum InitializationState {
 pub struct Service {
     spec:                    ServiceSpec,
     pub service_group:       ServiceGroup,
-    pub bldr_url:            String,
     pub channel:             ChannelIdent,
     pub desired_state:       DesiredState,
     pub spec_file:           PathBuf,
@@ -253,6 +252,8 @@ pub struct Service {
 }
 
 impl Service {
+    pub(crate) fn bldr_url(&self) -> String { self.spec.bldr_url.clone() }
+
     #[allow(clippy::too_many_arguments)]
     async fn with_package(sys: Arc<Sys>,
                           package: &PackageInstall,
@@ -275,7 +276,6 @@ impl Service {
                      sys,
                      cfg,
                      config_renderer: CfgRenderer::new(&config_root)?,
-                     bldr_url: spec.bldr_url,
                      channel: spec.channel,
                      desired_state: spec.desired_state,
                      health_check_result: Arc::new(Mutex::new(HealthCheckResult::Unknown)),
@@ -621,7 +621,7 @@ impl Service {
     pub fn to_spec(&self) -> ServiceSpec {
         let mut spec = ServiceSpec::new(self.spec_ident.clone());
         spec.group = self.service_group.group().to_string();
-        spec.bldr_url = self.bldr_url.clone();
+        spec.bldr_url = self.spec.bldr_url.clone();
         spec.channel = self.channel.clone();
         spec.topology = self.topology;
         spec.update_strategy = self.update_strategy;
@@ -1261,7 +1261,7 @@ impl<'a> Serialize for ServiceProxy<'a> {
         strukt.serialize_field("all_pkg_binds", &s.all_pkg_binds)?;
         strukt.serialize_field("binding_mode", &s.binding_mode)?;
         strukt.serialize_field("binds", &s.binds)?;
-        strukt.serialize_field("bldr_url", &s.bldr_url)?;
+        strukt.serialize_field("bldr_url", &s.spec.bldr_url)?;
 
         if self.config_rendering == ConfigRendering::Full {
             strukt.serialize_field("cfg", &s.cfg)?;

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -181,7 +181,6 @@ pub struct Service {
     // that's even useful, given that it's always the same value for a
     // given service.
     spec_file:               PathBuf,
-    pub update_strategy:     UpdateStrategy,
     pub update_condition:    UpdateCondition,
     pub cfg:                 Cfg,
     pub pkg:                 Pkg,
@@ -259,6 +258,8 @@ impl Service {
 
     pub(crate) fn topology(&self) -> Topology { self.spec.topology }
 
+    pub(crate) fn update_strategy(&self) -> UpdateStrategy { self.spec.update_strategy }
+
     #[allow(clippy::too_many_arguments)]
     async fn with_package(sys: Arc<Sys>,
                           package: &PackageInstall,
@@ -301,7 +302,6 @@ impl Service {
                      unsatisfied_binds: HashSet::new(),
                      binding_mode: spec.binding_mode,
                      spec_file,
-                     update_strategy: spec.update_strategy,
                      update_condition: spec.update_condition,
                      config_from: spec.config_from,
                      svc_encrypted_password: spec.svc_encrypted_password,
@@ -626,7 +626,7 @@ impl Service {
         spec.bldr_url = self.spec.bldr_url.clone();
         spec.channel = self.spec.channel.clone();
         spec.topology = self.spec.topology;
-        spec.update_strategy = self.update_strategy;
+        spec.update_strategy = self.spec.update_strategy;
         spec.update_condition = self.update_condition;
         spec.binds = self.binds.clone();
         spec.binding_mode = self.binding_mode;
@@ -1295,7 +1295,7 @@ impl<'a> Serialize for ServiceProxy<'a> {
         strukt.serialize_field("health_check_interval", &s.health_check_interval)?;
         strukt.serialize_field("sys", &s.sys)?;
         strukt.serialize_field("topology", &s.spec.topology)?;
-        strukt.serialize_field("update_strategy", &s.update_strategy)?;
+        strukt.serialize_field("update_strategy", &s.spec.update_strategy)?;
         strukt.serialize_field("update_condition", &s.update_condition)?;
         strukt.serialize_field("user_config_updated", &s.user_config_updated)?;
         strukt.end()

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -177,7 +177,6 @@ enum InitializationState {
 pub struct Service {
     spec:                    ServiceSpec,
     pub service_group:       ServiceGroup,
-    pub desired_state:       DesiredState,
     pub spec_file:           PathBuf,
     pub spec_ident:          PackageIdent,
     pub topology:            Topology,
@@ -277,7 +276,6 @@ impl Service {
                      sys,
                      cfg,
                      config_renderer: CfgRenderer::new(&config_root)?,
-                     desired_state: spec.desired_state,
                      health_check_result: Arc::new(Mutex::new(HealthCheckResult::Unknown)),
                      hooks: HookTable::load(&pkg.name,
                                             &hooks_root,
@@ -1269,7 +1267,7 @@ impl<'a> Serialize for ServiceProxy<'a> {
 
         strukt.serialize_field("channel", &s.spec.channel)?;
         strukt.serialize_field("config_from", &s.config_from)?;
-        strukt.serialize_field("desired_state", &s.desired_state)?;
+        strukt.serialize_field("desired_state", &s.spec.desired_state)?;
         strukt.serialize_field("health_check", &s.health_check_result)?;
         strukt.serialize_field("hooks", &s.hooks)?;
         strukt.serialize_field("initialized", &s.initialized())?;

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -181,7 +181,6 @@ pub struct Service {
     // that's even useful, given that it's always the same value for a
     // given service.
     spec_file:               PathBuf,
-    pub topology:            Topology,
     pub update_strategy:     UpdateStrategy,
     pub update_condition:    UpdateCondition,
     pub cfg:                 Cfg,
@@ -258,6 +257,8 @@ impl Service {
 
     pub(crate) fn spec_ident(&self) -> PackageIdent { self.spec.ident.clone() }
 
+    pub(crate) fn topology(&self) -> Topology { self.spec.topology }
+
     #[allow(clippy::too_many_arguments)]
     async fn with_package(sys: Arc<Sys>,
                           package: &PackageInstall,
@@ -300,7 +301,6 @@ impl Service {
                      unsatisfied_binds: HashSet::new(),
                      binding_mode: spec.binding_mode,
                      spec_file,
-                     topology: spec.topology,
                      update_strategy: spec.update_strategy,
                      update_condition: spec.update_condition,
                      config_from: spec.config_from,
@@ -569,7 +569,7 @@ impl Service {
             self.file_updated();
         }
 
-        match self.topology {
+        match self.spec.topology {
             Topology::Standalone => {
                 self.execute_hooks(launcher, &template_update);
             }
@@ -625,7 +625,7 @@ impl Service {
         spec.group = self.service_group.group().to_string();
         spec.bldr_url = self.spec.bldr_url.clone();
         spec.channel = self.spec.channel.clone();
-        spec.topology = self.topology;
+        spec.topology = self.spec.topology;
         spec.update_strategy = self.update_strategy;
         spec.update_condition = self.update_condition;
         spec.binds = self.binds.clone();
@@ -1294,7 +1294,7 @@ impl<'a> Serialize for ServiceProxy<'a> {
         strukt.serialize_field("svc_encrypted_password", &s.svc_encrypted_password)?;
         strukt.serialize_field("health_check_interval", &s.health_check_interval)?;
         strukt.serialize_field("sys", &s.sys)?;
-        strukt.serialize_field("topology", &s.topology)?;
+        strukt.serialize_field("topology", &s.spec.topology)?;
         strukt.serialize_field("update_strategy", &s.update_strategy)?;
         strukt.serialize_field("update_condition", &s.update_condition)?;
         strukt.serialize_field("user_config_updated", &s.user_config_updated)?;

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -177,7 +177,7 @@ enum InitializationState {
 pub struct Service {
     spec:                    ServiceSpec,
     pub service_group:       ServiceGroup,
-    pub channel:             ChannelIdent,
+    channel:                 ChannelIdent,
     pub desired_state:       DesiredState,
     pub spec_file:           PathBuf,
     pub spec_ident:          PackageIdent,
@@ -253,6 +253,8 @@ pub struct Service {
 
 impl Service {
     pub(crate) fn bldr_url(&self) -> String { self.spec.bldr_url.clone() }
+
+    pub(crate) fn channel(&self) -> ChannelIdent { self.spec.channel.clone() }
 
     #[allow(clippy::too_many_arguments)]
     async fn with_package(sys: Arc<Sys>,

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -177,7 +177,6 @@ enum InitializationState {
 pub struct Service {
     spec:                    ServiceSpec,
     pub service_group:       ServiceGroup,
-    channel:                 ChannelIdent,
     pub desired_state:       DesiredState,
     pub spec_file:           PathBuf,
     pub spec_ident:          PackageIdent,
@@ -278,7 +277,6 @@ impl Service {
                      sys,
                      cfg,
                      config_renderer: CfgRenderer::new(&config_root)?,
-                     channel: spec.channel,
                      desired_state: spec.desired_state,
                      health_check_result: Arc::new(Mutex::new(HealthCheckResult::Unknown)),
                      hooks: HookTable::load(&pkg.name,
@@ -624,7 +622,7 @@ impl Service {
         let mut spec = ServiceSpec::new(self.spec_ident.clone());
         spec.group = self.service_group.group().to_string();
         spec.bldr_url = self.spec.bldr_url.clone();
-        spec.channel = self.channel.clone();
+        spec.channel = self.spec.channel.clone();
         spec.topology = self.topology;
         spec.update_strategy = self.update_strategy;
         spec.update_condition = self.update_condition;
@@ -1269,7 +1267,7 @@ impl<'a> Serialize for ServiceProxy<'a> {
             strukt.serialize_field("cfg", &s.cfg)?;
         }
 
-        strukt.serialize_field("channel", &s.channel)?;
+        strukt.serialize_field("channel", &s.spec.channel)?;
         strukt.serialize_field("config_from", &s.config_from)?;
         strukt.serialize_field("desired_state", &s.desired_state)?;
         strukt.serialize_field("health_check", &s.health_check_result)?;

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -224,7 +224,6 @@ pub struct Service {
     /// census.
     unsatisfied_binds:    HashSet<ServiceBind>,
     hooks:                HookTable,
-    config_from:          Option<PathBuf>,
     manager_fs_cfg:       Arc<FsCfg>,
     supervisor:           Arc<Mutex<Supervisor>>,
 
@@ -293,7 +292,6 @@ impl Service {
                      all_pkg_binds,
                      unsatisfied_binds: HashSet::new(),
                      spec_file,
-                     config_from: spec.config_from,
                      gateway_state,
                      health_check_handle: None,
                      post_run_handle: None,
@@ -617,7 +615,7 @@ impl Service {
         spec.update_condition = self.spec.update_condition;
         spec.binds = self.spec.binds.clone();
         spec.binding_mode = self.spec.binding_mode;
-        spec.config_from = self.config_from.clone();
+        spec.config_from = self.spec.config_from.clone();
         spec.svc_encrypted_password = self.spec.svc_encrypted_password.clone();
         spec.health_check_interval = self.spec.health_check_interval;
         spec.shutdown_timeout = self.spec.shutdown_timeout;
@@ -1256,7 +1254,7 @@ impl<'a> Serialize for ServiceProxy<'a> {
         }
 
         strukt.serialize_field("channel", &s.spec.channel)?;
-        strukt.serialize_field("config_from", &s.config_from)?;
+        strukt.serialize_field("config_from", &s.spec.config_from)?;
         strukt.serialize_field("desired_state", &s.spec.desired_state)?;
         strukt.serialize_field("health_check", &s.health_check_result)?;
         strukt.serialize_field("hooks", &s.hooks)?;

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -252,6 +252,8 @@ impl Service {
 
     pub(crate) fn shutdown_timeout(&self) -> Option<ShutdownTimeout> { self.spec.shutdown_timeout }
 
+    pub(crate) fn spec(&self) -> ServiceSpec { self.spec.clone() }
+
     #[allow(clippy::too_many_arguments)]
     async fn with_package(sys: Arc<Sys>,
                           package: &PackageInstall,
@@ -602,24 +604,6 @@ impl Service {
             }
         }
         template_data_changed
-    }
-
-    pub fn to_spec(&self) -> ServiceSpec {
-        // TODO (CM): eventually just return a copy of self.spec
-        let mut spec = ServiceSpec::new(self.spec.ident.clone());
-        spec.group = self.service_group.group().to_string();
-        spec.bldr_url = self.spec.bldr_url.clone();
-        spec.channel = self.spec.channel.clone();
-        spec.topology = self.spec.topology;
-        spec.update_strategy = self.spec.update_strategy;
-        spec.update_condition = self.spec.update_condition;
-        spec.binds = self.spec.binds.clone();
-        spec.binding_mode = self.spec.binding_mode;
-        spec.config_from = self.spec.config_from.clone();
-        spec.svc_encrypted_password = self.spec.svc_encrypted_password.clone();
-        spec.health_check_interval = self.spec.health_check_interval;
-        spec.shutdown_timeout = self.spec.shutdown_timeout;
-        spec
     }
 
     /// Iterate through all the service binds, marking any that are

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -57,7 +57,7 @@ impl ServiceUpdater {
         self.remove(&service.service_group);
         // Determine what kind of worker we should use
         let service_group = service.service_group.clone();
-        match service.update_strategy {
+        match service.update_strategy() {
             UpdateStrategy::None => {}
             UpdateStrategy::AtOnce => {
                 let worker = self.at_once_worker(service);

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -89,7 +89,9 @@ impl ServiceUpdater {
     fn at_once_worker(&mut self, service: &Service) -> impl Future<Output = ()> + Send + 'static {
         debug!("'{}' service updater spawning at-once worker watching for changes to '{}' from \
                 channel '{}'",
-               service.service_group, service.spec_ident, service.channel);
+               service.service_group,
+               service.spec_ident,
+               service.channel());
         let service_group = service.service_group.clone();
         let full_ident = service.pkg.ident.clone();
         let updates = Arc::clone(&self.updates);
@@ -109,7 +111,9 @@ impl ServiceUpdater {
                       -> impl Future<Output = ()> + Send + 'static {
         debug!("'{}' service updater spawning rolling worker watching for changes to '{}' from \
                 channel '{}'",
-               service.service_group, service.spec_ident, service.channel);
+               service.service_group,
+               service.spec_ident,
+               service.channel());
         let service_group = service.service_group.clone();
         let full_ident = service.pkg.ident.clone();
         let updates = Arc::clone(&self.updates);

--- a/components/sup/src/manager/service_updater.rs
+++ b/components/sup/src/manager/service_updater.rs
@@ -90,7 +90,7 @@ impl ServiceUpdater {
         debug!("'{}' service updater spawning at-once worker watching for changes to '{}' from \
                 channel '{}'",
                service.service_group,
-               service.spec_ident,
+               service.spec_ident(),
                service.channel());
         let service_group = service.service_group.clone();
         let full_ident = service.pkg.ident.clone();
@@ -112,7 +112,7 @@ impl ServiceUpdater {
         debug!("'{}' service updater spawning rolling worker watching for changes to '{}' from \
                 channel '{}'",
                service.service_group,
-               service.spec_ident,
+               service.spec_ident(),
                service.channel());
         let service_group = service.service_group.clone();
         let full_ident = service.pkg.ident.clone();

--- a/components/sup/src/manager/service_updater/package_update_worker.rs
+++ b/components/sup/src/manager/service_updater/package_update_worker.rs
@@ -27,7 +27,7 @@ pub struct PackageUpdateWorker {
 impl PackageUpdateWorker {
     pub fn new(service: &Service, period: Duration) -> Self {
         Self { service_group: service.service_group.clone(),
-               ident: service.spec_ident.clone(),
+               ident: service.spec_ident(),
                full_ident: service.pkg.ident.clone(),
                update_condition: service.update_condition,
                channel: service.channel(),

--- a/components/sup/src/manager/service_updater/package_update_worker.rs
+++ b/components/sup/src/manager/service_updater/package_update_worker.rs
@@ -29,7 +29,7 @@ impl PackageUpdateWorker {
         Self { service_group: service.service_group.clone(),
                ident: service.spec_ident(),
                full_ident: service.pkg.ident.clone(),
-               update_condition: service.update_condition,
+               update_condition: service.update_condition(),
                channel: service.channel(),
                builder_url: service.bldr_url(),
                period }

--- a/components/sup/src/manager/service_updater/package_update_worker.rs
+++ b/components/sup/src/manager/service_updater/package_update_worker.rs
@@ -31,7 +31,7 @@ impl PackageUpdateWorker {
                full_ident: service.pkg.ident.clone(),
                update_condition: service.update_condition,
                channel: service.channel.clone(),
-               builder_url: service.bldr_url.clone(),
+               builder_url: service.bldr_url(),
                period }
     }
 }

--- a/components/sup/src/manager/service_updater/package_update_worker.rs
+++ b/components/sup/src/manager/service_updater/package_update_worker.rs
@@ -30,7 +30,7 @@ impl PackageUpdateWorker {
                ident: service.spec_ident.clone(),
                full_ident: service.pkg.ident.clone(),
                update_condition: service.update_condition,
-               channel: service.channel.clone(),
+               channel: service.channel(),
                builder_url: service.bldr_url(),
                period }
     }

--- a/components/sup/src/manager/service_updater/rolling_update_worker.rs
+++ b/components/sup/src/manager/service_updater/rolling_update_worker.rs
@@ -65,7 +65,7 @@ impl RollingUpdateWorker {
                period: Duration)
                -> Self {
         Self { service_group: service.service_group.clone(),
-               topology: service.topology,
+               topology: service.topology(),
                package_update_worker: PackageUpdateWorker::new(service, period),
                census_ring,
                butterfly }


### PR DESCRIPTION
This is a preliminary refactoring in service of https://github.com/habitat-sh/habitat/issues/7635.

Rather than storing every individual component of a `ServiceSpec` inside a `Service` instance, we'll simply store a copy of the whole spec itself.

Not only will this help clean up and streamline the `Service` struct, it should make it easier to update service configuration on-the-fly in the future by swapping in a new `ServiceSpec`.

Each commit deals with a small isolated aspect of this change (e.g., on field per commit) in order to ease the review burden.