### PR TITLE
[FIX] Ensure `toToml` helper works properly for tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3908,6 +3908,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
+ "indexmap",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3374,6 +3374,7 @@ version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -21,7 +21,7 @@ regex = "*"
 reqwest = { version = "*", features = ["blocking", "json", "stream"] }
 serde = "*"
 serde_derive = "*"
-serde_json = "*"
+serde_json = { version = "*", features = [ "preserve_order" ] }
 tabwriter = "*"
 tee = "*"
 tokio = { version = "*", features = ["full"] }

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -26,10 +26,10 @@ prost-derive = "*"
 rand = "*"
 serde = { version = "*", features = ["rc"] }
 serde_derive = "*"
-serde_json = "*"
+serde_json = { version = "*", features = [ "preserve_order" ] }
 tempfile = "*"
 threadpool = "*"
-toml = { version = "*", default-features = false }
+toml = { version = "*", features = [ "preserve_order" ] }
 uuid = { version = "*", features = ["v4"] }
 zmq = { git = "https://github.com/habitat-sh/rust-zmq", branch = "v0.8-symlinks-removed" }
 

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -36,7 +36,7 @@ regex = "*"
 reqwest = { version = "*", features = ["blocking", "json", "stream"] }
 serde = "*"
 serde_derive = "*"
-serde_json = "*"
+serde_json = { version = "*", features = ["preserve_order"] }
 serde-transcode = "*"
 serde_yaml = "*"
 tempfile = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -43,7 +43,7 @@ tempfile = "*"
 retry = { git = "https://github.com/habitat-sh/retry", features = ["asynchronous"] }
 termcolor = "*"
 tokio = { version = "*", features = ["full"] }
-toml = { version = "*", default-features = false }
+toml = { version = "*", features = ["preserve_order"] }
 uuid = { version = "*", features = ["v4"] }
 valico = "*"
 

--- a/components/common/src/templating/helpers/to_toml.rs
+++ b/components/common/src/templating/helpers/to_toml.rs
@@ -13,6 +13,10 @@ impl HelperDef for ToTomlHelper {
         let param = h.param(0)
                      .ok_or_else(|| RenderError::new("Expected 1 parameter for \"toToml\""))?
                      .value();
+        // Since `param` is a JSON object, this only works reliably if
+        // `serde_json` has been compiled with the `preserve_order`
+        // feature, since order *is* important for TOML (values must
+        // be emitted before tables).
         let bytes = toml::ser::to_vec(&param).map_err(|e| {
                                                  RenderError::new(format!("Can't serialize \
                                                                            parameter to TOML: {}",

--- a/components/common/src/templating/helpers/to_toml.rs
+++ b/components/common/src/templating/helpers/to_toml.rs
@@ -24,3 +24,59 @@ impl HelperDef for ToTomlHelper {
 }
 
 pub static TO_TOML: ToTomlHelper = ToTomlHelper;
+
+#[cfg(test)]
+mod tests {
+    use crate::templating::TemplateRenderer;
+    use toml::{self,
+               value::{Table,
+                       Value}};
+
+    /// Inspired by a reported issue... here, we are creating the
+    /// following TOML:
+    ///
+    ///     [[inputs.prometheus]]
+    ///     urls = ["http://127.0.0.1:15000/metics"]
+    ///     [inputs.prometheus.tags]
+    ///     service = "service_name"
+    ///
+    /// The idea is that you have that config in a file, run `hab
+    /// config apply` on it, and then attempt to render a file with
+    /// the template
+    ///
+    ///     {{ toToml cfg }}
+    ///
+    /// The `toToml` helper should be able to handle this.
+    #[test]
+    fn toml_tables_are_serialized_appropriately() {
+        let mut tags = Table::new();
+        tags.insert("service".to_string(),
+                    Value::String("service_name".to_string()));
+
+        let urls = Value::Array(vec![Value::String("http://127.0.0.1:15000/metrics".to_string())]);
+
+        let mut prometheus = Table::new();
+        prometheus.insert("urls".to_string(), urls);
+        prometheus.insert("tags".to_string(), Value::Table(tags));
+
+        let mut inputs = Table::new();
+        inputs.insert("prometheus".to_string(),
+                      Value::Array(vec![Value::Table(prometheus)]));
+
+        let mut the_stuff = Table::new();
+        the_stuff.insert("inputs".to_string(), Value::Table(inputs));
+
+        let mut cfg = Table::new();
+        cfg.insert("cfg".to_string(), Value::Table(the_stuff));
+
+        assert!(toml::to_string(&cfg).is_ok(),
+                "Should be able to render a Table directly as TOML");
+
+        // We should also be able to render the same thing through handlebars
+        let mut renderer = TemplateRenderer::new();
+        renderer.register_template_string("t", "{{ toToml cfg }}")
+                .expect("Couldn't register template!");
+
+        assert!(renderer.render("t", &cfg).is_ok());
+    }
+}

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -27,11 +27,11 @@ regex = "*"
 rust-crypto = "*"
 serde = "*"
 serde_derive = "*"
-serde_json = "*"
+serde_json = { version = "*", features = [ "preserve_order" ] }
 sodiumoxide = "*"
 tar = "*"
 tempfile = "*"
-toml = { version = "*", default-features = false }
+toml = { version = "*", features = [ "preserve_order" ] }
 typemap = "*"
 url = "*"
 xz2 = "*"

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -43,14 +43,14 @@ retry = { git = "https://github.com/habitat-sh/retry", features = ["asynchronous
 same-file = "*"
 serde = "*"
 serde_derive = "*"
-serde_json = "*"
+serde_json = { version = "*", features = [ "preserve_order" ] }
 serde_yaml = "*"
 structopt = { git = "https://github.com/habitat-sh/structopt.git" }
 tabwriter = "*"
 tar = "*"
 termcolor = "*"
 tokio = { version = "*", features = ["full"] }
-toml = { version = "*", default-features = false }
+toml = { version = "*", features = [ "preserve_order" ] }
 url = { version = "*", features = ["serde"] }
 walkdir = "*"
 

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -14,7 +14,7 @@ httparse = "*"
 reqwest = { version = "*", features = ["blocking", "json", "stream"] }
 env_proxy = { git = "https://github.com/inejge/env_proxy.git" }
 serde = "*"
-serde_json = "*"
+serde_json = { version = "*", features = [ "preserve_order" ] }
 url = "*"
 
 [dependencies.habitat_core]

--- a/components/pkg-export-container/Cargo.toml
+++ b/components/pkg-export-container/Cargo.toml
@@ -30,7 +30,7 @@ rusoto_core = "*"
 rusoto_credential = "*"
 rusoto_ecr = "*"
 serde = { version = "*", features = ["rc"] }
-serde_json = "*"
+serde_json = { version = "*", features = [ "preserve_order" ] }
 tempfile = "*"
 termcolor = "*"
 tokio = { version = "*", features = ["full"] }

--- a/components/pkg-export-tar/Cargo.toml
+++ b/components/pkg-export-tar/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "*"
 log = "*"
 mktemp = "*"
 serde = { version = "*", features = ["rc"] }
-serde_json = "*"
+serde_json = { version = "*", features = [ "preserve_order" ] }
 tokio = { version = "*", features = ["full"] }
 url = "*"
 failure = "*"

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -25,4 +25,4 @@ prost-build = "*"
 
 [dev-dependencies]
 tempfile = "*"
-toml = "*"
+toml = { version = "*", features = [ "preserve_order" ] }

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -52,14 +52,14 @@ regex = "*"
 rustls = "0.16.0"
 serde = { version = "*", features = ["rc"] }
 serde_derive = "*"
-serde_json = "*"
+serde_json = { version = "*", features = [ "preserve_order" ] }
 serde_yaml = "*"
 serde-transcode = "*"
 state = "*"
 structopt = { git = "https://github.com/habitat-sh/structopt.git" }
 tempfile = "*"
 termcolor = "*"
-toml = { version = "*", default-features = false }
+toml = { version = "*", features = ["preserve_order"]}
 tokio = { version = "*", features = ["full"] }
 tokio-util = { version = "*", features = ["full"] }
 url = "*"


### PR DESCRIPTION
A customer reported a failure of the `toToml` helper where a configuration containing TOML tables could not be serialized using the `toToml` helper, despite the fact that the data in question was a valid TOML object.

Handlebars information is represented in terms of JSON objects. When serializing to TOML, however, we can run into issues involving the ordering of keys. With TOML, values must be serialized *before* tables.

We can get around this by compiling `serde_json` with the `preserve_order` feature, which maintains insertion order of keys in JSON objects.

And, since we've run into multiple TOML table serialization issues in the past, this PR also proactively enabls order-preserving functionality across all our serialization code. With luck, this will be the last time we encounter a problem like this.