### PR TITLE
delete old objects in S3 bucket that do not exist in local website build

### DIFF
--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -122,11 +122,6 @@ s3_channel_url_root() {
     echo "s3://${s3_bucket_name}/${channel}/latest/habitat"
 }
 
-s3_sync() {
-    # ex. s3_sync "src" "dst" "option1" "option2 <value>" ...
-    aws s3 sync "$@"
-}
-
 purge_fastly_cache() {
 	local service_key="${1}"
 	local channel="${2:-}"

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -123,9 +123,8 @@ s3_channel_url_root() {
 }
 
 s3_sync() {
-	local src="${1}"
-	local dst="${2}"
-	aws s3 sync "${src}" "${dst}"
+    # ex. s3_sync "src" "dst" "option1" "option2 <value>" ...
+    aws s3 sync "$@"
 }
 
 purge_fastly_cache() {

--- a/.expeditor/scripts/website-deploy.sh
+++ b/.expeditor/scripts/website-deploy.sh
@@ -30,7 +30,7 @@ done
 cd www
 make build
 cd build
-s3_sync "." "s3://$AWS_BUCKET" "--delete"
+aws s3 sync . "s3://$AWS_BUCKET" --delete
 # This is purging the cache for either www.habitat.sh or www.acceptance.habitat.sh,
 # depending on which service key was provided.
 purge_fastly_cache "$FASTLY_SERVICE_KEY"

--- a/.expeditor/scripts/website-deploy.sh
+++ b/.expeditor/scripts/website-deploy.sh
@@ -30,7 +30,7 @@ done
 cd www
 make build
 cd build
-s3_sync "." "s3://$AWS_BUCKET"
+s3_sync "." "s3://$AWS_BUCKET" "--delete"
 # This is purging the cache for either www.habitat.sh or www.acceptance.habitat.sh,
 # depending on which service key was provided.
 purge_fastly_cache "$FASTLY_SERVICE_KEY"


### PR DESCRIPTION
We would like to ensure that the sync of content from each new website build removes files that exist in the S3 bucket but do not exist in the local build. 

From https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html#options

> --delete (boolean) Files that exist in the destination but not in the source are deleted during sync.

Signed-off-by: Jeremy J. Miller <jm@chef.io>