### PR TITLE
fallback to superuser root if home path cannot be found during license search

### DIFF
--- a/components/hab/src/license.rs
+++ b/components/hab/src/license.rs
@@ -133,8 +133,7 @@ fn user_license_root() -> PathBuf {
     if let Some(home) = dirs::home_dir() {
         home.join(".hab")
     } else {
-        panic!("No home directory available. Unable to find a suitable place to write a license \
-                file.");
+        superuser_license_root()
     }
 }
 


### PR DESCRIPTION
fixes #1852 

This uses the same logic we use everywhere else in our code base and uses the root location instead of the user location in the event there is a failure locating the `HOME` directory.

Signed-off-by: mwrock <matt@mattwrock.com>