### PR TITLE
[CI] Bump macOS timeout in release pipeline

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -64,8 +64,7 @@ steps:
         macos:
           os-version: "10.13"
           inherit-environment-vars: true
-      buildkite:
-        timeout_in_minutes: 45
+    timeout_in_minutes: 60
 
   - wait
 
@@ -190,8 +189,6 @@ steps:
           environment:
             - BUILD_PKG_TARGET=x86_64-windows
             - BUILDKITE_AGENT_ACCESS_TOKEN
-      buildkite:
-        timeout_in_minutes: 45
 
   - label: "[:linux: build hab-sup]"
     command:


### PR DESCRIPTION
Removes a timeout in a Windows stage because it was the same as the
default, but also structured improperly, as well.

Signed-off-by: Christopher Maier <cmaier@chef.io>