### PR TITLE
 [CI] Binlink `hab` earlier in the path for e2e tests

### DIFF
--- a/components/hab/tests/test_install_script.bats
+++ b/components/hab/tests/test_install_script.bats
@@ -1,6 +1,11 @@
 setup() {
   if [ -n "$CI" ]; then
+    # This is where our curlbash installer puts the link
     rm -f /bin/hab
+    # This is where our CI systems link Chef Workstation's `hab`
+    # binary. It comes earlier in the path than `/bin`, so we need to
+    # remove it. We don't use Workstation in our tests, so this is
+    # fine.
     rm -f /usr/bin/hab
     rm -rf /hab/pkgs/core/hab
   else


### PR DESCRIPTION
In our CI environment, `/usr/bin` comes ahead of `/bin` in the
path. We have Chef Workstation's `hab` binary linked to
`/usr/bin/hab`, which will mask anything we install and binlink to
`/bin/hab` by default.

Now, we link *our* `hab` into `/usr/bin`.

Additionally, we remove the `curlbash_hab` call when we set up our e2e
environment. That's only to get a `hab` on the box, but we'll already
have one because of the images and containers we're using in CI.

We also better document what the situation is in our
`test_install_script.bats` test.

Signed-off-by: Christopher Maier <cmaier@chef.io>

