### PR TITLE
fix ctrlc in local windows studio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ dependencies = [
  "chrono",
  "clap",
  "configopt",
+ "ctrlc",
  "dirs",
  "env_logger",
  "flate2",

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -18,6 +18,7 @@ bitflags = "*"
 chrono = {version = "*", features = ["serde"]}
 clap = { git = "https://github.com/habitat-sh/clap.git", branch = "v2-master", features = [ "suggestions", "color", "unstable" ] }
 configopt = { git = "https://github.com/davidMcneil/configopt.git" }
+ctrlc = "*"
 dirs = "*"
 env_logger = "*"
 flate2 = "*"

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -34,6 +34,7 @@ pub enum Error {
     ConfigOpt(configopt::Error),
     CryptoCLI(String),
     CtlClient(SrvClientError),
+    CtrlcError(ctrlc::Error),
     DockerDaemonDown,
     DockerFileSharingNotEnabled,
     DockerImageNotFound(String),
@@ -101,6 +102,7 @@ impl fmt::Display for Error {
             Error::ConfigOpt(ref err) => format!("{}", err),
             Error::CryptoCLI(ref e) => e.to_string(),
             Error::CtlClient(ref e) => e.to_string(),
+            Error::CtrlcError(ref err) => format!("{}", err),
             Error::DockerDaemonDown => {
                 "Can not connect to Docker. Is the Docker daemon running?".to_string()
             }
@@ -268,4 +270,8 @@ impl From<serde_yaml::Error> for Error {
 
 impl From<walkdir::Error> for Error {
     fn from(err: walkdir::Error) -> Self { Error::WalkDir(err) }
+}
+
+impl From<ctrlc::Error> for Error {
+    fn from(err: ctrlc::Error) -> Self { Error::CtrlcError(err) }
 }

--- a/components/studio/bin/hab-studio.bat
+++ b/components/studio/bin/hab-studio.bat
@@ -1,2 +1,0 @@
-@echo off
-"%~dp0powershell/pwsh.exe" -NoProfile -ExecutionPolicy bypass -NoLogo -File "%~dp0hab-studio.ps1" %*

--- a/components/studio/habitat/plan.ps1
+++ b/components/studio/habitat/plan.ps1
@@ -7,7 +7,9 @@ $pkg_build_deps=@(
     "core/hab",
     "core/hab-plan-build-ps1",
     "core/7zip")
-$pkg_bin_dirs=@("bin")
+$pkg_bin_dirs=@(
+    "bin",
+    "bin/powershell")
 
 function pkg_version {
     Get-Content "$SRC_PATH/VERSION"
@@ -25,12 +27,10 @@ function Invoke-Build {
 }
 
 function Invoke-Install {
-    mkdir "$pkg_prefix/bin/powershell" | Out-Null
     mkdir "$pkg_prefix/bin/hab" | Out-Null
     mkdir "$pkg_prefix/bin/7zip" | Out-Null
 
     Copy-Item hab-studio.ps1 "$pkg_prefix/bin/hab-studio.ps1"
-    Copy-Item $PLAN_CONTEXT/../bin/hab-studio.bat "$pkg_prefix/bin/hab-studio.bat"
     Copy-Item $PLAN_CONTEXT/../bin/SupervisorBootstrapper.cs "$pkg_prefix/bin/SupervisorBootstrapper.cs"
 
     Copy-Item "$(Get-HabPackagePath powershell)/bin/*" "$pkg_prefix/bin/powershell" -Recurse

--- a/components/studio/test/test.ps1
+++ b/components/studio/test/test.ps1
@@ -24,7 +24,7 @@ Copy-Item "$(hab pkg path core/7zip)/bin/*" "bin/7zip"
 Copy-Item "$(hab pkg path core/hab-plan-build-ps1)/bin/*" "bin/"
 
 try {
-    & bin/hab-studio.bat new
+    & bin/powershell/pwsh.exe -NoProfile -ExecutionPolicy bypass -NoLogo -File "bin/hab-studio.ps1" new
     $exit_code = $LASTEXITCODE
 } finally {
     # The test can exit before the Studio has closed all open


### PR DESCRIPTION
fixes #7794 

On windows, when a user enters ctrl-c, that sends a signal to every process running inside the console and not just the process running in the foreground. An application can register a handler for these signals or register `null` to disable the signal handling alltogether. Otherwise by default, a ctrlc will result in a call to `ExitProcess`. This PR registers an empty handler effectively turning off ctrl+c behavior for the hab cli process. This allows a user to stop builds and other processes inside of a studio with ctrlc without jacking up the stdin/out streams hosted by the parent hab process.

There are a couple associated fixes here to smooth this all out:

1. Removing the `habitat-studio.bat` wrapper. In order to provide cross-platform support for the `hab-studio` command. We mad a bat wrapper because windows will scan for files matching the command and that end in .`bat` and run those files against the `cmd` interpreter. Windows will not automatically run `.ps1` files with `pwsh`. Unfortunately `cmd` will prompt the user upon entering ctrl-c with `Terminate batch job (Y/N)`. The only way to suppress this is to send stdin to `NUL` which takes the interactive out of an interactive studio! So we are just jettisoning the wrapper here and calling the ps1 directly via pwsh.exe.

2. We are registering the local studio supervisor shutdown with `Register-EngineEvent` instead of just shutting down after the interactive prompt returns because the ctrl+c will exit the outer pwsh before it can execute any more code.

Signed-off-by: mwrock <matt@mattwrock.com>