### PR TITLE
Fix reading root certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "httparse",
  "log 0.4.8",
  "native-tls",
+ "pem",
  "reqwest",
  "serde",
  "serde_json",
@@ -2478,6 +2479,17 @@ dependencies = [
  "libc",
  "time 0.1.43",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "pem"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
+dependencies = [
+ "base64 0.12.1",
+ "once_cell",
+ "regex 1.3.9",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "url",
 ]
 

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -10,6 +10,7 @@ workspace = "../../"
 base64 = "*"
 log = "*"
 native-tls = { version = "*", features = ["vendored"] }
+pem = "*"
 httparse = "*"
 reqwest = { version = "*", features = ["blocking", "json", "stream"] }
 env_proxy = { git = "https://github.com/inejge/env_proxy.git" }

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -21,6 +21,9 @@ url = "*"
 [dependencies.habitat_core]
 path = "../core"
 
+[dev-dependencies]
+tempfile = "*"
+
 [features]
 default = []
 functional = []

--- a/components/http-client/src/api_client.rs
+++ b/components/http-client/src/api_client.rs
@@ -364,6 +364,13 @@ fn process_cert_file(certificates: &mut Vec<Certificate>, file_path: &Path) {
 }
 
 fn certs_from_pem_file(buf: &[u8]) -> Result<Vec<Certificate>> {
+    if buf.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Try to decode the first certificate as a pem file. This is necessary because
+    // `pem::parse_many` does not return an error. It simply parses what it can and ignores the
+    // rest.
+    Certificate::from_pem(buf)?;
     pem::parse_many(buf).iter()
                         .map(|cert| Ok(Certificate::from_der(&cert.contents)?))
                         .collect()
@@ -371,6 +378,86 @@ fn certs_from_pem_file(buf: &[u8]) -> Result<Vec<Certificate>> {
 
 fn certs_from_file(file_path: &Path) -> Result<Vec<Certificate>> {
     let buf = fs::read(file_path)?;
-
+    // Try and interpret the file as a pem cert. If that fails try and interpret it as a der cert.
     certs_from_pem_file(&buf).or_else(|_| Ok(vec![Certificate::from_der(&buf)?]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::certs_from_file;
+    use native_tls::Certificate;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_certs_from_file() {
+        const PEM_CERT: &str = "-----BEGIN CERTIFICATE-----
+MIIB/jCCAYWgAwIBAgIIdJclisc/elQwCgYIKoZIzj0EAwMwRTELMAkGA1UEBhMC
+VVMxFDASBgNVBAoMC0FmZmlybVRydXN0MSAwHgYDVQQDDBdBZmZpcm1UcnVzdCBQ
+cmVtaXVtIEVDQzAeFw0xMDAxMjkxNDIwMjRaFw00MDEyMzExNDIwMjRaMEUxCzAJ
+BgNVBAYTAlVTMRQwEgYDVQQKDAtBZmZpcm1UcnVzdDEgMB4GA1UEAwwXQWZmaXJt
+VHJ1c3QgUHJlbWl1bSBFQ0MwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAQNMF4bFZ0D
+0KF5Nbc6PJJ6yhUczWLznCZcBz3lVPqj1swS6vQUX+iOGasvLkjmrBhDeKzQN8O9
+ss0s5kfiGuZjuD0uL3jET9v0D6RoTFVya5UdThhClXjMNzyR4ptlKymjQjBAMB0G
+A1UdDgQWBBSaryl6wBE1NSZRMADDav5A1a7WPDAPBgNVHRMBAf8EBTADAQH/MA4G
+A1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAwNnADBkAjAXCfOHiFBar8jAQr9HX/Vs
+aobgxCd05DhT1wV/GzTjxi+zygk8N53X57hG8f2h4nECMEJZh0PUUd+60wkyWs6I
+flc9nF9Ca/UHLbXwgpP5WW+uZPpY5Yse42O+tYHNbwKMeQ==
+-----END CERTIFICATE-----";
+
+        // From empty file
+        let file = NamedTempFile::new().unwrap();
+        assert!(certs_from_file(file.path()).unwrap().is_empty());
+
+        // From der
+        let mut file = NamedTempFile::new().unwrap();
+        let cert = Certificate::from_pem(PEM_CERT.as_bytes()).unwrap();
+        file.write_all(&cert.to_der().unwrap()).unwrap();
+        assert_eq!(certs_from_file(file.path()).unwrap().len(), 1);
+
+        // From single pem
+        let mut file = NamedTempFile::new().unwrap();
+        write!(file, "{}", PEM_CERT).unwrap();
+        assert_eq!(certs_from_file(file.path()).unwrap().len(), 1);
+
+        // From multiple pems
+        let mut file = NamedTempFile::new().unwrap();
+        write!(
+               file,
+               "{}
+-----BEGIN CERTIFICATE-----
+MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF
+ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6
+b24gUm9vdCBDQSAxMB4XDTE1MDUyNjAwMDAwMFoXDTM4MDExNzAwMDAwMFowOTEL
+MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UEAxMQQW1hem9uIFJv
+b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALJ4gHHKeNXj
+ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQNroBvo3bSMgHFzZM
+9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9tBb6dNqcmzU5L/qw
+IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHheb4mjUcAwhmahRWa6
+VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD+rcdqsq08p8kDi1L
+93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/QCB/IIDEgEw+OyQm
+jgSubJrIqg0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMC
+AYYwHQYDVR0OBBYEFIQYzIU07LwMlJQuCFmcx7IQTgoIMA0GCSqGSIb3DQEBCwUA
+A4IBAQCY8jdaQZChGsV2USggNiMOruYou6r4lK5IpDB/G/wkjUu0yKGX9rbxenDI
+U5PMCCjjmCXPI6T53iHTfIUJrU6adTrCC2qJeHZERxhlbI1Bjjt/msv0tadQ1wUs
+N+gDS63pYaACbvXy8MWy7Vu33PqUXHeeE6V/Uq2V8viTO96LXFvKWlJbYK8U90vv
+o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU
+5MsI+yMRQ+hDKXJioaldXgjUkK642M4UwtBV8ob2xJNDd2ZhwLnoQdeXeGADbkpy
+rqXRfboQnoZsG4q5WTP468SQvvG5
+-----END CERTIFICATE-----
+",
+               PEM_CERT
+        ).unwrap();
+        assert_eq!(certs_from_file(file.path()).unwrap().len(), 2);
+
+        // Invalid cert gives an error
+        let mut file = NamedTempFile::new().unwrap();
+        write!(
+               file,
+               "-----BEGIN CERTIFICATE-----
+a bad cert
+-----END CERTIFICATE-----"
+        ).unwrap();
+        assert!(certs_from_file(file.path()).is_err());
+    }
 }


### PR DESCRIPTION
Resolves #7773 #7777 

We were only reading the first cert from `pem` files. This has been broken for a long time, but only just now manifested itself because we vendored `openssl`.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>