### PR TITLE
[CI] Ensure that kernel2 packages get build appropriately

### DIFF
--- a/.expeditor/scripts/release_habitat/build_component.sh
+++ b/.expeditor/scripts/release_habitat/build_component.sh
@@ -27,18 +27,23 @@ import_keys
 echo "--- :zap: Cleaning up old studio, if present"
 ${hab_binary} studio rm
 
-echo "--- :habicat: Building components/${component}"
+echo "--- :habicat: Building components/${component} using ${hab_binary}"
 
 HAB_BLDR_CHANNEL="${channel}" ${hab_binary} pkg build "components/${component}"
 source results/last_build.env
 
-echo "--- :habicat: Uploading ${pkg_ident:?} to ${HAB_BLDR_URL} in the '${channel}' channel"
+if [ "${pkg_target}" != "${BUILD_PKG_TARGET}" ]; then
+    echo "--- :face_with_symbols_on_mouth: Expected to build for target ${BUILD_PKG_TARGET}, but built ${pkg_target} instead!"
+    exit 1
+fi
+
+echo "--- :habicat: Uploading ${pkg_ident:?} (${pkg_target}) to ${HAB_BLDR_URL} in the '${channel}' channel"
 ${hab_binary} pkg upload \
               --channel="${channel}" \
               --auth="${HAB_AUTH_TOKEN}" \
               --no-build \
               "results/${pkg_artifact:?}"
 
-echo "<br>* ${pkg_ident:?} (${BUILD_PKG_TARGET:?})" | buildkite-agent annotate --append --context "release-manifest"
+echo "<br>* ${pkg_ident} (${pkg_target})" | buildkite-agent annotate --append --context "release-manifest"
 
 set_target_metadata "${pkg_ident}" "${pkg_target}"

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -33,7 +33,7 @@ curlbash_hab() {
             exit 1
             ;;
     esac
-    echo "--- :habicat: Hab binary set to $hab_binary"
+    echo "--- :habicat: Hab binary set to $hab_binary (version: $(${hab_binary} --version))"
 }
 
 install_rustup() {


### PR DESCRIPTION
It seems that some recent changes in CI may have made it so that we
get `x86_64-linux` `hab` binaries running our builds for kernel2
packages, which, of course, results in not actually getting kernel2
packages.

I'm not yet clear on the mechanisms, but it seems we need to
explicitly use `${hab_binary}` rather than simply `hab` to run `hab
pkg path`, or else we get the wrong package back.

This PR does that, as well as cleans up logging, tightens up helper
function contracts around package targets, and adds a test that
ensures we are building the intended package target.

Signed-off-by: Christopher Maier <cmaier@chef.io>