### PR TITLE
Improve error message when installing internal packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tabwriter",
  "tee",
  "tokio",
  "tokio-util 0.3.1",
@@ -1451,6 +1450,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sodiumoxide",
+ "tabwriter",
  "tar",
  "tempfile",
  "toml 0.5.6",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "retry"
 version = "1.0.0"
-source = "git+https://github.com/habitat-sh/retry#715ec21da9fb0d575c60be2eb51704610b551795"
+source = "git+https://github.com/habitat-sh/retry#955385fba7da7a2f1bf1f8d7d2f2b33bd173a7b6"
 dependencies = [
  "rand 0.7.3",
  "tokio",

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -78,7 +78,6 @@ pub enum Error {
         hook:          &'static str,
         error:         CommandExecutionError,
     },
-    InterpreterNotFound(PackageIdent, Box<Self>),
     InvalidEventStreamToken(String),
     /// Occurs when making lower level IO calls.
     IO(io::Error),
@@ -91,6 +90,7 @@ pub enum Error {
     OfflineArtifactNotFound(PackageIdent),
     OfflineOriginKeyNotFound(String),
     OfflinePackageNotFound(PackageIdent),
+    PackageFailedToInstall(PackageIdent, Box<Self>),
     PackageNotFound(String),
     /// Occurs upon errors related to file or directory permissions.
     PermissionFailed(String),
@@ -175,9 +175,6 @@ impl fmt::Display for Error {
                                 ref error, } => {
                 format!("{} {} hook failed: {}", package_ident, hook, error)
             }
-            Error::InterpreterNotFound(ref ident, ref e) => {
-                format!("Unable to install interpreter ident: {} - {}", ident, e)
-            }
             Error::InvalidEventStreamToken(ref s) => {
                 format!("Invalid event stream token provided: '{}'", s)
             }
@@ -200,6 +197,9 @@ impl fmt::Display for Error {
                 format!("No installed package or cached artifact could be found locally in \
                          offline mode: {}",
                         ident)
+            }
+            Error::PackageFailedToInstall(ref ident, ref e) => {
+                format!("Failed to install package {} - {}", ident, e)
             }
             Error::PackageNotFound(ref e) => format!("Package not found. {}", e),
             Error::PermissionFailed(ref e) => e.to_string(),

--- a/components/common/src/util/path.rs
+++ b/components/common/src/util/path.rs
@@ -111,7 +111,9 @@ async fn interpreter_paths() -> Result<Vec<PathBuf>> {
                                                      InstallHookMode::default()).await
                     {
                         Ok(pkg_install) => pkg_install.paths()?,
-                        Err(err) => return Err(Error::InterpreterNotFound(ident, Box::new(err))),
+                        Err(err) => {
+                            return Err(Error::PackageFailedToInstall(ident, Box::new(err)))
+                        }
                     }
                 }
             }

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -18,6 +18,7 @@ use crate::{common::{self,
                     ChannelIdent},
             PRODUCT,
             VERSION};
+use habitat_common::error::Error as CommonError;
 use retry::delay;
 use std::path::PathBuf;
 
@@ -89,7 +90,7 @@ pub async fn command_from_min_pkg(ui: &mut UI,
                                                          &LocalPackageUsage::default(),
                                                          InstallHookMode::default()).await
             }).await
-              .map_err(|_| Error::ExecCommandNotFound(command.clone()))?
+              .map_err(|e| CommonError::PackageFailedToInstall(ident.clone(), Box::new(e.error)))?
         }
         Err(e) => return Err(Error::from(e)),
     };


### PR DESCRIPTION
When trying to install internal packages (eg `hab pkg export tar`) we always mapped the install error to `Error::ExecCommandNotFound`. This was very confusing if the error was a result of something other than not being able to find the command. For example if you did not have permission to install the package. In this case the error used to be `hab-pkg-export-tar' was not found on the filesystem or in PATH` it is now `Failed to install package core/hab-pkg-export-tar - Permission denied (os error 13)`.

A few thoughts on error handling in general:

1. Should `package::install::start` simply return `PackageFailedToInstall` instead of needing to map it to that type. This raises the larger question of where/when/how errors should be handled.
2. We have a lot of error types and variants. If we get the opportunity it might be worth trying to consolidate some of these and ensuring that our errors have complete and relevant information.
 

Signed-off-by: David McNeil <mcneil.david2@gmail.com>