### PR TITLE
Add splay to health check execution

### DIFF
--- a/components/core/src/service.rs
+++ b/components/core/src/service.rs
@@ -275,8 +275,8 @@ impl From<u64> for HealthCheckInterval {
     fn from(seconds: u64) -> Self { Self(Duration::from_secs(seconds)) }
 }
 
-impl Into<u64> for HealthCheckInterval {
-    fn into(self) -> u64 { self.0.as_secs() }
+impl From<HealthCheckInterval> for u64 {
+    fn from(h: HealthCheckInterval) -> Self { h.0.as_secs() }
 }
 
 impl fmt::Display for HealthCheckInterval {
@@ -297,6 +297,10 @@ impl FromStr for HealthCheckInterval {
 
 impl From<HealthCheckInterval> for Duration {
     fn from(h: HealthCheckInterval) -> Self { h.0 }
+}
+
+impl From<Duration> for HealthCheckInterval {
+    fn from(d: Duration) -> Self { Self(d) }
 }
 
 #[cfg(test)]

--- a/components/habitat-chef-io/content/habitat/application-lifecycle-hooks.md
+++ b/components/habitat-chef-io/content/habitat/application-lifecycle-hooks.md
@@ -29,10 +29,10 @@ Optionally you may add an extension to the hook file. For example, you might cre
 File location: `<plan>/hooks/file-updated`. This hook is run whenever a configuration file that is not related to a user or about the state of the service instances is updated.
 
 ### health-check
-File location: `<plan>/hooks/health-check`. This hook is run periodically on a configurable interval. There are two exceptions to the interval used between `health-check` runs:
+File location: `<plan>/hooks/health-check`. (Default: 30 seconds) This hook repeats at a configured interval. There are two exceptions to the interval used between `health-check` runs:
 
   - If the `health-check` hook exits with a non-`ok` status the next `health-check` will run after the default `health-check` interval (thirty seconds). This is only done when the configured interval is greater than the default interval.
-  - Following the first `ok` `health-check` the next `health-check` will run after a randomly chosen delay between zero and the configured interval. This is done to introduce splay between `health-check` runs.
+  - If the `health-check` hook returns an `ok` status for the first time, then the next `health-check` will run after a randomly chosen delay between 0 and the configured `health-check` interval. This introduces a splay - a degree of difference - in the timing between the first and second `health-check` runs. All following health-check hooks run at the configured interval. The splay prevents more than one health-check hook from starting at the same time by giving each of them a unique starting point.
 
 The `health-check` script must return a valid exit code from the list below.
 

--- a/components/habitat-chef-io/content/habitat/application-lifecycle-hooks.md
+++ b/components/habitat-chef-io/content/habitat/application-lifecycle-hooks.md
@@ -29,7 +29,10 @@ Optionally you may add an extension to the hook file. For example, you might cre
 File location: `<plan>/hooks/file-updated`. This hook is run whenever a configuration file that is not related to a user or about the state of the service instances is updated.
 
 ### health-check
-File location: `<plan>/hooks/health-check`. This hook is run when the Chef Habitat HTTP API receives a request at `/health`.
+File location: `<plan>/hooks/health-check`. This hook is run periodically on a configurable interval. There are two exceptions to the interval used between `health-check` runs:
+
+  - If the `health-check` hook exits with a non-`ok` status the next `health-check` will run after the default `health-check` interval (thirty seconds). This is only done when the configured interval is greater than the default interval.
+  - Following the first `ok` `health-check` the next `health-check` will run after a randomly chosen delay between zero and the configured interval. This is done to introduce splay between `health-check` runs.
 
 The `health-check` script must return a valid exit code from the list below.
 

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -196,9 +196,10 @@ pub fn check_repeatedly(supervisor: Arc<Mutex<Supervisor>>,
                     // the nominal interval
                     let splay = rand::thread_rng().gen_range(0, u64::from(nominal_interval));
                     let splay = Duration::from_secs(splay);
-                    debug!("Adding {}s of splay for {} health-checks",
-                           splay.as_secs(),
-                           service_group);
+                    debug!("Following `{}`'s first `ok` health-check, delaying a randomly chosen \
+                            {}s to introduce health-check splay",
+                           service_group,
+                           splay.as_secs());
                     first_successful_health_check = true;
                     splay.into()
                 } else {

--- a/www/source/docs/reference.html.md.erb
+++ b/www/source/docs/reference.html.md.erb
@@ -799,7 +799,10 @@ Optionally you may add an extension to the hook file. For example, you might cre
 File location: `<plan>/hooks/file-updated`. This hook is run whenever a configuration file that is not related to a user or about the state of the service instances is updated.
 
 #### health-check
-File location: `<plan>/hooks/health-check`. This hook is run periodically on a configurable interval.
+File location: `<plan>/hooks/health-check`. This hook is run periodically on a configurable interval. There are two exceptions to the interval used between `health-check` runs:
+
+  - If the `health-check` hook exits with a non-`ok` status the next `health-check` will run after the default `health-check` interval (thirty seconds). This is only done when the configured interval is greater than the default interval.
+  - Following the first `ok` `health-check` the next `health-check` will run after a randomly chosen delay between zero and the configured interval. This is done to introduce splay between `health-check` runs.
 
 The `health-check` script must return a valid exit code from the list below.
 

--- a/www/source/docs/reference.html.md.erb
+++ b/www/source/docs/reference.html.md.erb
@@ -799,10 +799,10 @@ Optionally you may add an extension to the hook file. For example, you might cre
 File location: `<plan>/hooks/file-updated`. This hook is run whenever a configuration file that is not related to a user or about the state of the service instances is updated.
 
 #### health-check
-File location: `<plan>/hooks/health-check`. This hook is run periodically on a configurable interval. There are two exceptions to the interval used between `health-check` runs:
+File location: `<plan>/hooks/health-check`. (Default: 30 seconds) This hook repeats at a configured interval. There are two exceptions to the interval used between `health-check` runs:
 
   - If the `health-check` hook exits with a non-`ok` status the next `health-check` will run after the default `health-check` interval (thirty seconds). This is only done when the configured interval is greater than the default interval.
-  - Following the first `ok` `health-check` the next `health-check` will run after a randomly chosen delay between zero and the configured interval. This is done to introduce splay between `health-check` runs.
+  - If the `health-check` hook returns an `ok` status for the first time, then the next `health-check` will run after a randomly chosen delay between 0 and the configured `health-check` interval. This introduces a splay - a degree of difference - in the timing between the first and second `health-check` runs. All following health-check hooks run at the configured interval. The splay prevents more than one health-check hook from starting at the same time by giving each of them a unique starting point.
 
 The `health-check` script must return a valid exit code from the list below.
 


### PR DESCRIPTION
Resolves #6867 

This PR adds splay to health check hooks runs following the first successful health check.

This is slightly different than what was discussed in standup which proposed adding splay to every health check run. I decided to only add splay following the first successful run because the health check interval is reported to automate. I also did not add a config value for the splay and instead simply used the health check interval. If we think an explicit interval would be useful I can add one.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>