### PR TITLE
[CI] Bump macOS stage retry limits

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -65,6 +65,9 @@ steps:
           os-version: "10.13"
           inherit-environment-vars: true
     timeout_in_minutes: 60
+    retry:
+      automatic:
+        limit: 10 # Addressing current Anka system timeouts due to oversubscription
 
   - wait
 

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -305,7 +305,7 @@ steps:
     timeout_in_minutes: 10
     retry:
       automatic:
-        limit: 1
+        limit: 10 # Addressing current Anka system timeouts due to oversubscription
 
  #################################################################
 
@@ -952,3 +952,6 @@ steps:
           os-version: "10.13"
           inherit-environment-vars: true
     timeout_in_minutes: 60
+    retry:
+      automatic:
+        limit: 10 # Addressing current Anka system timeouts due to oversubscription


### PR DESCRIPTION
Currently, our Anka backends seem to be oversubscribed globally,
resulting in timeouts to our stages that can cause pipelines to fail.

Out of an excessive paranoia, we're going to raise the retry limit to
a ridiculous number. We'll try and keep an eye on this behavior over
time so we can remove it when it's no longer required.

Signed-off-by: Christopher Maier <cmaier@chef.io>