### PR TITLE
Fix e2e failures

### DIFF
--- a/.expeditor/scripts/end_to_end/SupervisorRunner.cs
+++ b/.expeditor/scripts/end_to_end/SupervisorRunner.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 
 public class SupervisorRunner {
     private String logPath = null;
@@ -17,6 +18,10 @@ public class SupervisorRunner {
         proc.StartInfo.RedirectStandardOutput = true;
         proc.StartInfo.RedirectStandardError = true;
         proc.StartInfo.FileName = "hab";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            // Use the fullpath to avoid running the version installed via chocolatey
+            proc.StartInfo.FileName = "/hab/bin/hab.bat";
+        }
         proc.StartInfo.Arguments = "sup run --no-color " + String.Join(" ", args);
         proc.StartInfo.EnvironmentVariables["HAB_NOCOLORING"] = "1";
         proc.OutputDataReceived += new DataReceivedEventHandler(SupOutputHandler);

--- a/.expeditor/scripts/end_to_end/SupervisorRunner.cs
+++ b/.expeditor/scripts/end_to_end/SupervisorRunner.cs
@@ -17,10 +17,11 @@ public class SupervisorRunner {
         proc.StartInfo.CreateNoWindow = true;
         proc.StartInfo.RedirectStandardOutput = true;
         proc.StartInfo.RedirectStandardError = true;
-        proc.StartInfo.FileName = "hab";
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
             // Use the fullpath to avoid running the version installed via chocolatey
             proc.StartInfo.FileName = "/hab/bin/hab.bat";
+        } else {
+            proc.StartInfo.FileName = "hab";
         }
         proc.StartInfo.Arguments = "sup run --no-color " + String.Join(" ", args);
         proc.StartInfo.EnvironmentVariables["HAB_NOCOLORING"] = "1";

--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -83,7 +83,7 @@ function Wait-Supervisor($Timeout = 1, $port = 9631) {
     Write-Host "Supervisor is now running."
 }
 
-function Wait-StopSupervisor($Timeout = 1, $port = 9631) {
+function Wait-StopSupervisor($Timeout = 10, $port = 9631) {
     Write-Host "Waiting up to $Timeout seconds for Supervisor to stop..."
     $testScript = { -Not (Test-Connection -ComputerName 127.0.0.1 -TCPPort $port) }
     $timeoutScript = { Write-Error "Timed out waiting $Timeout seconds for Supervisor to stop on port $port" }
@@ -198,11 +198,7 @@ function Restart-Supervisor {
 }
 
 function Stop-Supervisor {
-    if ($IsLinux) {
-        pkill --signal=KILL hab-launch
-    } else {
-        Stop-Process | Get-Process hab-launch
-    }
+    Stop-Process -ErrorAction 'silentlycontinue' -Name hab-launch
     Wait-StopSupervisor
 }
 


### PR DESCRIPTION
Add the following fixes to the e2e pipeline: 

* ignore errors when trying to stop the `hab-lauch` process
* increase the timeout for waiting to stop the supervisor
* use the full path to the binlinked `hab` binary, this avoids us trying to run the version installed with chocolatey

Signed-off-by: David McNeil <mcneil.david2@gmail.com>