### PR TITLE
Restore and deprecate update period env vars

### DIFF
--- a/components/sup/src/manager/service_updater/package_update_worker.rs
+++ b/components/sup/src/manager/service_updater/package_update_worker.rs
@@ -1,6 +1,7 @@
 use crate::{manager::service::Service,
             util};
-use habitat_core::{package::{FullyQualifiedPackageIdent,
+use habitat_core::{self,
+                   package::{FullyQualifiedPackageIdent,
                              PackageIdent},
                    service::ServiceGroup,
                    ChannelIdent};
@@ -10,6 +11,40 @@ use std::{self,
           time::Duration};
 use tokio::{self,
             time};
+
+// TODO (CM): Yes, the variable value should be "period" and not
+// "frequency"... we need to fix that.
+const PERIOD_BYPASS_CHECK_ENVVAR: &str = "HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK";
+
+// TODO (DM): Remove this deprecated env var
+habitat_core::env_config_duration!(
+    /// Represents how far apart checks for updates to individual services
+    /// are, in milliseconds.
+    PackageUpdateWorkerPeriod,
+    // TODO (CM): Yes, the variable value should be "period" and not
+    // "frequency"... we need to fix that.
+    HAB_UPDATE_STRATEGY_FREQUENCY_MS => from_millis,
+    PackageUpdateWorkerPeriod::MIN_ALLOWED);
+
+impl PackageUpdateWorkerPeriod {
+    const MIN_ALLOWED: Duration = Duration::from_secs(60);
+
+    fn get() -> Option<Duration> {
+        if habitat_core::env::var(PackageUpdateWorkerPeriod::ENVVAR).is_err() {
+            return None;
+        }
+        warn!("Using deprecated environment variable `HAB_UPDATE_STRATEGY_FREQUENCY_MS`. Prefer \
+               using the `hab sup run --service-update-period` argument or config file setting.");
+        let val = PackageUpdateWorkerPeriod::configured_value().into();
+        if val >= PackageUpdateWorkerPeriod::MIN_ALLOWED
+           || habitat_core::env::var(PERIOD_BYPASS_CHECK_ENVVAR).is_ok()
+        {
+            Some(val)
+        } else {
+            Some(PackageUpdateWorkerPeriod::MIN_ALLOWED)
+        }
+    }
+}
 
 /// When `run`, a `PackageUpdateWorker` returns a future that continuously checks for a change in
 /// version of the package being run by a service. If a change is detected, the package is installed
@@ -43,7 +78,8 @@ impl PackageUpdateWorker {
     /// package is found.
     // TODO (DM): The returned package ident should use FullyQualifiedPackageIdent.
     pub async fn update_to(&self, ident: PackageIdent) -> PackageIdent {
-        let splay = Duration::from_secs(rand::thread_rng().gen_range(0, self.period.as_secs()));
+        let period = PackageUpdateWorkerPeriod::get().unwrap_or(self.period);
+        let splay = Duration::from_secs(rand::thread_rng().gen_range(0, period.as_secs()));
         debug!("Starting package update worker for {} in {}s",
                ident,
                splay.as_secs());
@@ -87,8 +123,8 @@ impl PackageUpdateWorker {
             }
             trace!("Package update worker for {} delaying for {}s",
                    ident,
-                   self.period.as_secs());
-            time::delay_for(self.period).await;
+                   period.as_secs());
+            time::delay_for(period).await;
         }
     }
 


### PR DESCRIPTION
Restores and deprecates env vars that were removed in #7733. This is done to preserve backwards compatability. 

Signed-off-by: David McNeil <mcneil.david2@gmail.com>