### PR TITLE
refactor account/sid/win_perms to not need to contact a domian controller

### DIFF
--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -931,7 +931,7 @@ fn create_process_as_user(credential: &ServiceCredential,
                                                         io::Error::last_os_error())));
         }
 
-        let sid = Sid::from_token(token)?;
+        let sid = Sid::logon_sid_from_token(token)?;
         sid.add_to_user_object(station as HANDLE,
                                sid::CONTAINER_INHERIT_ACE
                                | sid::INHERIT_ONLY_ACE

--- a/components/win-users/Cargo.toml
+++ b/components/win-users/Cargo.toml
@@ -15,4 +15,4 @@ log = "*"
 
 [target.'cfg(windows)'.dependencies]
 widestring = "*"
-winapi = { version = "*", features = ["winbase", "winerror", "handleapi", "sddl"] }
+winapi = { version = "*", features = ["winbase", "winerror", "handleapi", "sddl", "securitybaseapi"] }

--- a/components/win-users/src/account.rs
+++ b/components/win-users/src/account.rs
@@ -104,23 +104,6 @@ impl Account {
                        account_type: sid_type,
                        sid })
     }
-
-    pub fn machine() -> Account {
-        let name = env::var("COMPUTERNAME").expect("COMPUTERNAME env var");
-        Account::from_name(&name).expect("computer account")
-    }
-
-    pub fn built_in_administrators() -> Account {
-        // Use the SID string constant for the built in administrators
-        // https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-strings
-        Account::from_sid("BA").expect("local administrator account")
-    }
-
-    pub fn local_system() -> Account {
-        // Use the SID string constant for the local system
-        // https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-strings
-        Account::from_sid("SY").expect("local system account")
-    }
 }
 
 fn lookup_account(name: &str, system_name: Option<String>) -> Option<Account> {
@@ -244,48 +227,10 @@ mod tests {
 
     #[test]
     fn test_built_in_accounts() {
-        // Check the machine account
-        let machine = Account::machine();
-        assert_eq!(machine.name, machine.domain);
-        let machine_sid = machine.sid.to_string().expect("sid to string");
-        assert!(machine_sid.starts_with("S-1-5-21-"));
-
         // Check the local administrator account
         let administrator = Account::from_sid("LA").expect("Administrator account");
         assert_eq!(administrator.name, "Administrator");
-        assert_eq!(administrator.domain, machine.name);
-        assert_eq!(administrator.sid.to_string().expect("sid to string"),
-                   format!("{}-500", machine_sid));
-
-        // Check the built in administrators account
-        let administrators = Account::built_in_administrators();
-        assert_eq!(administrators.name, "Administrators");
-        assert_eq!(administrators.domain, "BUILTIN");
-        assert_eq!(administrators.sid.to_string().expect("sid to string"),
-                   "S-1-5-32-544");
-
-        // The built in administrators account should be identical to the account we get looking up
-        // the "Administrators" account by name
-        let a = Account::from_name("Administrators").expect("Administrators account");
-        assert_eq!(administrators.name, a.name);
-        assert_eq!(administrators.system_name, a.system_name);
-        assert_eq!(administrators.domain, a.domain);
-        assert_eq!(administrators.account_type, a.account_type);
-        assert_eq!(administrators.sid.raw, a.sid.raw);
-
-        // Check the system account
-        let system = Account::local_system();
-        assert_eq!(system.name, "SYSTEM");
-        assert_eq!(system.domain, "NT AUTHORITY");
-        assert_eq!(system.sid.to_string().expect("sid to string"), "S-1-5-18");
-
-        // The system account should be identical to the account we get looking up the
-        // "SYSTEM" account by name
-        let s = Account::from_name("SYSTEM").expect("SYSTEM account");
-        assert_eq!(system.name, s.name);
-        assert_eq!(system.system_name, s.system_name);
-        assert_eq!(system.domain, s.domain);
-        assert_eq!(system.account_type, s.account_type);
-        assert_eq!(system.sid.raw, s.sid.raw);
+        assert_eq!(administrator.domain,
+                   env::var("COMPUTERNAME").expect("COMPUTERNAME env var"));
     }
 }


### PR DESCRIPTION
fixes #7836

In some scenarios where a supervisor runs on a node that is domain joined, some account lookup functions may attempt to reach out to the domain controller for account information. In a scenario where a node is being provisioned or perhaps shortly after a
reboot, this may fail. However for the accounts that we typically deal with when setting folder ACLs, the information we need should not require ant DC interaction. We only need the SID and these are for "well known" users or the currently logged in user.

This PR simply retrieves the SIDs. There was also some refactoring of `Sid::from_current_user` which was previously plain wrong and fortunately not used, but it is used now. It was using the "logon SID" and not the user SID. The comments go into the details on what is a logon sid.

Signed-off-by: mwrock <matt@mattwrock.com>