### PR TITLE
[CI] Simplify PKG_CONFIG_PATH for cargo_update.sh

### DIFF
--- a/.expeditor/scripts/finish_release/cargo_update.sh
+++ b/.expeditor/scripts/finish_release/cargo_update.sh
@@ -18,8 +18,8 @@ install_hub
 echo "--- :habicat: Installing and configuring build dependencies"
 hab pkg install core/zeromq
 
-PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(< "$(hab pkg path core/zeromq)"/PKG_CONFIG_PATH)"
-export PKG_CONFIG_PATH 
+PKG_CONFIG_PATH="$(< "$(hab pkg path core/zeromq)"/PKG_CONFIG_PATH)"
+export PKG_CONFIG_PATH
 
 # The library detection for the zeromq crate needs this additional hint. 
 LD_RUN_PATH="$(hab pkg path core/zeromq)/lib"


### PR DESCRIPTION
With recent changes, the only thing needed in `PKG_CONFIG_PATH` is the
ZeroMQ entry.

(As it was, this was failing because `PKG_CONFIG_PATH` was unset in
the environment. Since we don't need to concatenate anything, we'll
just set the value directly and move on.)

Signed-off-by: Christopher Maier <cmaier@chef.io>