### PR TITLE
hab-plan-build: don't fail on empty hooks dir

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -1980,14 +1980,16 @@ do_default_build_config() {
     mkdir -p "$pkg_prefix"/hooks
     for file in "$PLAN_CONTEXT"/hooks/*
     do
-      # The supervisor does not recognize extensions so all hooks are
-      # copied without extensions
-      local target
-      target="$pkg_prefix"/hooks/"$(basename "${file%.*}")"
-      if [[ -f "$target" ]]; then
-        exit_with "Multiple hook files found for $(basename "${file%.*}") hook. No more than one hook file permitted per lifecycle hook." 1
-      else
-        cp "$file" "$target"
+      if [[ -e "$file" ]]; then
+        # The supervisor does not recognize extensions so all hooks are
+        # copied without extensions
+        local target
+        target="$pkg_prefix"/hooks/"$(basename "${file%.*}")"
+        if [[ -f "$target" ]]; then
+          exit_with "Multiple hook files found for $(basename "${file%.*}") hook. No more than one hook file permitted per lifecycle hook." 1
+        else
+          cp "$file" "$target"
+        fi
       fi
     done
     chmod 755 "$pkg_prefix"/hooks


### PR DESCRIPTION
As of 2901d4d25fc0394793cf830b44c43c3aae5ec8ff, attempting to build a
package with an empty hooks directory would fail with the following:

    cp: can't stat '/src/habitat/hooks/*': No such file or directory

This is because when a shell glob does not match any files on the file
system, it is passed literally. Thus, cp is being passed the literal
string `/src/habitat/hooks/*`, which is not a file on the filesystem.

This is unfortunate because `hab plan init` creates an empty `hooks`
directory by default.

There are a few ways to fix this, including using find or setting the
nullglob option in Bash. I've opted to check for the existence of the
file again before doing anything with it.

Signed-off-by: Steven Danna <steve@chef.io>