### PR TITLE
Update configopt version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ checksum = "370c83b49aedf022ee27942e8ae1d9de1cf40dc9653ee6550e4455d08f6406f9"
 [[package]]
 name = "configopt"
 version = "0.1.0"
-source = "git+https://github.com/davidMcneil/configopt.git#35a0f18b07da10c530f41afe92ed2f0d7df4a892"
+source = "git+https://github.com/davidMcneil/configopt.git#8c937d8c20f53bfa61c26fe0506482525af06257"
 dependencies = [
  "colosseum",
  "configopt-derive",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "configopt-derive"
 version = "0.1.0"
-source = "git+https://github.com/davidMcneil/configopt.git#35a0f18b07da10c530f41afe92ed2f0d7df4a892"
+source = "git+https://github.com/davidMcneil/configopt.git#8c937d8c20f53bfa61c26fe0506482525af06257"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,7 @@ checksum = "370c83b49aedf022ee27942e8ae1d9de1cf40dc9653ee6550e4455d08f6406f9"
 [[package]]
 name = "configopt"
 version = "0.1.0"
-source = "git+https://github.com/davidMcneil/configopt.git#8c937d8c20f53bfa61c26fe0506482525af06257"
+source = "git+https://github.com/davidMcneil/configopt.git#152ed46d71d38a2a592c8f412ebacadeed1fc19d"
 dependencies = [
  "colosseum",
  "configopt-derive",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "configopt-derive"
 version = "0.1.0"
-source = "git+https://github.com/davidMcneil/configopt.git#8c937d8c20f53bfa61c26fe0506482525af06257"
+source = "git+https://github.com/davidMcneil/configopt.git#152ed46d71d38a2a592c8f412ebacadeed1fc19d"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/components/hab/tests/test_install_script.bats
+++ b/components/hab/tests/test_install_script.bats
@@ -1,6 +1,7 @@
 setup() {
   if [ -n "$CI" ]; then
     rm -f /bin/hab
+    rm -f /usr/bin/hab
     rm -rf /hab/pkgs/core/hab
   else
     echo "Not running in CI, skipping cleanup"


### PR DESCRIPTION
The previous version of `configopt` had a problem manifesting specifically in failing end-to-end tests that invoked `hab svc update $ORIGIN/$PACKAGE --bind` (that is, passing an empty value for `--bind` as a way to _remove_ binds from a running service).

Also addresses an unrelated failing CI test that manifested recently.