### PR TITLE
hab pkg info extended metadata

### DIFF
--- a/components/core/src/package.rs
+++ b/components/core/src/package.rs
@@ -7,7 +7,8 @@ pub mod plan;
 pub mod target;
 
 pub use self::{archive::{FromArchive,
-                         PackageArchive},
+                         PackageArchive,
+                         PackageArchiveInfo},
                ident::{FullyQualifiedPackageIdent,
                        Identifiable,
                        PackageIdent},

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -512,7 +512,6 @@ impl PackageArchiveInfo {
 mod test {
     use super::{super::target,
                 *};
-    use serde_json;
     use std::path::PathBuf;
 
     #[test]

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -419,8 +419,7 @@ pub trait FromArchive: Sized {
     fn from_archive(archive: &mut PackageArchive) -> result::Result<Self, Self::Error>;
 }
 
-// Exposes the extended metadata from a PackageArchive
-// for easier display or de-serialization.
+// Exposes the extended archive and header metadata
 #[derive(Deserialize, Serialize)]
 pub struct PackageArchiveInfo {
     pub format_version:    String,

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -467,51 +467,25 @@ impl PackageArchiveInfo {
                                 checksum:       archive.checksum()?,
                                 target:         archive.target()?,
                                 is_a_service:   archive.is_a_service(),
-                                // All of the following unwraps are safe since the version
-                                // and release are guaranteed to be Some by this point.
                                 deps:           archive.deps()
                                                        .unwrap_or_default()
                                                        .iter()
-                                                       .map(|x| {
-                                                           format!("{}/{}/{}/{}",
-                                                                   x.origin,
-                                                                   x.name,
-                                                                   x.version.as_ref().unwrap(),
-                                                                   x.release.as_ref().unwrap())
-                                                       })
+                                                       .map(|x| format!("{}", x))
                                                        .collect(),
                                 build_deps:     archive.build_deps()
                                                        .unwrap_or_default()
                                                        .iter()
-                                                       .map(|x| {
-                                                           format!("{}/{}/{}/{}",
-                                                                   x.origin,
-                                                                   x.name,
-                                                                   x.version.as_ref().unwrap(),
-                                                                   x.release.as_ref().unwrap())
-                                                       })
+                                                       .map(|x| format!("{}", x))
                                                        .collect(),
                                 tdeps:          archive.tdeps()
                                                        .unwrap_or_default()
                                                        .iter()
-                                                       .map(|x| {
-                                                           format!("{}/{}/{}/{}",
-                                                                   x.origin,
-                                                                   x.name,
-                                                                   x.version.as_ref().unwrap(),
-                                                                   x.release.as_ref().unwrap())
-                                                       })
+                                                       .map(|x| format!("{}", x))
                                                        .collect(),
                                 build_tdeps:    archive.build_tdeps()
                                                        .unwrap_or_default()
                                                        .iter()
-                                                       .map(|x| {
-                                                           format!("{}/{}/{}/{}",
-                                                                   x.origin,
-                                                                   x.name,
-                                                                   x.version.as_ref().unwrap(),
-                                                                   x.release.as_ref().unwrap())
-                                                       })
+                                                       .map(|x| format!("{}", x))
                                                        .collect(),
                                 exposes:        archive.exposes().unwrap_or_default(),
                                 manifest:       archive.manifest()?.to_string(),

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -543,8 +543,10 @@ mod test {
 
     #[test]
     fn reading_artifact_extended_metadata() {
-        let src = fixtures().join("unhappyhumans-possums-8.1.4-20160427165340-x86_64-linux.hart");
-        let info = PackageArchiveInfo::new(src).unwrap();
+        let hart =
+            PackageArchive::new(fixtures().join("unhappyhumans-possums-8.1.\
+                                                 4-20160427165340-x86_64-linux.hart")).unwrap();
+        let info = PackageArchiveInfo::from_path(hart.path).unwrap();
         assert_eq!(info.format_version, "HART-1");
         assert_eq!(info.key_name, "happyhumans-20160424223347");
         assert_eq!(info.hash_type, "BLAKE2b");
@@ -552,6 +554,7 @@ mod test {
         assert_eq!(info.target, target::X86_64_LINUX);
         assert_eq!(info.deps.len(), 0);
         assert_eq!(info.tdeps.len(), 1024);
+        assert_eq!(info.tdeps[0], "core/glibc/2.22/20160612063629");
     }
 
     pub fn root() -> PathBuf { PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests") }

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -419,6 +419,8 @@ pub trait FromArchive: Sized {
     fn from_archive(archive: &mut PackageArchive) -> result::Result<Self, Self::Error>;
 }
 
+// Exposes the extended metadata from a PackageArchive
+// for easier display or de-serialization.
 #[derive(Deserialize, Serialize)]
 pub struct PackageArchiveInfo {
     pub format_version:    String,
@@ -505,6 +507,19 @@ mod test {
         assert_eq!(ident.name, "possums");
         assert_eq!(ident.version, Some("8.1.4".to_string()));
         assert_eq!(ident.release, Some("20160427165340".to_string()));
+    }
+
+    #[test]
+    fn reading_artifact_extended_metadata() {
+        let src = fixtures().join("unhappyhumans-possums-8.1.4-20160427165340-x86_64-linux.hart");
+        let info = PackageArchiveInfo::new(src).unwrap();
+        assert_eq!(info.format_version, "HART-1");
+        assert_eq!(info.key_name, "happyhumans-20160424223347");
+        assert_eq!(info.hash_type, "BLAKE2b");
+        assert_eq!(info.signature_raw, "AgdmAKa9wr4ExnSWe5rg2VJh6cc2vOfyXCs3JOnsSm1XtmtQNhhON6fhgp0hW0xZkNcgXmC1lQ7w5WdZU0M4Bjg4MDVlNTU3NWFiOGMwMjllNmQyNTgyNjEzNzlmYmQwMmQ0YmIzZDkwZTIwNjg0N2Q0NTUzYTFiZjczOTVkNjU=");
+        assert_eq!(info.target, target::X86_64_LINUX);
+        assert_eq!(info.deps.len(), 0);
+        assert_eq!(info.tdeps.len(), 1024);
     }
 
     pub fn root() -> PathBuf { PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests") }

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -449,9 +449,9 @@ pub struct PackageArchiveInfo {
 
 impl PackageArchiveInfo {
     pub fn new(path: impl Into<PathBuf>) -> Result<Self> {
-        let path = path.into();
-        let mut archive = PackageArchive::new(path.clone())?;
-        let header = artifact::get_artifact_header(&path)?;
+        let src = path.into();
+        let mut archive = PackageArchive::new(src.clone())?;
+        let header = artifact::get_artifact_header(&src)?;
         let ident = archive.ident()?;
         Ok(PackageArchiveInfo { format_version:    header.format_version,
                                 key_name:          header.key_name,
@@ -464,6 +464,7 @@ impl PackageArchiveInfo {
                                 checksum:          archive.checksum().ok(),
                                 target:            archive.target()
                                                           .expect("pkg info archive target"),
+                                is_a_service:      archive.is_a_service(),
                                 deps:              archive.deps().unwrap_or_default(),
                                 build_deps:        archive.build_deps().unwrap_or_default(),
                                 tdeps:             archive.tdeps().unwrap_or_default(),
@@ -474,18 +475,17 @@ impl PackageArchiveInfo {
                                 manifest:
                                     archive.manifest()
                                            .map_or_else(|_| None, |v| Some(v.to_string())),
-                                config:            archive.config()
-                                                          .map(std::string::ToString::to_string),
                                 svc_user:
                                     archive.svc_user()
                                            .map_or_else(|_| None, |v| Some(v.to_string())),
+                                config:            archive.config()
+                                                          .map(std::string::ToString::to_string),
                                 ld_run_path:       archive.ld_run_path()
                                                           .map(std::string::ToString::to_string),
                                 ldflags:           archive.ldflags()
                                                           .map(std::string::ToString::to_string),
                                 cflags:            archive.cflags()
-                                                          .map(std::string::ToString::to_string),
-                                is_a_service:      archive.is_a_service(), })
+                                                          .map(std::string::ToString::to_string), })
     }
 }
 

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -419,7 +419,9 @@ pub trait FromArchive: Sized {
     fn from_archive(archive: &mut PackageArchive) -> result::Result<Self, Self::Error>;
 }
 
-// Exposes the extended archive and header metadata
+// Exposes the extended archive and header metadata. Types are stored as non habitat primitives
+// with the intent being ease of deserialization into content such as conveniently formatted json
+// at the client display layer.
 #[derive(Deserialize, Serialize)]
 pub struct PackageArchiveInfo {
     pub format_version: String,
@@ -431,7 +433,7 @@ pub struct PackageArchiveInfo {
     pub version:        String,
     pub release:        String,
     pub checksum:       String,
-    pub target:         PackageTarget,
+    pub target:         String,
     pub is_a_service:   bool,
     pub deps:           Vec<String>,
     pub tdeps:          Vec<String>,
@@ -465,7 +467,7 @@ impl PackageArchiveInfo {
                                 version:        ident.version.unwrap_or_default(),
                                 release:        ident.release.unwrap_or_default(),
                                 checksum:       archive.checksum()?,
-                                target:         archive.target()?,
+                                target:         format!("{}", archive.target()?),
                                 is_a_service:   archive.is_a_service(),
                                 deps:           archive.deps()
                                                        .unwrap_or_default()
@@ -525,7 +527,7 @@ mod test {
         assert_eq!(info.key_name, "happyhumans-20160424223347");
         assert_eq!(info.hash_type, "BLAKE2b");
         assert_eq!(info.signature_raw, "AgdmAKa9wr4ExnSWe5rg2VJh6cc2vOfyXCs3JOnsSm1XtmtQNhhON6fhgp0hW0xZkNcgXmC1lQ7w5WdZU0M4Bjg4MDVlNTU3NWFiOGMwMjllNmQyNTgyNjEzNzlmYmQwMmQ0YmIzZDkwZTIwNjg0N2Q0NTUzYTFiZjczOTVkNjU=");
-        assert_eq!(info.target, target::X86_64_LINUX);
+        assert_eq!(info.target, "x86_64-linux");
         assert_eq!(info.deps.len(), 0);
         assert_eq!(info.tdeps.len(), 1024);
         assert_eq!(info.tdeps[0], "core/glibc/2.22/20160612063629");

--- a/components/core/src/package/archive.rs
+++ b/components/core/src/package/archive.rs
@@ -213,13 +213,7 @@ impl PackageArchive {
     //
     // See https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
     #[allow(clippy::wrong_self_convention)]
-    pub fn is_a_service(&mut self) -> bool {
-        if let Some(_user) = self.svc_user() {
-            true
-        } else {
-            false
-        }
-    }
+    pub fn is_a_service(&mut self) -> bool { self.svc_user().is_some() }
 
     /// Returns a list of package identifiers representing the runtime package dependencies for
     /// this archive.

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -295,7 +295,7 @@ impl From<FullyQualifiedPackageIdent> for PackageIdent {
 /// Represents a fully-qualified Package Identifier, meaning that the normally optional version and
 /// release package coordinates are guaranteed to be set. This fully-qualified-ness is checked on
 /// construction and as the underlying representation is immutable, this state does not change.
-#[derive(Eq, PartialEq, PartialOrd, Debug, Clone, Hash)]
+#[derive(Eq, PartialEq, PartialOrd, Debug, Clone, Hash, Serialize, Deserialize)]
 pub struct FullyQualifiedPackageIdent(PackageIdent);
 
 impl FullyQualifiedPackageIdent {

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -751,7 +751,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
             (@subcommand info =>
                 (about: "Returns the Habitat Artifact information")
                 (aliases: &["inf", "info"])
-                (@arg TO_JSON: -j --json "Output will be rendered in json")
+                (@arg TO_JSON: -j --json "Output will be rendered in json. (Includes extended metadata)")
                 (@arg SOURCE: +required +takes_value {file_exists} "A path to a Habitat Artifact \
                     (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)")
             )

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -267,7 +267,7 @@ pub enum Pkg {
     },
     /// Returns the Habitat Artifact information
     Info {
-        /// Output will be rendered in json
+        /// Output will be rendered in json. (Includes extended metadata)
         #[structopt(name = "TO_JSON", short = "j", long = "json")]
         to_json: bool,
         /// A path to a Habitat Artifact (ex:

--- a/components/hab/src/command/pkg/info.rs
+++ b/components/hab/src/command/pkg/info.rs
@@ -1,32 +1,107 @@
 use crate::{common::ui::{UIWriter,
                          UI},
-            error::Result,
-            hcore::package::PackageArchive};
+            error::{Error,
+                    Result},
+            hcore::{crypto::artifact,
+                    package::{PackageArchive,
+                              PackageIdent,
+                              PackageTarget}}};
 use serde::Serialize;
 use serde_json::{self,
                  Value as Json};
 use std::path::Path;
 
-fn convert_to_json<T>(src: &T) -> Json
+#[derive(Deserialize, Serialize)]
+struct PackageArchiveInfo {
+    format_version:    String,
+    key_name:          String,
+    hash_type:         String,
+    signature_raw:     String,
+    origin:            String,
+    name:              String,
+    version:           Option<String>,
+    release:           Option<String>,
+    checksum:          Option<String>,
+    target:            PackageTarget,
+    is_a_service:      bool,
+    deps:              Vec<PackageIdent>,
+    tdeps:             Vec<PackageIdent>,
+    build_deps:        Vec<PackageIdent>,
+    build_tdeps:       Vec<PackageIdent>,
+    exposes:           Vec<u16>,
+    pkg_services:      Vec<PackageIdent>,
+    resolved_services: Vec<PackageIdent>,
+    manifest:          Option<String>,
+    config:            Option<String>,
+    svc_user:          Option<String>,
+    ld_run_path:       Option<String>,
+    ldflags:           Option<String>,
+    cflags:            Option<String>,
+}
+
+fn convert_to_json<T>(src: &T) -> Result<Json>
     where T: Serialize
 {
-    serde_json::to_value(src).unwrap_or(Json::Null)
+    serde_json::to_value(src).map_err(|e| habitat_core::Error::RenderContextSerialization(e).into())
 }
 
 pub fn start(ui: &mut UI, src: &Path, to_json: bool) -> Result<()> {
-    let ident = PackageArchive::new(src)?.ident()?;
+    let header = artifact::get_artifact_header(src)?;
+    let mut archive = PackageArchive::new(src)?;
+    let ident = archive.ident()?;
+    let info =
+        PackageArchiveInfo { format_version:    header.format_version,
+                             key_name:          header.key_name,
+                             hash_type:         header.hash_type,
+                             signature_raw:     header.signature_raw,
+                             origin:            ident.origin.clone(),
+                             name:              ident.name.clone(),
+                             version:           ident.version,
+                             release:           ident.release,
+                             checksum:          archive.checksum().ok(),
+                             target:            archive.target().expect("pkg info archive target"),
+                             deps:              archive.deps().unwrap_or(Vec::new()),
+                             build_deps:        archive.build_deps().unwrap_or(Vec::new()),
+                             tdeps:             archive.tdeps().unwrap_or(Vec::new()),
+                             build_tdeps:       archive.build_tdeps().unwrap_or(Vec::new()),
+                             exposes:           archive.exposes().unwrap_or(Vec::new()),
+                             pkg_services:      archive.pkg_services().unwrap_or(Vec::new()),
+                             resolved_services: archive.resolved_services().unwrap_or(Vec::new()),
+                             manifest:
+                                 archive.manifest()
+                                        .map_or_else(|_| None, |v| Some(v.to_string())),
+                             config:            archive.config().and_then(|v| Some(v.to_string())),
+                             svc_user:
+                                 archive.svc_user()
+                                        .map_or_else(|_| None, |v| Some(v.to_string())),
+                             ld_run_path:       archive.ld_run_path()
+                                                       .and_then(|v| Some(v.to_string())),
+                             ldflags:           archive.ldflags().and_then(|v| Some(v.to_string())),
+                             cflags:            archive.cflags().and_then(|v| Some(v.to_string())),
+                             is_a_service:      archive.is_a_service(), };
 
     if to_json {
-        println!("{}", convert_to_json(&ident));
+        match convert_to_json(&info) {
+            Ok(content) => {
+                println!("{}", content);
+                return Ok(());
+            }
+            Err(e) => {
+                ui.fatal(format!("Failed to deserialize into json! {:?}.", e))?;
+                return Err(Error::from(e));
+            }
+        }
     } else {
         ui.begin(format!("Reading PackageIdent from {}", &src.display()))?;
         ui.para("")?;
 
         println!("Package Path   : {}", &src.display());
-        println!("Origin         : {}", &ident.origin);
-        println!("Name           : {}", &ident.name);
-        println!("Version        : {}", &ident.version.unwrap());
-        println!("Release        : {}", &ident.release.unwrap());
+        println!("Origin         : {}", info.origin);
+        println!("Name           : {}", info.name);
+        println!("Version        : {}",
+                 info.version.unwrap_or("".to_string()));
+        println!("Release        : {}",
+                 info.release.unwrap_or("".to_string()));
     }
     Ok(())
 }

--- a/components/hab/src/command/pkg/info.rs
+++ b/components/hab/src/command/pkg/info.rs
@@ -69,13 +69,17 @@ pub fn start(ui: &mut UI, src: &Path, to_json: bool) -> Result<()> {
                              manifest:
                                  archive.manifest()
                                         .map_or_else(|_| None, |v| Some(v.to_string())),
-                             config:            archive.config().map(|v| v.to_string()),
+                             config:            archive.config()
+                                                       .map(std::string::ToString::to_string),
                              svc_user:
                                  archive.svc_user()
                                         .map_or_else(|_| None, |v| Some(v.to_string())),
-                             ld_run_path:       archive.ld_run_path().map(|v| v.to_string()),
-                             ldflags:           archive.ldflags().map(|v| v.to_string()),
-                             cflags:            archive.cflags().map(|v| v.to_string()),
+                             ld_run_path:       archive.ld_run_path()
+                                                       .map(std::string::ToString::to_string),
+                             ldflags:           archive.ldflags()
+                                                       .map(std::string::ToString::to_string),
+                             cflags:            archive.cflags()
+                                                       .map(std::string::ToString::to_string),
                              is_a_service:      archive.is_a_service(), };
 
     if to_json {

--- a/components/hab/src/command/pkg/info.rs
+++ b/components/hab/src/command/pkg/info.rs
@@ -14,7 +14,7 @@ fn convert_to_json<T>(src: &T) -> Result<Json>
 }
 
 pub fn start(ui: &mut UI, src: &Path, to_json: bool) -> Result<()> {
-    let info = PackageArchiveInfo::new(src)?;
+    let info = PackageArchiveInfo::from_path(src)?;
 
     if to_json {
         match convert_to_json(&info) {
@@ -34,10 +34,8 @@ pub fn start(ui: &mut UI, src: &Path, to_json: bool) -> Result<()> {
         println!("Package Path   : {}", &src.display());
         println!("Origin         : {}", info.origin);
         println!("Name           : {}", info.name);
-        println!("Version        : {}",
-                 info.version.unwrap_or_else(|| "".to_string()));
-        println!("Release        : {}",
-                 info.release.unwrap_or_else(|| "".to_string()));
+        println!("Version        : {}", info.version);
+        println!("Release        : {}", info.release);
     }
     Ok(())
 }

--- a/components/hab/src/command/pkg/info.rs
+++ b/components/hab/src/command/pkg/info.rs
@@ -1,7 +1,6 @@
 use crate::{common::ui::{UIWriter,
                          UI},
-            error::{Error,
-                    Result},
+            error::Result,
             hcore::{crypto::artifact,
                     package::{PackageArchive,
                               PackageIdent,
@@ -60,24 +59,23 @@ pub fn start(ui: &mut UI, src: &Path, to_json: bool) -> Result<()> {
                              release:           ident.release,
                              checksum:          archive.checksum().ok(),
                              target:            archive.target().expect("pkg info archive target"),
-                             deps:              archive.deps().unwrap_or(Vec::new()),
-                             build_deps:        archive.build_deps().unwrap_or(Vec::new()),
-                             tdeps:             archive.tdeps().unwrap_or(Vec::new()),
-                             build_tdeps:       archive.build_tdeps().unwrap_or(Vec::new()),
-                             exposes:           archive.exposes().unwrap_or(Vec::new()),
-                             pkg_services:      archive.pkg_services().unwrap_or(Vec::new()),
-                             resolved_services: archive.resolved_services().unwrap_or(Vec::new()),
+                             deps:              archive.deps().unwrap_or_default(),
+                             build_deps:        archive.build_deps().unwrap_or_default(),
+                             tdeps:             archive.tdeps().unwrap_or_default(),
+                             build_tdeps:       archive.build_tdeps().unwrap_or_default(),
+                             exposes:           archive.exposes().unwrap_or_default(),
+                             pkg_services:      archive.pkg_services().unwrap_or_default(),
+                             resolved_services: archive.resolved_services().unwrap_or_default(),
                              manifest:
                                  archive.manifest()
                                         .map_or_else(|_| None, |v| Some(v.to_string())),
-                             config:            archive.config().and_then(|v| Some(v.to_string())),
+                             config:            archive.config().map(|v| v.to_string()),
                              svc_user:
                                  archive.svc_user()
                                         .map_or_else(|_| None, |v| Some(v.to_string())),
-                             ld_run_path:       archive.ld_run_path()
-                                                       .and_then(|v| Some(v.to_string())),
-                             ldflags:           archive.ldflags().and_then(|v| Some(v.to_string())),
-                             cflags:            archive.cflags().and_then(|v| Some(v.to_string())),
+                             ld_run_path:       archive.ld_run_path().map(|v| v.to_string()),
+                             ldflags:           archive.ldflags().map(|v| v.to_string()),
+                             cflags:            archive.cflags().map(|v| v.to_string()),
                              is_a_service:      archive.is_a_service(), };
 
     if to_json {
@@ -88,7 +86,7 @@ pub fn start(ui: &mut UI, src: &Path, to_json: bool) -> Result<()> {
             }
             Err(e) => {
                 ui.fatal(format!("Failed to deserialize into json! {:?}.", e))?;
-                return Err(Error::from(e));
+                return Err(e);
             }
         }
     } else {
@@ -99,9 +97,9 @@ pub fn start(ui: &mut UI, src: &Path, to_json: bool) -> Result<()> {
         println!("Origin         : {}", info.origin);
         println!("Name           : {}", info.name);
         println!("Version        : {}",
-                 info.version.unwrap_or("".to_string()));
+                 info.version.unwrap_or_else(|| "".to_string()));
         println!("Release        : {}",
-                 info.release.unwrap_or("".to_string()));
+                 info.release.unwrap_or_else(|| "".to_string()));
     }
     Ok(())
 }


### PR DESCRIPTION
All the extra goodies are in the `--json` content.  This is a backwards compatible change.
The primary use-case is for programmatic consumption via automation in pipelines, et. al. 

Signed-off-by: Jeremy J. Miller <jm@chef.io>