### PR TITLE
fix launcher version parsing

### DIFF
--- a/components/launcher/habitat/plan.ps1
+++ b/components/launcher/habitat/plan.ps1
@@ -20,7 +20,8 @@ function Invoke-Prepare {
     }
 
     $env:SSL_CERT_FILE              = "$(Get-HabPackagePath "cacerts")/ssl/certs/cacert.pem"
-    $env:PLAN_VERSION               = "$pkg_version/$pkg_release"
+    $env:PLAN_VERSION               = "$pkg_version"
+    Write-BuildLine "Setting env:PLAN_VERSION=$env:PLAN_VERSION"
     $env:LIB                        += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/lib"
     $env:INCLUDE                    += ";$HAB_CACHE_SRC_PATH/$pkg_dirname/include"
 }

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -36,7 +36,7 @@ do_prepare() {
   export CARGO_TARGET_DIR="$HAB_CACHE_SRC_PATH/$pkg_dirname"
   build_line "Setting CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
   
-  export PLAN_VERSION="${pkg_version}/${pkg_release}"
+  export PLAN_VERSION="${pkg_version}"
   build_line "Setting PLAN_VERSION=$PLAN_VERSION"
 
   # Prost (our Rust protobuf library) embeds a `protoc` binary, but

--- a/components/launcher/src/server/handlers/version.rs
+++ b/components/launcher/src/server/handlers/version.rs
@@ -13,14 +13,18 @@ impl Handler for VersionHandler {
     fn handle(_: Self::Message, _: &mut ServiceTable) -> HandleResult<Self::Reply> {
         // VERSION will be none if this is a cargo built binary as opposed to
         // being built by our hab plan. So in that case we will fallback to u32::MAX.
-        match VERSION.unwrap_or(&u32::MAX.to_string()).parse::<u32>() {
-            Ok(version) => {
-                let reply = protocol::VersionNumber { version };
+        let max = u32::MAX.to_string();
+        let version = VERSION.unwrap_or(&max);
+        match version.parse::<u32>() {
+            Ok(v) => {
+                let reply = protocol::VersionNumber { version: v };
                 Ok(reply)
             }
-            Err(_) => {
+            Err(err) => {
+                let err_msg = format!("Unable to parse version {}: {}", version, err.to_string());
                 let mut reply = protocol::NetErr::default();
                 reply.code = protocol::ErrCode::InvalidVersionNumber;
+                reply.msg = err_msg;
                 Err(reply)
             }
         }


### PR DESCRIPTION
Removing release stamp from version which given out versioning scheme for launcher is not necessary and just hinders a straight forward integer based comparison. 

Signed-off-by: mwrock <matt@mattwrock.com>