### PR TITLE
fix e2e test with older launcher

### DIFF
--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -74,6 +74,7 @@ jemalloc-ctl = "*"
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "*"
+habitat-launcher-protocol = { path = "../launcher-protocol" }
 mio-named-pipes = "*"
 # Pinning for now. Since upgrading to 0.7.0 results in conflicts with other crates
 # See https://github.com/habitat-sh/habitat/issues/7522

--- a/test/end-to-end/test_supervisor_windows_service.ps1
+++ b/test/end-to-end/test_supervisor_windows_service.ps1
@@ -35,6 +35,7 @@ Describe "Habitat Windows Service" {
 
         AfterAll {
             hab svc unload core/nginx
+            Start-Sleep -Seconds 3 # tears
             Stop-Service Habitat
         }
     }


### PR DESCRIPTION
Fixes failing test because supervisor stops before unloading package.

This also allows supervisor to survive any error from the launcher when checking version. It was failing because of an `UnknownMessage NerErr`. I think breaking it down by timeout, UnknownMessage and other is over kill and we should just write out the error message.

Signed-off-by: mwrock <matt@mattwrock.com>