### PR TITLE
always promote package on upload if a user specifies a channel

### DIFF
--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -73,10 +73,8 @@ pub async fn start(ui: &mut UI,
             ui.status(Status::Using,
                       format!("existing {} already on target", &ident))?;
             // Always promote to additional_release_channel if specified
-            if additional_release_channel.is_some() {
-                if let Some(channel) = additional_release_channel.clone() {
-                    promote_to_channel(ui, &api_client, (&ident, target), channel, token).await?
-                }
+            if let Some(channel) = additional_release_channel.clone() {
+                promote_to_channel(ui, &api_client, (&ident, target), channel, token).await?
             }
             Ok(())
         }
@@ -183,7 +181,7 @@ async fn upload_into_depot(ui: &mut UI,
     ui.status(Status::Uploaded, ident)?;
 
     // Promote to additional_release_channel if specified
-    if package_exists_in_target && additional_release_channel.is_some() {
+    if package_exists_in_target {
         if let Some(channel) = additional_release_channel.clone() {
             promote_to_channel(ui, api_client, (ident, target), channel, token).await?
         }

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -74,10 +74,8 @@ pub async fn start(ui: &mut UI,
                       format!("existing {} already on target", &ident))?;
             // Always promote to additional_release_channel if specified
             if additional_release_channel.is_some() {
-                let channel = additional_release_channel.clone().unwrap();
-                match promote_to_channel(ui, &api_client, (&ident, target), channel, token).await {
-                    Ok(_) => (),
-                    Err(e) => return Err(e),
+                if let Some(channel) = additional_release_channel.clone() {
+                    promote_to_channel(ui, &api_client, (&ident, target), channel, token).await?
                 }
             }
             Ok(())
@@ -186,10 +184,8 @@ async fn upload_into_depot(ui: &mut UI,
 
     // Promote to additional_release_channel if specified
     if package_exists_in_target && additional_release_channel.is_some() {
-        let channel = additional_release_channel.clone().unwrap();
-        match promote_to_channel(ui, api_client, (ident, target), channel, token).await {
-            Ok(_) => (),
-            Err(e) => return Err(e),
+        if let Some(channel) = additional_release_channel.clone() {
+            promote_to_channel(ui, api_client, (ident, target), channel, token).await?
         }
     }
 
@@ -214,12 +210,8 @@ async fn promote_to_channel(ui: &mut UI,
         };
     }
 
-    match api_client.promote_package((ident, target), &channel, token)
-                    .await
-    {
-        Ok(_) => (),
-        Err(e) => return Err(Error::from(e)),
-    };
+    api_client.promote_package((ident, target), &channel, token)
+              .await?;
     ui.status(Status::Promoted, ident)?;
 
     Ok(())

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -77,7 +77,7 @@ pub async fn start(ui: &mut UI,
                 let channel = additional_release_channel.clone().unwrap();
                 match promote_to_channel(ui, &api_client, (&ident, target), channel, token).await {
                     Ok(_) => (),
-                    Err(e) => return Err(Error::from(e)),
+                    Err(e) => return Err(e),
                 }
             }
             Ok(())
@@ -189,7 +189,7 @@ async fn upload_into_depot(ui: &mut UI,
         let channel = additional_release_channel.clone().unwrap();
         match promote_to_channel(ui, api_client, (ident, target), channel, token).await {
             Ok(_) => (),
-            Err(e) => return Err(Error::from(e)),
+            Err(e) => return Err(e),
         }
     }
 


### PR DESCRIPTION
closes #7704 

On an upload, we will ensure that a channel promotion always occurs for the package and its tdeps (from the archive path) if they exist in the target and if the user specified `--channel xxx` on the cli.

Signed-off-by: Jeremy J. Miller <jm@chef.io>