### PR TITLE
[CI] Update changelog management labels in Expeditor config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -19,9 +19,9 @@ slack:
 
 changelog:
   categories:
-    - "X-change": "Behavioral Changes"
-    - "X-feature": "New Features & Enhancements"
-    - "X-fix": "Bug Fixes"
+    - "Changelog: Behavioral Change": "Behavioral Changes"
+    - "Changelog: New Feature": "New Features & Enhancements"
+    - "Changelog: Bug Fix": "Bug Fixes"
 
 pipelines:
   - verify:


### PR DESCRIPTION
We are updating our labeling scheme, and thus need to inform Expeditor
so it can continue to manage our Changelog appropriately.

Signed-off-by: Christopher Maier <cmaier@chef.io>