### PR TITLE
Remove custom cli parsing

### DIFF
--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -3,6 +3,7 @@ pub mod hab;
 
 use crate::{cli::hab::{origin::Rbac,
                        pkg::ExportCommand,
+                       studio::Studio,
                        sup::{Sup,
                              SupRun},
                        svc::{BulkLoad as SvcBulkLoad,
@@ -843,12 +844,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
             (subcommand: sub_svc_stop().aliases(&["sto"]))
             (subcommand: sub_svc_unload().aliases(&["u", "un", "unl", "unlo", "unloa"]))
         )
-        (@subcommand studio =>
-            (about: "Commands relating to Habitat Studios")
-            (aliases: &["stu", "stud", "studi"])
-            (@setting ArgRequiredElseHelp)
-            (@setting SubcommandRequiredElseHelp)
-        )
+        (subcommand: Studio::clap().aliases(&["stu", "stud", "studi"]))
         (@subcommand supportbundle =>
             (about: "Create a tarball of Habitat Supervisor data to send to support")
             (aliases: &["supp", "suppo", "suppor", "support-bundle"])

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -2,7 +2,8 @@ pub mod gateway_util;
 pub mod hab;
 
 use crate::{cli::hab::{origin::Rbac,
-                       pkg::ExportCommand,
+                       pkg::{ExportCommand,
+                             PkgExec},
                        studio::Studio,
                        sup::{Sup,
                              SupRun},
@@ -559,16 +560,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                 (@arg PKG_IDENT: +required +takes_value {valid_ident}
                     "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
             )
-            (@subcommand exec =>
-                (about: "Executes a command using the 'PATH' context of an installed package")
-                (aliases: &["exe"])
-                (@arg PKG_IDENT: +required +takes_value {valid_ident}
-                    "A package identifier (ex: core/redis, core/busybox-static/1.42.2)")
-                (@arg CMD: +required +takes_value
-                    "The command to execute (ex: ls)")
-                (@arg ARGS: +takes_value +multiple
-                    "Arguments to the command (ex: -l /tmp)")
-            )
+            (subcommand: PkgExec::clap())
             (subcommand: ExportCommand::clap())
             (@subcommand hash =>
                 (about: "Generates a blake2b hashsum from a target at any given filepath")

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -5,7 +5,7 @@ use crate::{cli::hab::{origin::Rbac,
                        pkg::{ExportCommand,
                              PkgExec},
                        studio::Studio,
-                       sup::{Sup,
+                       sup::{HabSup,
                              SupRun},
                        svc::{BulkLoad as SvcBulkLoad,
                              Load as SvcLoad,
@@ -815,7 +815,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                 )
             )
         )
-        (subcommand: Sup::clap())
+        (subcommand: HabSup::clap())
         (@subcommand svc =>
             (about: "Commands relating to Habitat services")
             (aliases: &["sv", "ser", "serv", "service"])

--- a/components/hab/src/cli.rs
+++ b/components/hab/src/cli.rs
@@ -836,7 +836,7 @@ pub fn get(feature_flags: FeatureFlag) -> App<'static, 'static> {
                     (arg: arg_cache_key_path())
                 )
             )
-            (subcommand: SvcLoad::clap().aliases(&["l", "lo", "loa"]))
+            (subcommand: SvcLoad::clap())
             (subcommand: SvcUpdate::clap())
             (subcommand: sub_svc_start().aliases(&["star"]))
             (subcommand: sub_svc_status().aliases(&["stat", "statu"]))

--- a/components/hab/src/cli/hab.rs
+++ b/components/hab/src/cli/hab.rs
@@ -87,7 +87,7 @@ pub enum Hab {
     Plan(Plan),
     #[structopt(no_version)]
     Ring(Ring),
-    #[structopt(no_version)]
+    #[structopt(no_version, aliases = &["stu", "stud", "studi"])]
     Studio(Studio),
     #[structopt(no_version)]
     Sup(HabSup),

--- a/components/hab/src/cli/hab.rs
+++ b/components/hab/src/cli/hab.rs
@@ -20,7 +20,9 @@ use self::{bldr::{Bldr,
            cli::{Cli,
                  ConfigOptCli},
            config::{ConfigOptServiceConfig,
-                    ServiceConfig},
+                    ConfigOptServiceConfigApply,
+                    ServiceConfig,
+                    ServiceConfigApply},
            file::{ConfigOptFile,
                   File},
            license::{ConfigOptLicense,
@@ -28,20 +30,31 @@ use self::{bldr::{Bldr,
            origin::{ConfigOptOrigin,
                     Origin},
            pkg::{ConfigOptPkg,
-                 Pkg},
+                 ConfigOptPkgInstall,
+                 Pkg,
+                 PkgInstall},
            plan::{ConfigOptPlan,
                   Plan},
            ring::{ConfigOptRing,
                   Ring},
            studio::{ConfigOptStudio,
                     Studio},
-           sup::{ConfigOptSup,
-                 Sup},
+           sup::{ConfigOptHabSup,
+                 ConfigOptSupRun,
+                 HabSup,
+                 SupRun},
            svc::{ConfigOptSvc,
-                 Svc},
+                 ConfigOptSvcStart,
+                 ConfigOptSvcStop,
+                 Svc,
+                 SvcStart,
+                 SvcStop},
            user::{ConfigOptUser,
-                  User}};
-use crate::VERSION;
+                  User},
+           util::{CacheKeyPath,
+                  ConfigOptCacheKeyPath}};
+use crate::{cli::AFTER_HELP,
+            VERSION};
 use configopt::ConfigOpt;
 use structopt::{clap::AppSettings,
                 StructOpt};
@@ -52,6 +65,7 @@ use structopt::{clap::AppSettings,
             about = "\"A Habitat is the natural environment for your services\" - Alan Turing",
             author = "\nThe Habitat Maintainers <humans@habitat.sh>\n",
             settings = &[AppSettings::GlobalVersion],
+            after_help = AFTER_HELP
         )]
 #[allow(clippy::large_enum_variant)]
 pub enum Hab {
@@ -76,7 +90,7 @@ pub enum Hab {
     #[structopt(no_version)]
     Studio(Studio),
     #[structopt(no_version)]
-    Sup(Sup),
+    Sup(HabSup),
     /// Create a tarball of Habitat Supervisor data to send to support
     #[structopt(no_version)]
     Supportbundle,
@@ -84,4 +98,26 @@ pub enum Hab {
     Svc(Svc),
     #[structopt(no_version)]
     User(User),
+
+    /// Alias for 'config apply'
+    #[structopt(no_version, settings = &[AppSettings::Hidden])]
+    Apply(ServiceConfigApply),
+    /// Alias for 'pkg install'
+    #[structopt(no_version, settings = &[AppSettings::Hidden])]
+    Install(PkgInstall),
+    /// Alias for 'sup run'
+    #[structopt(no_version, settings = &[AppSettings::Hidden])]
+    Run(SupRun),
+    /// Alias for 'cli setup'
+    #[structopt(no_version, settings = &[AppSettings::Hidden])]
+    Setup(CacheKeyPath),
+    /// Alias for 'svc start'
+    #[structopt(no_version, settings = &[AppSettings::Hidden])]
+    Start(SvcStart),
+    /// Alias for 'svc stop'
+    #[structopt(no_version, settings = &[AppSettings::Hidden])]
+    Stop(SvcStop),
+    /// Alias for 'sup term'
+    #[structopt(no_version, settings = &[AppSettings::Hidden])]
+    Term,
 }

--- a/components/hab/src/cli/hab.rs
+++ b/components/hab/src/cli/hab.rs
@@ -2,12 +2,12 @@ mod bldr;
 mod cli;
 mod config;
 mod file;
-mod license;
+pub mod license;
 pub mod origin;
 pub mod pkg;
 mod plan;
 mod ring;
-mod studio;
+pub mod studio;
 pub mod sup;
 pub mod svc;
 #[cfg(test)]

--- a/components/hab/src/cli/hab/config.rs
+++ b/components/hab/src/cli/hab/config.rs
@@ -13,26 +13,7 @@ use structopt::StructOpt;
 #[structopt(no_version)]
 /// Commands relating to a Service's runtime config
 pub enum ServiceConfig {
-    /// Sets a configuration to be shared by members of a Service Group
-    Apply {
-        /// Target service group service.group[@organization] (ex: redis.default or
-        /// foo.default@bazcorp)
-        #[structopt(name = "SERVICE_GROUP")]
-        service_group:  ServiceGroup,
-        /// A version number (positive integer) for this configuration (ex: 42)
-        #[structopt(name = "VERSION_NUMBER")]
-        version_number: i64,
-        /// Path to local file on disk (ex: /tmp/config.toml, default: <stdin>)
-        #[structopt(name = "FILE", validator = file_exists_or_stdin)]
-        file:           Option<String>,
-        /// Name of a user key to use for encryption
-        #[structopt(name = "USER", short = "u", long = "user")]
-        user:           Option<String>,
-        #[structopt(flatten)]
-        remote_sup:     RemoteSup,
-        #[structopt(flatten)]
-        cache_key_path: CacheKeyPath,
-    },
+    Apply(ServiceConfigApply),
     /// Displays the default configuration options for a service
     Show {
         #[structopt(flatten)]
@@ -40,4 +21,27 @@ pub enum ServiceConfig {
         #[structopt(flatten)]
         remote_sup: RemoteSup,
     },
+}
+
+/// Sets a configuration to be shared by members of a Service Group
+#[derive(ConfigOpt, StructOpt)]
+#[structopt(no_version, rename_all = "screamingsnake")]
+pub struct ServiceConfigApply {
+    /// Target service group service.group[@organization] (ex: redis.default or
+    /// foo.default@bazcorp)
+    #[structopt()]
+    service_group:  ServiceGroup,
+    /// A version number (positive integer) for this configuration (ex: 42)
+    #[structopt()]
+    version_number: i64,
+    /// Path to local file on disk (ex: /tmp/config.toml, default: <stdin>)
+    #[structopt(validator = file_exists_or_stdin)]
+    file:           Option<String>,
+    /// Name of a user key to use for encryption
+    #[structopt(short = "u", long = "user")]
+    user:           Option<String>,
+    #[structopt(flatten)]
+    remote_sup:     RemoteSup,
+    #[structopt(flatten)]
+    cache_key_path: CacheKeyPath,
 }

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -259,48 +259,7 @@ pub enum Pkg {
         #[structopt(name = "SOURCE", validator = file_exists)]
         source:  PathBuf,
     },
-    /// Installs a Habitat package from Builder or locally from a Habitat Artifact
-    Install {
-        #[structopt(flatten)]
-        bldr_url:              BldrUrl,
-        /// Install from the specified release channel
-        #[structopt(name = "CHANNEL",
-                    short = "c",
-                    long = "channel",
-                    default_value = "stable",
-                    env = ChannelIdent::ENVVAR)]
-        channel:               String,
-        /// One or more Habitat package identifiers (ex: acme/redis) and/or filepaths to a Habitat
-        /// Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
-        #[structopt(name = "PKG_IDENT_OR_ARTIFACT", required = true)]
-        pkg_ident_or_artifact: Vec<String>,
-        /// Binlink all binaries from installed package(s) into BINLINK_DIR
-        #[structopt(name = "BINLINK", short = "b", long = "binlink")]
-        binlink:               bool,
-        /// Binlink all binaries from installed package(s) into BINLINK_DIR
-        #[structopt(name = "BINLINK_DIR",
-                    long = "binlink-dir",
-                    default_value = DEFAULT_BINLINK_DIR,
-                    env = BINLINK_DIR_ENVVAR)]
-        binlink_dir:           PathBuf,
-        /// Overwrite existing binlinks
-        #[structopt(name = "FORCE", short = "f", long = "force")]
-        force:                 bool,
-        #[structopt(flatten)]
-        auth_token:            AuthToken,
-        /// Do not run any install hooks
-        #[structopt(name = "IGNORE_INSTALL_HOOK", long = "ignore-install-hook")]
-        ignore_install_hook:   bool,
-        /// Install packages in offline mode
-        #[structopt(name = "OFFLINE", long = "offline",
-                    hidden = !FEATURE_FLAGS.contains(FeatureFlag::OFFLINE_INSTALL))]
-        offline:               bool,
-        /// Do not use locally-installed packages when a corresponding package cannot be installed
-        /// from Builder
-        #[structopt(name = "IGNORE_LOCAL", long = "ignore-local",
-                    hidden = !FEATURE_FLAGS.contains(FeatureFlag::IGNORE_LOCAL))]
-        ignore_local:          bool,
-    },
+    Install(PkgInstall),
     /// List all versions of installed packages
     List(List),
     /// Prints the path to a specific installed release of a package
@@ -420,6 +379,49 @@ pub enum Pkg {
         #[structopt(flatten)]
         cache_key_path: CacheKeyPath,
     },
+}
+
+/// Installs a Habitat package from Builder or locally from a Habitat Artifact
+#[derive(ConfigOpt, StructOpt)]
+#[structopt(no_version, rename_all = "screamingsnake")]
+pub struct PkgInstall {
+    #[structopt(flatten)]
+    bldr_url:              BldrUrl,
+    /// Install from the specified release channel
+    #[structopt(short = "c",
+                long = "channel",
+                default_value = "stable",
+                env = ChannelIdent::ENVVAR)]
+    channel:               String,
+    /// One or more Habitat package identifiers (ex: acme/redis) and/or filepaths to a Habitat
+    /// Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
+    #[structopt(required = true)]
+    pkg_ident_or_artifact: Vec<String>,
+    /// Binlink all binaries from installed package(s) into BINLINK_DIR
+    #[structopt(short = "b", long = "binlink")]
+    binlink:               bool,
+    /// Binlink all binaries from installed package(s) into BINLINK_DIR
+    #[structopt(long = "binlink-dir",
+                default_value = DEFAULT_BINLINK_DIR,
+                env = BINLINK_DIR_ENVVAR)]
+    binlink_dir:           PathBuf,
+    /// Overwrite existing binlinks
+    #[structopt(short = "f", long = "force")]
+    force:                 bool,
+    #[structopt(flatten)]
+    auth_token:            AuthToken,
+    /// Do not run any install hooks
+    #[structopt(long = "ignore-install-hook")]
+    ignore_install_hook:   bool,
+    /// Install packages in offline mode
+    #[structopt(long = "offline",
+                hidden = !FEATURE_FLAGS.contains(FeatureFlag::OFFLINE_INSTALL))]
+    offline:               bool,
+    /// Do not use locally-installed packages when a corresponding package cannot be installed
+    /// from Builder
+    #[structopt(long = "ignore-local",
+                hidden = !FEATURE_FLAGS.contains(FeatureFlag::IGNORE_LOCAL))]
+    ignore_local:          bool,
 }
 
 /// Exports the package to the specified format

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -5,9 +5,11 @@ use super::util::{AuthToken,
                   ConfigOptBldrUrl,
                   ConfigOptCacheKeyPath,
                   ConfigOptExternalCommandArgs,
+                  ConfigOptExternalCommandArgsWithHelpAndVersion,
                   ConfigOptFullyQualifiedPkgIdent,
                   ConfigOptPkgIdent,
                   ExternalCommandArgs,
+                  ExternalCommandArgsWithHelpAndVersion,
                   FullyQualifiedPkgIdent,
                   PkgIdent};
 use crate::cli::{dir_exists,
@@ -223,17 +225,7 @@ pub enum Pkg {
         #[structopt(flatten)]
         pkg_ident: PkgIdent,
     },
-    /// Executes a command using the 'PATH' context of an installed package
-    Exec {
-        #[structopt(flatten)]
-        pkg_ident: PkgIdent,
-        /// The command to execute (ex: ls)
-        #[structopt(name = "CMD")]
-        cmd:       String,
-        /// Arguments to the command (ex: -l /tmp)
-        #[structopt(name = "ARGS")]
-        args:      Vec<String>,
-    },
+    Exec(PkgExec),
     Export(ExportCommand),
     /// Generates a blake2b hashsum from a target at any given filepath
     Hash {
@@ -379,6 +371,19 @@ pub enum Pkg {
         #[structopt(flatten)]
         cache_key_path: CacheKeyPath,
     },
+}
+
+/// Executes a command using the 'PATH' context of an installed package
+#[derive(ConfigOpt, StructOpt)]
+#[structopt(name = "exec", no_version, rename_all = "screamingsnake")]
+pub struct PkgExec {
+    #[structopt(flatten)]
+    pub pkg_ident: PkgIdent,
+    /// The command to execute (ex: ls)
+    #[structopt()]
+    pub cmd:       PathBuf,
+    #[structopt(flatten)]
+    pub args:      ExternalCommandArgsWithHelpAndVersion,
 }
 
 /// Installs a Habitat package from Builder or locally from a Habitat Artifact

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -375,7 +375,7 @@ pub enum Pkg {
 
 /// Executes a command using the 'PATH' context of an installed package
 #[derive(ConfigOpt, StructOpt)]
-#[structopt(name = "exec", no_version, rename_all = "screamingsnake")]
+#[structopt(name = "exec", aliases = &["exe"], no_version, rename_all = "screamingsnake")]
 pub struct PkgExec {
     #[structopt(flatten)]
     pub pkg_ident: PkgIdent,
@@ -431,7 +431,7 @@ pub struct PkgInstall {
 
 /// Exports the package to the specified format
 #[derive(ConfigOpt, StructOpt)]
-#[structopt(name = "export", no_version)]
+#[structopt(name = "export", aliases = &["e", "ex", "exp", "expo", "expor"], no_version)]
 pub enum ExportCommand {
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     /// Cloud Foundry exporter

--- a/components/hab/src/cli/hab/studio.rs
+++ b/components/hab/src/cli/hab/studio.rs
@@ -1,7 +1,17 @@
+use super::util::{ConfigOptExternalCommandArgs,
+                  ExternalCommandArgs};
 use configopt::ConfigOpt;
+use std::ffi::OsString;
 use structopt::StructOpt;
 
 #[derive(ConfigOpt, StructOpt)]
-#[structopt(no_version)]
+#[structopt(name = "studio", no_version)]
 /// Commands relating to Habitat Studios
-pub enum Studio {}
+pub struct Studio {
+    #[structopt(flatten)]
+    args: ExternalCommandArgs,
+}
+
+impl Studio {
+    pub fn args(&self) -> &[OsString] { &self.args.args }
+}

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -45,7 +45,7 @@ use structopt::{clap::AppSettings,
 pub enum HabSup {
     /// Depart a Supervisor from the gossip ring; kicking and banning the target from joining again
     /// with the same member-id
-    #[structopt(no_version)]
+    #[structopt(no_version, aliases = &["d", "de", "dep", "depa", "depart"])]
     Depart {
         /// The member-id of the Supervisor to depart
         #[structopt(name = "MEMBER_ID")]
@@ -53,10 +53,10 @@ pub enum HabSup {
         #[structopt(flatten)]
         remote_sup: RemoteSup,
     },
-    #[structopt(no_version)]
+    #[structopt(no_version, aliases = &["sec", "secr"])]
     Secret(Secret),
     /// Query the status of Habitat services
-    #[structopt(no_version)]
+    #[structopt(no_version, aliases = &["stat", "statu"])]
     Status {
         /// A package identifier (ex: core/redis, core/busybox-static/1.42.2)
         #[structopt(name = "PKG_IDENT")]
@@ -79,15 +79,15 @@ pub enum HabSup {
 #[allow(clippy::large_enum_variant)]
 pub enum Sup {
     /// Start an interactive Bash-like shell
-    #[structopt(no_version)]
+    #[structopt(no_version, aliases = &["b", "ba", "bas"])]
     Bash,
-    #[structopt(no_version)]
+    #[structopt(no_version, aliases = &["r", "ru"])]
     Run(SupRun),
     /// Start an interactive Bourne-like shell
     #[structopt(no_version)]
     Sh,
     /// Gracefully terminate the Habitat Supervisor and all of its running services
-    #[structopt(no_version)]
+    #[structopt(no_version, aliases = &["ter"])]
     Term,
 }
 

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -40,7 +40,7 @@ use structopt::{clap::AppSettings,
 // All commands relating to the Supervisor (ie commands handled by both the `hab` and `hab-sup`
 // binary)
 #[derive(ConfigOpt, StructOpt)]
-#[structopt(no_version)]
+#[structopt(no_version, name = "sup")]
 #[allow(clippy::large_enum_variant)]
 pub enum HabSup {
     /// Depart a Supervisor from the gossip ring; kicking and banning the target from joining again

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -37,19 +37,12 @@ use std::{fmt,
 use structopt::{clap::AppSettings,
                 StructOpt};
 
+// All commands relating to the Supervisor (ie commands handled by both the `hab` and `hab-sup`
+// binary)
 #[derive(ConfigOpt, StructOpt)]
-#[structopt(name = "hab",
-            version = VERSION,
-            about = "The Habitat Supervisor",
-            author = "\nThe Habitat Maintainers <humans@habitat.sh>\n",
-            usage = "hab sup <SUBCOMMAND>",
-            settings = &[AppSettings::VersionlessSubcommands],
-        )]
+#[structopt(no_version)]
 #[allow(clippy::large_enum_variant)]
-pub enum Sup {
-    /// Start an interactive Bash-like shell
-    #[structopt(usage = "hab sup bash", no_version)]
-    Bash,
+pub enum HabSup {
     /// Depart a Supervisor from the gossip ring; kicking and banning the target from joining again
     /// with the same member-id
     #[structopt(no_version)]
@@ -60,14 +53,8 @@ pub enum Sup {
         #[structopt(flatten)]
         remote_sup: RemoteSup,
     },
-    /// Run the Habitat Supervisor
-    #[structopt(no_version)]
-    Run(SupRun),
     #[structopt(no_version)]
     Secret(Secret),
-    /// Start an interactive Bourne-like shell
-    #[structopt(usage = "hab sup sh", no_version)]
-    Sh,
     /// Query the status of Habitat services
     #[structopt(no_version)]
     Status {
@@ -77,8 +64,30 @@ pub enum Sup {
         #[structopt(flatten)]
         remote_sup: RemoteSup,
     },
+    #[structopt(flatten)]
+    Sup(Sup),
+}
+
+// Supervisor commands handled by the `hab-sup` binary
+#[derive(ConfigOpt, StructOpt)]
+#[structopt(name = "sup",
+            version = VERSION,
+            about = "The Habitat Supervisor",
+            author = "\nThe Habitat Maintainers <humans@habitat.sh>\n",
+            settings = &[AppSettings::VersionlessSubcommands],
+        )]
+#[allow(clippy::large_enum_variant)]
+pub enum Sup {
+    /// Start an interactive Bash-like shell
+    #[structopt(no_version)]
+    Bash,
+    #[structopt(no_version)]
+    Run(SupRun),
+    /// Start an interactive Bourne-like shell
+    #[structopt(no_version)]
+    Sh,
     /// Gracefully terminate the Habitat Supervisor and all of its running services
-    #[structopt(usage = "hab sup term [OPTIONS]", no_version)]
+    #[structopt(no_version)]
     Term,
 }
 
@@ -106,6 +115,7 @@ fn parse_peer(s: &str) -> io::Result<SocketAddr> {
     util::socket_addr_with_default_port(s, GossipListenAddr::DEFAULT_PORT)
 }
 
+/// Run the Habitat Supervisor
 #[configopt_fields]
 #[derive(ConfigOpt, StructOpt, Deserialize)]
 #[configopt(attrs(serde), default_config_file("/hab/sup/default/config/sup.toml"))]

--- a/components/hab/src/cli/hab/svc.rs
+++ b/components/hab/src/cli/hab/svc.rs
@@ -45,6 +45,7 @@ pub enum Svc {
     Update(Update),
     Start(SvcStart),
     /// Query the status of Habitat services
+    #[structopt(aliases = &["stat", "statu"])]
     Status {
         /// A package identifier (ex: core/redis, core/busybox-static/1.42.2)
         #[structopt(name = "PKG_IDENT")]
@@ -249,7 +250,7 @@ fn load_default_config_files() -> Vec<PathBuf> {
             derive(Clone, Debug),
             default_config_file(load_default_config_files))]
 #[serde(deny_unknown_fields)]
-#[structopt(name = "load", no_version, rename_all = "screamingsnake")]
+#[structopt(name = "load", aliases = &["l", "lo", "loa"], no_version, rename_all = "screamingsnake")]
 /// Load a service to be started and supervised by Habitat from a package identifier. If an
 /// installed package doesn't satisfy the given package identifier, a suitable package will be
 /// installed from Builder.

--- a/components/hab/src/cli/hab/svc.rs
+++ b/components/hab/src/cli/hab/svc.rs
@@ -43,13 +43,7 @@ pub enum Svc {
     Load(Load),
     #[structopt(no_version)]
     Update(Update),
-    /// Start a loaded, but stopped, Habitat service.
-    Start {
-        #[structopt(flatten)]
-        pkg_ident:  PkgIdent,
-        #[structopt(flatten)]
-        remote_sup: RemoteSup,
-    },
+    Start(SvcStart),
     /// Query the status of Habitat services
     Status {
         /// A package identifier (ex: core/redis, core/busybox-static/1.42.2)
@@ -58,19 +52,7 @@ pub enum Svc {
         #[structopt(flatten)]
         remote_sup: RemoteSup,
     },
-    /// Stop a running Habitat service.
-    Stop {
-        #[structopt(flatten)]
-        pkg_ident:        PkgIdent,
-        #[structopt(flatten)]
-        remote_sup:       RemoteSup,
-        /// The delay in seconds after sending the shutdown signal to wait before killing the
-        /// service process
-        ///
-        /// The default value is set in the packages plan file.
-        #[structopt(name = "SHUTDOWN_TIMEOUT", long = "shutdown-timeout")]
-        shutdown_timeout: Option<ShutdownTimeout>,
-    },
+    Stop(SvcStop),
     /// Unload a service loaded by the Habitat Supervisor. If the service is running it will
     /// additionally be stopped.
     Unload {
@@ -103,6 +85,32 @@ pub struct BulkLoad {
     #[structopt(long = "svc-config-paths",
                 default_value = "/hab/sup/default/config/svc")]
     pub svc_config_paths: Vec<PathBuf>,
+}
+
+/// Start a loaded, but stopped, Habitat service.
+#[derive(ConfigOpt, StructOpt)]
+#[structopt(no_version, rename_all = "screamingsnake")]
+pub struct SvcStart {
+    #[structopt(flatten)]
+    pkg_ident:  PkgIdent,
+    #[structopt(flatten)]
+    remote_sup: RemoteSup,
+}
+
+/// Stop a running Habitat service.
+#[derive(ConfigOpt, StructOpt)]
+#[structopt(no_version, rename_all = "screamingsnake")]
+pub struct SvcStop {
+    #[structopt(flatten)]
+    pkg_ident:        PkgIdent,
+    #[structopt(flatten)]
+    remote_sup:       RemoteSup,
+    /// The delay in seconds after sending the shutdown signal to wait before killing the
+    /// service process
+    ///
+    /// The default value is set in the packages plan file.
+    #[structopt(name = "SHUTDOWN_TIMEOUT", long = "shutdown-timeout")]
+    shutdown_timeout: Option<ShutdownTimeout>,
 }
 
 #[derive(ConfigOpt, StructOpt)]

--- a/components/hab/src/cli/hab/tests.rs
+++ b/components/hab/src/cli/hab/tests.rs
@@ -409,22 +409,9 @@ fn test_hab_help() {
     let env = lock_service_config_files();
     env.set("1");
 
-    let mut hab1 = cli::get(feature_flags_for_cli_test()).after_help("");
-    // Remove the subcommand aliases
-    hab1.p.subcommands.truncate(hab1.p.subcommands.len() - 7);
-    let mut hab2 = cli::get(feature_flags_for_cli_test_with_structopt()).after_help("");
+    let mut hab1 = cli::get(feature_flags_for_cli_test());
+    let mut hab2 = cli::get(feature_flags_for_cli_test_with_structopt());
     compare(&mut hab1, &mut hab2, "hab");
-}
-
-#[test]
-fn test_sup_run_help() {
-    habitat_core::locked_env_var!(HAB_FEAT_SERVICE_CONFIG_FILES, lock_service_config_files);
-    let env = lock_service_config_files();
-    env.set("1");
-
-    let mut sup1 = cli::sub_sup_run(feature_flags_for_cli_test()).after_help("");
-    let mut sup2 = cli::sub_sup_run(feature_flags_for_cli_test_with_structopt()).after_help("");
-    compare(&mut sup1, &mut sup2, "sup");
 }
 
 fn extract_hab_svc_load(hab: Hab) -> Load {

--- a/components/hab/src/cli/hab/util.rs
+++ b/components/hab/src/cli/hab/util.rs
@@ -235,6 +235,7 @@ impl fmt::Display for DurationProxy {
 }
 
 #[derive(ConfigOpt, StructOpt)]
+#[configopt(derive(Serialize))]
 #[structopt(no_version, rename_all = "screamingsnake",
             settings = &[AppSettings::TrailingVarArg,
                         AppSettings::AllowLeadingHyphen,

--- a/components/hab/src/cli/hab/util.rs
+++ b/components/hab/src/cli/hab/util.rs
@@ -112,7 +112,7 @@ lazy_static! {
 }
 
 #[derive(ConfigOpt, StructOpt, Debug, Deserialize)]
-#[configopt(derive(Debug), attrs(serde))]
+#[configopt(derive(Serialize, Debug), attrs(serde))]
 #[serde(deny_unknown_fields)]
 #[structopt(no_version, rename_all = "screamingsnake")]
 pub struct CacheKeyPath {
@@ -171,7 +171,7 @@ pub struct FullyQualifiedPkgIdent {
 }
 
 #[derive(ConfigOpt, StructOpt, Deserialize, Debug)]
-#[configopt(derive(Clone, Debug))]
+#[configopt(derive(Serialize, Clone, Debug))]
 #[structopt(no_version)]
 pub struct RemoteSup {
     /// Address to a remote Supervisor's Control Gateway

--- a/components/hab/src/cli/hab/util.rs
+++ b/components/hab/src/cli/hab/util.rs
@@ -234,15 +234,46 @@ impl fmt::Display for DurationProxy {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", u64::from(*self)) }
 }
 
+// Collect trailing arguments to pass to an external command
+//
+// This disables help and version flags for the subcommand. Making it easy to check the help or
+// version of the external command. See `ExternalCommandArgsWithHelpAndVersion` for more details.
 #[derive(ConfigOpt, StructOpt)]
 #[configopt(derive(Serialize))]
 #[structopt(no_version, rename_all = "screamingsnake",
             settings = &[AppSettings::TrailingVarArg,
-                        AppSettings::AllowLeadingHyphen,
-                        AppSettings::DisableHelpFlags,
-                        AppSettings::DisableHelpSubcommand,
-                        AppSettings::DisableVersion])]
+                         AppSettings::AllowLeadingHyphen,
+                         AppSettings::DisableHelpFlags,
+                         AppSettings::DisableHelpSubcommand,
+                         AppSettings::DisableVersion
+                        ])]
 pub struct ExternalCommandArgs {
+    /// Arguments to the command
+    #[structopt(parse(from_os_str), takes_value = true, multiple = true)]
+    pub args: Vec<OsString>,
+}
+
+// Collect trailing arguments to pass to an external command
+//
+// This is useful when you have a subcommand that has more arguments than just "external command
+// args" because it allows showing the help of the subcommand. Consider:
+//
+// 1. hab pkg exec --help
+// 2. hab pkg exec core/redis ls --help
+// 3. hab pkg exec core/redis ls -- --help
+//
+// If we were to use `ExternalCommandArgs` #1 would produce an error due to missing args instead of
+// displaying the help because the help is disabled. #2 is ambiguous. Should it show the help of the
+// subcommand or of `ls`? In this case it will show the help of the subcommand. If we want to see
+// the help of `ls` we can use #3.
+#[derive(ConfigOpt, StructOpt)]
+#[configopt(derive(Serialize))]
+#[structopt(no_version, rename_all = "screamingsnake",
+            settings = &[AppSettings::TrailingVarArg,
+                         AppSettings::AllowLeadingHyphen,
+                        ])]
+pub struct ExternalCommandArgsWithHelpAndVersion {
+    /// Arguments to the command
     #[structopt(parse(from_os_str), takes_value = true, multiple = true)]
     pub args: Vec<OsString>,
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -15,7 +15,8 @@ use configopt::{ConfigOpt,
 use futures::stream::StreamExt;
 use hab::{cli::{self,
                 gateway_util,
-                hab::{origin::{Origin,
+                hab::{license::License,
+                      origin::{Origin,
                                Rbac,
                                RbacSet,
                                RbacShow},
@@ -128,8 +129,7 @@ async fn main() {
 async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
     let hab = Hab::try_from_args_with_configopt();
 
-    let args = std::env::args().skip(1).collect::<Vec<_>>();
-    if args == vec!["license", "accept"] {
+    if let Ok(Hab::License(License::Accept)) = hab {
         license::accept_license(ui)?;
         return Ok(());
     }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -22,6 +22,9 @@ use hab::{cli::{self,
                                RbacShow},
                       pkg::{ExportCommand as PkgExportCommand,
                             Pkg},
+                      sup::{HabSup,
+                            Secret,
+                            Sup},
                       svc::{self,
                             BulkLoad as SvcBulkLoad,
                             Load as SvcLoad,
@@ -135,9 +138,10 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
     }
 
     // Allow checking version information and displaying command help without accepting the license.
-    // We execute other binaries below in `exec_subcommand_if_called` so we only make the check if
-    // the license has not been accepted. `version` and `help` may behave differently when executed
-    // with alternate binaries. See the comment on `exec_subcommand_if_called` below.
+    // TODO (DM): To prevent errors in discrepancy between the structopt and cli versions only do
+    // this when the license has not yet been accepted. When we switchly fully to structopt this can
+    // be completely removed and we should just call `Hab::from_args_with_configopt` which will
+    // automatically result in this functionality.
     if !license::check_for_license_acceptance().unwrap_or_default()
                                                .accepted()
     {
@@ -149,23 +153,6 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
     }
 
     license::check_for_license_acceptance_and_prompt(ui)?;
-
-    // TODO JB: this feels like an anti-pattern to me. I get that in certain cases, we want to hand
-    // off control from hab to a different binary to do the work, but this implementation feels
-    // like it's duplicating a lot of what clap does for us. I think we should let clap do the work
-    // it was designed to do, and hand off control a little bit later. Maybe there's a tiny
-    // performance penalty, but the code would be much clearer.
-    //
-    // In addition, it creates a confusing UX because we advertise certain options via clap, e.g.
-    // --url and --channel and since we're handing off control before clap has even had a chance to
-    // parse the args, clap doesn't have a chance to do any validation that it needs to. We just
-    // grab everything that was submitted and shove it all to the exporter or whatever other binary
-    // is doing the job, and trust that it implements those flags. In some cases, e.g. the cf
-    // exporter, it doesn't, so we're effectively lying to users.
-    //
-    // In my opinion, this function should go away and we should follow 1 standard flow for arg
-    // parsing and delegation.
-    exec_subcommand_if_called(ui).await?;
 
     let (args, remaining_args) = raw_parse_args();
     debug!("clap cli args: {:?}", &args);
@@ -195,8 +182,41 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                         }
                     }
                 }
+                Hab::Run(_) => {
+                    return command::launcher::start(ui, &args_after_first(1)).await;
+                }
                 Hab::Studio(studio) => {
                     return command::studio::enter::start(ui, studio.args()).await;
+                }
+                Hab::Sup(sup) => {
+                    match sup {
+                        HabSup::Sup(sup) => {
+                            // These commands are handled by the `hab-sup` or `hab-launch` binaries.
+                            // We need to pass the subcommand that was issued to the underlying
+                            // binary. It is a bit hacky, but to do that we strip off the `hab sup`
+                            // command prefix and pass the rest of the args to underlying binary.
+                            let args = args_after_first(2);
+                            match sup {
+                                Sup::Bash | Sup::Sh | Sup::Term => {
+                                    return command::sup::start(ui, &args).await;
+                                }
+                                Sup::Run(_) => {
+                                    return command::launcher::start(ui, &args).await;
+                                }
+                            }
+                        }
+                        HabSup::Depart { member_id,
+                                         remote_sup, } => {
+                            return sub_sup_depart(member_id, &remote_sup.to_listen_ctl_addr()).await;
+                        }
+                        HabSup::Secret(Secret::Generate) => {
+                            return sub_sup_secret_generate();
+                        }
+                        HabSup::Status { pkg_ident,
+                                         remote_sup, } => {
+                            return sub_svc_status(pkg_ident, &remote_sup.to_listen_ctl_addr()).await;
+                        }
+                    }
                 }
                 Hab::Svc(svc) => {
                     match svc {
@@ -211,10 +231,17 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                             return sub_svc_load(svc_load).await;
                         }
                         Svc::Update(svc_update) => return sub_svc_update(svc_update).await,
+                        Svc::Status { pkg_ident,
+                                      remote_sup, } => {
+                            return sub_svc_status(pkg_ident, &remote_sup.to_listen_ctl_addr()).await;
+                        }
                         _ => {
                             // All other commands will be caught by the CLI parsing logic below.
                         }
                     }
+                }
+                Hab::Term => {
+                    return command::sup::start(ui, &args_after_first(1)).await;
                 }
                 Hab::Pkg(pkg) => {
                     match pkg {
@@ -425,21 +452,6 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                 ("unload", Some(m)) => sub_svc_unload(m).await?,
                 ("start", Some(m)) => sub_svc_start(m).await?,
                 ("stop", Some(m)) => sub_svc_stop(m).await?,
-                ("status", Some(m)) => sub_svc_status(m).await?,
-                _ => unreachable!(),
-            }
-        }
-        ("sup", Some(m)) => {
-            match m.subcommand() {
-                ("depart", Some(m)) => sub_sup_depart(m).await?,
-                ("secret", Some(m)) => {
-                    match m.subcommand() {
-                        ("generate", _) => sub_sup_secret_generate()?,
-                        _ => unreachable!(),
-                    }
-                }
-                // this is effectively an alias of `hab svc status`
-                ("status", Some(m)) => sub_svc_status(m).await?,
                 _ => unreachable!(),
             }
         }
@@ -1387,17 +1399,14 @@ async fn sub_svc_start(m: &ArgMatches<'_>) -> Result<()> {
     gateway_util::send(&remote_sup_addr, msg).await
 }
 
-async fn sub_svc_status(m: &ArgMatches<'_>) -> Result<()> {
+async fn sub_svc_status(pkg_ident: Option<PackageIdent>, remote_sup: &ListenCtlAddr) -> Result<()> {
     let cfg = config::load()?;
-    let remote_sup_addr = remote_sup_from_input(m)?;
     let secret_key = config::ctl_secret_key(&cfg)?;
     let mut msg = sup_proto::ctl::SvcStatus::default();
-    if let Some(pkg) = m.value_of("PKG_IDENT") {
-        msg.ident = Some(PackageIdent::from_str(pkg)?.into());
-    }
+    msg.ident = pkg_ident.map(Into::into);
 
     let mut out = TabWriter::new(io::stdout());
-    let mut response = SrvClient::request(&remote_sup_addr, &secret_key, msg).await?;
+    let mut response = SrvClient::request(remote_sup, &secret_key, msg).await?;
     // Ensure there is at least one result from the server otherwise produce an error
     if let Some(message_result) = response.next().await {
         let reply = message_result?;
@@ -1490,20 +1499,19 @@ async fn sub_file_put(m: &ArgMatches<'_>) -> Result<()> {
     Ok(())
 }
 
-async fn sub_sup_depart(m: &ArgMatches<'_>) -> Result<()> {
+async fn sub_sup_depart(member_id: String, remote_sup: &ListenCtlAddr) -> Result<()> {
     let cfg = config::load()?;
-    let remote_sup_addr = remote_sup_from_input(m)?;
     let secret_key = config::ctl_secret_key(&cfg)?;
     let mut ui = ui::ui();
     let mut msg = sup_proto::ctl::SupDepart::default();
-    msg.member_id = Some(m.value_of("MEMBER_ID").unwrap().to_string());
+    msg.member_id = Some(member_id);
 
     ui.begin(format!("Permanently marking {} as departed",
                      msg.member_id.as_deref().unwrap_or("UNKNOWN")))
       .unwrap();
-    ui.status(Status::Applying, format!("via peer {}", remote_sup_addr))
+    ui.status(Status::Applying, format!("via peer {}", remote_sup))
       .unwrap();
-    let mut response = SrvClient::request(&remote_sup_addr, &secret_key, msg).await?;
+    let mut response = SrvClient::request(&remote_sup, &secret_key, msg).await?;
     while let Some(message_result) = response.next().await {
         let reply = message_result?;
         match reply.message_id() {
@@ -1579,37 +1587,6 @@ fn sub_user_key_generate(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 
 fn args_after_first(args_to_skip: usize) -> Vec<OsString> {
     env::args_os().skip(args_to_skip).collect()
-}
-
-async fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
-    let mut args = env::args();
-    let first = args.nth(1).unwrap_or_default();
-    let second = args.next().unwrap_or_default();
-    let third = args.next().unwrap_or_default();
-
-    match (first.as_str(), second.as_str(), third.as_str()) {
-        ("run", ..) => command::launcher::start(ui, &args_after_first(1)).await,
-        // Skip invoking the `hab-sup` binary for sup cli help messages;
-        // handle these from within `hab`
-        ("help", "sup", _)
-        | ("sup", _, "help")
-        | ("sup", "help", _)
-        | ("sup", _, "-h")
-        | ("sup", "-h", _)
-        | ("sup", _, "--help")
-        | ("sup", "--help", _) => Ok(()),
-        // Delegate remaining Supervisor subcommands to `hab-sup`
-        ("sup", "", "")
-        | ("sup", "term", _)
-        | ("sup", "bash", _)
-        | ("sup", "sh", _)
-        | ("sup", "-V", _)
-        | ("sup", "--version", _) => command::sup::start(ui, &args_after_first(2)).await,
-        ("term", ..) => command::sup::start(ui, &args_after_first(1)).await,
-        // Delegate `hab sup run *` to the Launcher
-        ("sup", "run", _) => command::launcher::start(ui, &args_after_first(2)).await,
-        _ => Ok(()),
-    }
 }
 
 /// Parse the raw program arguments and split off any arguments that will skip clap's parsing.

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -195,6 +195,9 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                         }
                     }
                 }
+                Hab::Studio(studio) => {
+                    return command::studio::enter::start(ui, studio.args()).await;
+                }
                 Hab::Svc(svc) => {
                     match svc {
                         Svc::BulkLoad(svc_bulk_load) => {
@@ -1586,9 +1589,6 @@ async fn exec_subcommand_if_called(ui: &mut UI) -> Result<()> {
 
     match (first.as_str(), second.as_str(), third.as_str()) {
         ("run", ..) => command::launcher::start(ui, &args_after_first(1)).await,
-        ("stu", ..) | ("stud", ..) | ("studi", ..) | ("studio", ..) => {
-            command::studio::enter::start(ui, &args_after_first(2)).await
-        }
         // Skip invoking the `hab-sup` binary for sup cli help messages;
         // handle these from within `hab`
         ("help", "sup", _)

--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -1,29 +1,26 @@
 use clap::App;
-use hab::cli::sup_commands;
-use habitat_common::FeatureFlag;
+use hab::cli::hab::sup::Sup;
+use structopt::StructOpt;
 
-pub fn cli<'a, 'b>(feature_flags: FeatureFlag) -> App<'a, 'b> { sup_commands(feature_flags) }
+pub fn cli<'a, 'b>() -> App<'a, 'b> { Sup::clap() }
 
 #[cfg(test)]
 mod test {
     use super::cli;
     use clap::ErrorKind;
-    use habitat_common::FeatureFlag;
-
-    fn no_feature_flags() -> FeatureFlag { FeatureFlag::empty() }
 
     macro_rules! assert_cli_cmd {
-        ($test:ident, $flags:expr, $cmd:expr, $( $key:expr => $value:tt ),+) => {
+        ($test:ident, $cmd:expr, $( $key:expr => $value:tt ),+) => {
             #[test]
             fn $test() {
-                assert_cmd!(cli($flags), $cmd, $( $key => $value ),+ );
+                assert_cmd!(cli(), $cmd, $( $key => $value ),+ );
             }
         }
     }
 
     #[test]
     fn sup_help_on_run_subcommand() {
-        let r = cli(no_feature_flags()).get_matches_from_safe(vec!["hab-sup", "run", "--help"]);
+        let r = cli().get_matches_from_safe(vec!["hab-sup", "run", "--help"]);
         assert!(r.is_err());
         // not `ErrorKind::InvalidSubcommand`
         assert_eq!(r.unwrap_err().kind, ErrorKind::HelpDisplayed);
@@ -34,33 +31,27 @@ mod test {
         use std::iter::FromIterator as _;
 
         assert_cli_cmd!(should_handle_multiple_peer_flags,
-                        no_feature_flags(),
                         "hab-sup run --peer 1.1.1.1 --peer 2.2.2.2",
                         "PEER" => ["1.1.1.1", "2.2.2.2"]);
 
         assert_cli_cmd!(should_handle_single_peer_flag_with_multiple_values,
-                        no_feature_flags(),
                         "hab-sup run --peer 1.1.1.1 2.2.2.2",
                         "PEER" => ["1.1.1.1", "2.2.2.2"]);
 
         assert_cli_cmd!(should_handle_peer_flag_with_arguments,
-                        no_feature_flags(),
                         "hab-sup run --peer 1.1.1.1 2.2.2.2 -- core/redis",
                         "PEER" => ["1.1.1.1", "2.2.2.2"],
                         "PKG_IDENT_OR_ARTIFACT" => "core/redis");
 
         assert_cli_cmd!(should_handle_multiple_bind_flags,
-                        no_feature_flags(),
                         "hab-sup run --bind test:service.group1 --bind test:service.group2",
                         "BIND" => ["test:service.group1", "test:service.group2"]);
 
         assert_cli_cmd!(should_handle_single_bind_flag_with_multiple_values,
-                        no_feature_flags(),
                         "hab-sup run --bind test:service.group1 test2:service.group2",
                         "BIND" => ["test:service.group1", "test2:service.group2"]);
 
         assert_cli_cmd!(should_handle_bind_flag_with_arguments,
-                        no_feature_flags(),
                         "hab-sup run --bind test:service.group1 test:service.group2 -- core/redis",
                         "BIND" => ["test:service.group1", "test:service.group2"],
                         "PKG_IDENT_OR_ARTIFACT" => "core/redis");
@@ -70,8 +61,7 @@ mod test {
             let cmd_vec = Vec::from_iter("hab-sup run --listen-gossip 1.1.1.1:1111 \
                                           --local-gossip-mode"
                                                               .split_whitespace());
-            assert!(cli(no_feature_flags()).get_matches_from_safe(cmd_vec)
-                                           .is_err());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
         }
 
         #[test]
@@ -79,8 +69,7 @@ mod test {
             let cmd_vec = Vec::from_iter(
                 "hab-sup run --peer 1.1.1.1:1111 --local-gossip-mode".split_whitespace(),
             );
-            assert!(cli(no_feature_flags()).get_matches_from_safe(cmd_vec)
-                                           .is_err());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
         }
 
         #[test]
@@ -88,8 +77,7 @@ mod test {
             let cmd_vec = Vec::from_iter("hab-sup run --local-gossip-mode --peer-watch-file \
                                           foobar"
                                                  .split_whitespace());
-            assert!(cli(no_feature_flags()).get_matches_from_safe(cmd_vec)
-                                           .is_err());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
         }
 
         #[test]
@@ -97,8 +85,7 @@ mod test {
             let cmd_vec = Vec::from_iter("hab-sup run --peer 1.1.1.1:1111 --peer-watch-file \
                                           foobar"
                                                  .split_whitespace());
-            assert!(cli(no_feature_flags()).get_matches_from_safe(cmd_vec)
-                                           .is_err());
+            assert!(cli().get_matches_from_safe(cmd_vec).is_err());
         }
     }
 }

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -134,7 +134,7 @@ async fn start_rsr_imlw_mlw_gsw_smw_rhw_msw(feature_flags: FeatureFlag) -> Resul
     liveliness_checker::spawn_thread_alive_checker();
     let launcher = boot();
 
-    let app_matches = match cli(feature_flags).get_matches_safe() {
+    let app_matches = match cli().get_matches_safe() {
         Ok(matches) => matches,
         Err(err) => {
             let out = io::stdout();


### PR DESCRIPTION
This PR removes all manual CLI argument parsing. Namely, the parsing of `hab studio`, `hab sup`, and `hab pkg exec` are now all handled by structopt.