### PR TITLE
Ignore unreadable keys when exporting (among other uses)

### DIFF
--- a/components/core/src/crypto/keys.rs
+++ b/components/core/src/crypto/keys.rs
@@ -284,14 +284,9 @@ fn get_key_revisions<P>(keyname: &str,
         check_filename(keyname, &filename, &mut candidates, pair_type);
     }
 
-    // traverse the candidates set and sort the entries
-    let mut candidate_vec = Vec::new();
-    for c in &candidates {
-        candidate_vec.push(c.clone());
-    }
+    let mut candidate_vec = candidates.into_iter().collect::<Vec<String>>();
     candidate_vec.sort();
-    // newest key first
-    candidate_vec.reverse();
+    candidate_vec.reverse(); // newest key first
     Ok(candidate_vec)
 }
 

--- a/components/core/src/crypto/keys.rs
+++ b/components/core/src/crypto/keys.rs
@@ -237,13 +237,10 @@ fn get_key_revisions<P>(keyname: &str,
                       })?;
 
     for result in dir_entries {
-        let dir_entry = match result {
-            Ok(ref dir_entry) => dir_entry,
-            Err(e) => {
-                debug!("Error reading path {}", e);
-                return Err(Error::CryptoError(format!("Error reading key path {}", e)));
-            }
-        };
+        let dir_entry = result.map_err(|e| {
+                                  debug!("Error reading path {}", e);
+                                  Error::CryptoError(format!("Error reading key path {}", e))
+                              })?;
 
         // NB: this metadata() call traverses symlinks, which is
         // exactly what we want.

--- a/components/core/src/crypto/keys.rs
+++ b/components/core/src/crypto/keys.rs
@@ -156,7 +156,7 @@ impl<P: PartialEq, S: PartialEq> KeyPair<P, S> {
 fn check_filename(keyname: &str,
                   filename: &str,
                   candidates: &mut HashSet<String>,
-                  pair_type: Option<&PairType>) {
+                  pair_type: Option<PairType>) {
     let caps = match KEYFILE_RE.captures(&filename) {
         Some(c) => c,
         None => {
@@ -203,12 +203,12 @@ fn check_filename(keyname: &str,
         let thiskey = format!("{}-{}", name, rev);
 
         let do_insert = match pair_type {
-            Some(&PairType::Secret) => {
+            Some(PairType::Secret) => {
                 suffix == SECRET_SIG_KEY_SUFFIX
                 || suffix == SECRET_BOX_KEY_SUFFIX
                 || suffix == SECRET_SYM_KEY_SUFFIX
             }
-            Some(&PairType::Public) => suffix == PUBLIC_KEY_SUFFIX,
+            Some(PairType::Public) => suffix == PUBLIC_KEY_SUFFIX,
             None => true,
         };
 
@@ -222,7 +222,7 @@ fn check_filename(keyname: &str,
 /// keyname in the `cache_key_path`.
 fn get_key_revisions<P>(keyname: &str,
                         cache_key_path: P,
-                        pair_type: Option<&PairType>,
+                        pair_type: Option<PairType>,
                         key_type: &KeyType)
                         -> Result<Vec<String>>
     where P: AsRef<Path>
@@ -665,7 +665,7 @@ mod test {
                                                    .unwrap();
         let revs = super::get_key_revisions("foo",
                                             cache.path(),
-                                            Some(&PairType::Secret),
+                                            Some(PairType::Secret),
                                             &KeyType::Sig).unwrap();
         assert_eq!(2, revs.len());
     }
@@ -681,7 +681,7 @@ mod test {
                                                    .unwrap();
         let revs = super::get_key_revisions("foo",
                                             cache.path(),
-                                            Some(&PairType::Public),
+                                            Some(PairType::Public),
                                             &KeyType::Sig).unwrap();
         assert_eq!(2, revs.len());
     }
@@ -849,15 +849,15 @@ mod test {
         super::check_filename("wecoyote",
                               "wecoyote-20160519203610.pub",
                               &mut candidates,
-                              Some(&PairType::Secret));
+                              Some(PairType::Secret));
         super::check_filename("wecoyote",
                               "wecoyote-foo-20160519203610.pub",
                               &mut candidates,
-                              Some(&PairType::Secret));
+                              Some(PairType::Secret));
         super::check_filename("wecoyote",
                               "wecoyote-20160519203610.sig.key",
                               &mut candidates,
-                              Some(&PairType::Secret));
+                              Some(PairType::Secret));
         assert_eq!(1, candidates.len());
     }
 
@@ -868,15 +868,15 @@ mod test {
         super::check_filename("wecoyote",
                               "wecoyote-20160519203610.pub",
                               &mut candidates,
-                              Some(&PairType::Public));
+                              Some(PairType::Public));
         super::check_filename("wecoyote",
                               "wecoyote-20160519203611.pub",
                               &mut candidates,
-                              Some(&PairType::Public));
+                              Some(PairType::Public));
         super::check_filename("wecoyote",
                               "wecoyote-20160519203610.sig.key",
                               &mut candidates,
-                              Some(&PairType::Public));
+                              Some(PairType::Public));
         assert_eq!(2, candidates.len());
     }
 

--- a/components/core/src/crypto/keys.rs
+++ b/components/core/src/crypto/keys.rs
@@ -106,13 +106,13 @@ impl Drop for TmpKeyfile {
 #[derive(Clone, PartialEq)]
 pub struct KeyPair<P: PartialEq, S: PartialEq> {
     /// The name of the key, ex: "habitat"
-    pub name:   String,
+    name:   String,
     /// The revision of the key, which is a timestamp, ex: "201604051449"
-    pub rev:    String,
+    rev:    String,
     /// The public key component, if relevant
-    pub public: Option<P>,
+    public: Option<P>,
     /// The private key component, if relevant
-    pub secret: Option<S>,
+    secret: Option<S>,
 }
 
 impl<P: PartialEq, S: PartialEq> KeyPair<P, S> {

--- a/components/core/src/crypto/keys.rs
+++ b/components/core/src/crypto/keys.rs
@@ -229,16 +229,13 @@ fn get_key_revisions<P>(keyname: &str,
 {
     // accumulator for files that match
     let mut candidates = HashSet::new();
-    let dir_entries = match fs::read_dir(cache_key_path.as_ref()) {
-        Ok(dir_entries) => dir_entries,
-        Err(e) => {
-            return Err(Error::CryptoError(format!("Error reading key directory \
-                                                   {}: {}",
-                                                  cache_key_path.as_ref()
-                                                                .display(),
-                                                  e)));
-        }
-    };
+
+    let dir_entries = fs::read_dir(cache_key_path.as_ref()).map_err(|e| {
+                          Error::CryptoError(format!("Error reading key directory {}: {}",
+                                                     cache_key_path.as_ref().display(),
+                                                     e))
+                      })?;
+
     for result in dir_entries {
         let dir_entry = match result {
             Ok(ref dir_entry) => dir_entry,

--- a/components/core/src/crypto/keys/box_key_pair.rs
+++ b/components/core/src/crypto/keys/box_key_pair.rs
@@ -93,7 +93,7 @@ impl BoxKeyPair {
               P: AsRef<Path>
     {
         let revisions =
-            get_key_revisions(name.as_ref(), cache_key_path.as_ref(), None, &KeyType::Box)?;
+            get_key_revisions(name.as_ref(), cache_key_path.as_ref(), None, KeyType::Box)?;
         let mut key_pairs = Vec::new();
         for name_with_rev in revisions {
             debug!("Attempting to read key name_with_rev {} for {}",

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -38,7 +38,7 @@ impl SigKeyPair {
                                                   cache_key_path: &P,
                                                   pair_type: Option<PairType>)
                                                   -> Result<Vec<Self>> {
-        let revisions = get_key_revisions(name, cache_key_path.as_ref(), pair_type, &KeyType::Sig)?;
+        let revisions = get_key_revisions(name, cache_key_path.as_ref(), pair_type, KeyType::Sig)?;
         debug!("revisions = {:?}", &revisions);
         let mut key_pairs = Vec::new();
         for name_with_rev in &revisions {

--- a/components/core/src/crypto/keys/sig_key_pair.rs
+++ b/components/core/src/crypto/keys/sig_key_pair.rs
@@ -36,7 +36,7 @@ impl SigKeyPair {
     /// The newest key is listed first in the Vec.
     pub fn get_pairs_for<P: AsRef<Path> + ?Sized>(name: &str,
                                                   cache_key_path: &P,
-                                                  pair_type: Option<&PairType>)
+                                                  pair_type: Option<PairType>)
                                                   -> Result<Vec<Self>> {
         let revisions = get_key_revisions(name, cache_key_path.as_ref(), pair_type, &KeyType::Sig)?;
         debug!("revisions = {:?}", &revisions);
@@ -82,7 +82,7 @@ impl SigKeyPair {
 
     pub fn get_latest_pair_for<P: AsRef<Path> + ?Sized>(name: &str,
                                                         cache_key_path: &P,
-                                                        pair_type: Option<&PairType>)
+                                                        pair_type: Option<PairType>)
                                                         -> Result<Self> {
         let mut all = Self::get_pairs_for(name, cache_key_path, pair_type)?;
         match all.len() {
@@ -390,11 +390,11 @@ mod test {
 
         // We should be able to count public and private keys separately
         let pairs =
-            SigKeyPair::get_pairs_for("unicorn", cache.path(), Some(&PairType::Secret)).unwrap();
+            SigKeyPair::get_pairs_for("unicorn", cache.path(), Some(PairType::Secret)).unwrap();
         assert_eq!(pairs.len(), 2);
 
         let pairs =
-            SigKeyPair::get_pairs_for("unicorn", cache.path(), Some(&PairType::Public)).unwrap();
+            SigKeyPair::get_pairs_for("unicorn", cache.path(), Some(PairType::Public)).unwrap();
         assert_eq!(pairs.len(), 2);
     }
 
@@ -464,7 +464,7 @@ mod test {
         p.to_pair_files(cache.path()).unwrap();
         let latest = SigKeyPair::get_latest_pair_for("unicorn",
                                                      cache.path(),
-                                                     Some(&PairType::Secret)).unwrap();
+                                                     Some(PairType::Secret)).unwrap();
         assert_eq!(latest.name, p.name);
         assert_eq!(latest.rev, p.rev);
     }
@@ -476,7 +476,7 @@ mod test {
         p.to_pair_files(cache.path()).unwrap();
         let latest = SigKeyPair::get_latest_pair_for("unicorn",
                                                      cache.path(),
-                                                     Some(&PairType::Public)).unwrap();
+                                                     Some(PairType::Public)).unwrap();
         assert_eq!(latest.name, p.name);
         assert_eq!(latest.rev, p.rev);
     }

--- a/components/core/src/crypto/keys/sym_key.rs
+++ b/components/core/src/crypto/keys/sym_key.rs
@@ -37,7 +37,7 @@ impl SymKey {
     pub fn get_pairs_for<P: AsRef<Path> + ?Sized>(name: &str,
                                                   cache_key_path: &P)
                                                   -> Result<Vec<Self>> {
-        let revisions = get_key_revisions(name, cache_key_path.as_ref(), None, &KeyType::Sym)?;
+        let revisions = get_key_revisions(name, cache_key_path.as_ref(), None, KeyType::Sym)?;
         let mut key_pairs = Vec::new();
         for name_with_rev in &revisions {
             debug!("Attempting to read key name_with_rev {} for {}",

--- a/components/hab/src/command/origin/key/export.rs
+++ b/components/hab/src/command/origin/key/export.rs
@@ -8,15 +8,15 @@ use crate::hcore::crypto::{keys::PairType,
 use crate::error::Result;
 
 pub fn start(origin: &str, pair_type: PairType, cache: &Path) -> Result<()> {
-    let latest = SigKeyPair::get_latest_pair_for(origin, cache, Some(&pair_type))?;
+    let latest = SigKeyPair::get_latest_pair_for(origin, cache, Some(pair_type))?;
     let path = match pair_type {
         PairType::Public => SigKeyPair::get_public_key_path(&latest.name_with_rev(), cache)?,
         PairType::Secret => SigKeyPair::get_secret_key_path(&latest.name_with_rev(), cache)?,
     };
     let mut file = File::open(&path)?;
     debug!("Streaming file contents of {} {} to standard out",
-           &pair_type,
-           &path.display());
+           pair_type,
+           path.display());
     io::copy(&mut file, &mut io::stdout())?;
     Ok(())
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1013,7 +1013,7 @@ fn sub_pkg_sign(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     init()?;
     let pair = SigKeyPair::get_latest_pair_for(&origin_param_or_env(&m)?,
                                                &cache_key_path,
-                                               Some(&PairType::Secret))?;
+                                               Some(PairType::Secret))?;
 
     command::pkg::sign::start(ui, &pair, &src, &dst)
 }


### PR DESCRIPTION
Previously, as we scanned all available keys looking for a specific one, the entire process would halt if any one of the keys was unreadable for any reason. Leaving aside how that might happen, it was unfortunate, in that an unrelated unreadable key could prevent finding the actual readable key you were looking for.

Here, we extract the file-checking logic to a separate function (with unit tests) for an increase in clarity, while also handling I/O errors by logging-and-continuing, rather than failing the entire search.

Fixes #7269