### PR TITLE
[CI] Ensure GPG keys are imported before verifying manifest

### DIFF
--- a/.expeditor/scripts/expeditor_promote.sh
+++ b/.expeditor/scripts/expeditor_promote.sh
@@ -25,6 +25,7 @@ export HAB_BLDR_URL="${expeditor_hab_bldr_url}"
 
 ########################################################################
 # CORE LOGIC
+import_gpg_keys
 get_manifest_for_environment "${source_environment}"
 promote_packages_to_builder_channel manifest.json "${destination_channel}"
 


### PR DESCRIPTION
I'm not quite sure how this has worked until just now, but this
operation really should have been in place from the beginning.

Signed-off-by: Christopher Maier <cmaier@chef.io>