### PR TITLE
 Write all service files when a service is loaded 

### DIFF
--- a/test/end-to-end/multi-supervisor/testcases/service_files_are_written_to_disk_when_service_is_loaded/Dockerfile
+++ b/test/end-to-end/multi-supervisor/testcases/service_files_are_written_to_disk_when_service_is_loaded/Dockerfile
@@ -1,0 +1,4 @@
+FROM habitat_integration_base
+
+COPY run_test.ps1 /run_test.ps1
+CMD pwsh /scripts/end_to_end/run_e2e_test_core.ps1 /run_test.ps1

--- a/test/end-to-end/multi-supervisor/testcases/service_files_are_written_to_disk_when_service_is_loaded/docker-compose.override.yml
+++ b/test/end-to-end/multi-supervisor/testcases/service_files_are_written_to_disk_when_service_is_loaded/docker-compose.override.yml
@@ -1,0 +1,9 @@
+version: '2.4'
+services:
+  tester:
+    extends:
+      service: test_base
+    depends_on:
+      - bastion
+      - alpha
+      - beta

--- a/test/end-to-end/multi-supervisor/testcases/service_files_are_written_to_disk_when_service_is_loaded/run_test.ps1
+++ b/test/end-to-end/multi-supervisor/testcases/service_files_are_written_to_disk_when_service_is_loaded/run_test.ps1
@@ -1,0 +1,39 @@
+Describe "hab file upload" {
+
+    $redisRelease = "core/redis/4.0.14/20200421191514"
+
+    Load-SupervisorService $redisRelease -Remote "alpha.habitat.dev"
+    Wait-Release -Ident $redisRelease -Remote "alpha"
+
+    $message = "Hello from Habitat!"
+    Set-Content message.txt -Value $message
+    hab file upload `
+        redis.default `
+    ([DateTime]::Now.Ticks) `
+        message.txt `
+        --remote-sup=bastion.habitat.dev
+    Start-Sleep 5
+
+    It "should upload the file to a Supervisor running the service" {
+        $uploadedMessage = docker exec "${env:COMPOSE_PROJECT_NAME}_alpha_1" cat /hab/svc/redis/files/message.txt
+        $uploadedMessage | Should -Be $message
+    }
+
+    It "should NOT upload the file to a Supervisor not running the service" {
+        docker exec "${env:COMPOSE_PROJECT_NAME}_beta_1" cat /hab/svc/redis/files/message.txt
+        $LASTEXITCODE | Should -Not -Be 0
+    }
+
+    Context "loading service on a new Supervisor" {
+        # Now load the service on another supervisor... the file should be
+        # present now, as well
+        Load-SupervisorService $redisRelease -Remote "beta.habitat.dev"
+        Wait-Release -Ident $redisRelease -Remote "beta"
+
+        It "should write the previously-uploaded service file to disk on the new Supervisor" {
+            $uploadedMessage = docker exec "${env:COMPOSE_PROJECT_NAME}_beta_1" cat /hab/svc/redis/files/message.txt
+            $uploadedMessage | Should -Be $message
+        }
+
+    }
+}


### PR DESCRIPTION
Previously, because of how service files are tracked, you could start
up a service that did not have access to all its relevant service
files.

For instance, assume Supervisor A and Supervisor B are peered, and
that Supervisor A is running Service X, but Supervisor B is not. A
user uploads a file for Service X using `hab file upload`. The file is
written out to disk on Supervisor A, but not on Supervisor B, as
expected.

Then, the user loads Service X onto Supervisor B. The expectation
would be that the file is also written to disk there, but it is
not. Files are only written out at the time the file rumor is
received, and only if it is a "new" rumor. Since Supervisor B wasn't
running Service X when the file was uploaded, there was no managed
service present to cause the file to be written.

Uploading the file again with a new incarnation number would result in
Supervisor B writing out the file.

Here, we fix this by having the Supervisor write out any files for the
service that it knows about when the service is loaded, regardless of
whether or not they are "new" to the Supervisor.

Fixes #4877