### PR TITLE
make bind timeout configurable and add debug output around startup

### DIFF
--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -226,6 +226,7 @@ impl Server {
                feature_flags: FeatureFlag,
                control: Arc<(Mutex<ServerStartup>, Condvar)>) {
         thread::spawn(move || {
+            debug!("Entering http_gateway run thread");
             let &(ref lock, ref cvar) = &*control;
             let thread_count = match henv::var(HTTP_THREADS_ENVVAR) {
                 Ok(val) => {
@@ -249,11 +250,13 @@ impl Server {
                              }).workers(thread_count);
 
             server = server.disable_signals();
+            debug!("http_gateway server configured");
 
             let bind = match tls_config {
                 Some(c) => server.bind_rustls(listen_addr.to_string(), c),
                 None => server.bind(listen_addr.to_string()),
             };
+            debug!("http_gateway server port bound");
 
             *lock.lock().expect("Control mutex is poisoned") = match bind {
                 Ok(_) => ServerStartup::Started,


### PR DESCRIPTION
fixes #7780 

This allows the hard coded 10 second timeout of the http_gateway to be configurable. At this point we want this to be fairly obscure just to allow users affected by #7780 to tune the timeout and determine if it indeed needs more time in their environment or if there might be something truly hanging their server. This also adds some debug messaging so that if it is hanging, we can get a better idea of where that hang might be occurring.

Signed-off-by: mwrock <matt@mattwrock.com>