### PR TITLE
fix license environment injection in container exporter

### DIFF
--- a/components/hab/src/license.rs
+++ b/components/hab/src/license.rs
@@ -67,7 +67,7 @@ impl LicenseData {
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum LicenseAcceptance {
     Accepted,
     /// Explicitly deny the license and do not prompt for license acceptance. This is useful for

--- a/components/pkg-export-container/src/build.rs
+++ b/components/pkg-export-container/src/build.rs
@@ -502,8 +502,8 @@ impl BuildRootContext {
                  })
                  .collect();
 
-        if !license::check_for_license_acceptance().unwrap_or_default()
-                                                   .accepted()
+        if license::check_for_license_acceptance().unwrap_or_default()
+                                                  .accepted()
         {
             environment.insert(String::from("HAB_LICENSE"),
                                String::from("accept-no-persist"));


### PR DESCRIPTION
Simple boolean switcheroo so that the license environment is injected into build environment.

Signed-off-by: mwrock <matt@mattwrock.com>