### PR TITLE
Pull packages from the `--channel` argument on `hab sup run`

### DIFF
--- a/components/hab/src/cli/hab.rs
+++ b/components/hab/src/cli/hab.rs
@@ -105,6 +105,7 @@ pub enum Hab {
     /// Alias for 'pkg install'
     #[structopt(no_version, settings = &[AppSettings::Hidden])]
     Install(PkgInstall),
+    #[cfg(not(target_os = "macos"))]
     /// Alias for 'sup run'
     #[structopt(no_version, settings = &[AppSettings::Hidden])]
     Run(SupRun),
@@ -117,6 +118,7 @@ pub enum Hab {
     /// Alias for 'svc stop'
     #[structopt(no_version, settings = &[AppSettings::Hidden])]
     Stop(SvcStop),
+    #[cfg(not(target_os = "macos"))]
     /// Alias for 'sup term'
     #[structopt(no_version, settings = &[AppSettings::Hidden])]
     Term,

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -64,6 +64,7 @@ pub enum HabSup {
         #[structopt(flatten)]
         remote_sup: RemoteSup,
     },
+    #[cfg(not(target_os = "macos"))]
     #[structopt(flatten)]
     Sup(Sup),
 }

--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -1,80 +1,47 @@
-use std::ffi::OsString;
+use crate::{command::sup::{SUP_CMD,
+                           SUP_CMD_ENVVAR,
+                           SUP_PKG_IDENT},
+            common::ui::UI,
+            error::{Error,
+                    Result},
+            exec,
+            hcore::{crypto::init,
+                    env as henv,
+                    fs::find_command,
+                    os::process,
+                    package::PackageIdent},
+            VERSION};
+use std::{ffi::OsString,
+          path::PathBuf,
+          str::FromStr};
 
-use crate::common::ui::UI;
+const LAUNCH_CMD: &str = "hab-launch";
+const LAUNCH_CMD_ENVVAR: &str = "HAB_LAUNCH_BINARY";
+const LAUNCH_PKG_IDENT: &str = "core/hab-launcher";
 
-use crate::error::Result;
-
-pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> { inner::start(ui, args).await }
-
-#[cfg(not(target_os = "macos"))]
-mod inner {
-    use std::{ffi::OsString,
-              path::PathBuf,
-              str::FromStr};
-
-    use crate::{common::ui::UI,
-                hcore::{crypto::init,
-                        env as henv,
-                        fs::find_command,
-                        os::process,
-                        package::PackageIdent}};
-
-    use super::super::sup::{SUP_CMD,
-                            SUP_CMD_ENVVAR,
-                            SUP_PKG_IDENT};
-    use crate::{error::{Error,
-                        Result},
-                exec,
-                VERSION};
-
-    const LAUNCH_CMD: &str = "hab-launch";
-    const LAUNCH_CMD_ENVVAR: &str = "HAB_LAUNCH_BINARY";
-    const LAUNCH_PKG_IDENT: &str = "core/hab-launcher";
-
-    pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
-        init()?;
-        if henv::var(SUP_CMD_ENVVAR).is_err() {
-            let version: Vec<&str> = VERSION.split('/').collect();
-            exec::command_from_min_pkg(ui,
+pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
+    init()?;
+    if henv::var(SUP_CMD_ENVVAR).is_err() {
+        let version: Vec<&str> = VERSION.split('/').collect();
+        exec::command_from_min_pkg(ui,
                                        SUP_CMD,
                                        &PackageIdent::from_str(&format!("{}/{}",
                                                                         SUP_PKG_IDENT,
                                                                         version[0]))?).await?;
-        }
-        let command = match henv::var(LAUNCH_CMD_ENVVAR) {
-            Ok(command) => PathBuf::from(command),
-            Err(_) => {
-                init()?;
-                exec::command_from_min_pkg(ui,
+    }
+    let command = match henv::var(LAUNCH_CMD_ENVVAR) {
+        Ok(command) => PathBuf::from(command),
+        Err(_) => {
+            init()?;
+            exec::command_from_min_pkg(ui,
                                            LAUNCH_CMD,
                                            &PackageIdent::from_str(LAUNCH_PKG_IDENT)?).await?
-            }
-        };
-        if let Some(cmd) = find_command(&command) {
-            process::become_command(cmd, args)?;
-            Ok(())
-        } else {
-            Err(Error::ExecCommandNotFound(command))
         }
-    }
-}
-
-#[cfg(target_os = "macos")]
-mod inner {
-    use std::{env,
-              ffi::OsString};
-
-    use crate::common::ui::{UIWriter,
-                            UI};
-
-    use crate::error::{Error,
-                       Result};
-
-    pub async fn start(ui: &mut UI, _args: &[OsString]) -> Result<()> {
-        let subcmd = env::args().nth(1).unwrap_or("<unknown>".to_string());
-        ui.warn("Launching a native Supervisor on this operating system is not yet supported. \
-                 Try running this command again on 64-bit Linux or Windows.")?;
-        ui.br()?;
-        Err(Error::SubcommandNotSupported(subcmd))
+    };
+    if let Some(cmd) = find_command(&command) {
+        process::become_command(cmd, args)?;
+        Ok(())
+    } else {
+        Err(Error::ExecCommandNotFound(command))
     }
 }

--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -1,4 +1,5 @@
-use crate::{command::sup::{SUP_CMD,
+use crate::{cli::hab::sup::SupRun,
+            command::sup::{SUP_CMD,
                            SUP_CMD_ENVVAR,
                            SUP_PKG_IDENT},
             common::ui::UI,
@@ -19,23 +20,26 @@ const LAUNCH_CMD: &str = "hab-launch";
 const LAUNCH_CMD_ENVVAR: &str = "HAB_LAUNCH_BINARY";
 const LAUNCH_PKG_IDENT: &str = "core/hab-launcher";
 
-pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
+pub async fn start(ui: &mut UI, sup_run: SupRun, args: &[OsString]) -> Result<()> {
     init()?;
+    let channel = sup_run.shared_load.channel;
     if henv::var(SUP_CMD_ENVVAR).is_err() {
         let version: Vec<&str> = VERSION.split('/').collect();
-        exec::command_from_min_pkg(ui,
-                                       SUP_CMD,
-                                       &PackageIdent::from_str(&format!("{}/{}",
-                                                                        SUP_PKG_IDENT,
-                                                                        version[0]))?).await?;
+        exec::command_from_min_pkg_with_channel(ui,
+                                                SUP_CMD,
+                                                &PackageIdent::from_str(&format!("{}/{}",
+                                                                                 SUP_PKG_IDENT,
+                                                                                 version[0]))?,
+                                                channel.clone()).await?;
     }
     let command = match henv::var(LAUNCH_CMD_ENVVAR) {
         Ok(command) => PathBuf::from(command),
         Err(_) => {
             init()?;
-            exec::command_from_min_pkg(ui,
-                                           LAUNCH_CMD,
-                                           &PackageIdent::from_str(LAUNCH_PKG_IDENT)?).await?
+            exec::command_from_min_pkg_with_channel(ui,
+                                                    LAUNCH_CMD,
+                                                    &PackageIdent::from_str(LAUNCH_PKG_IDENT)?,
+                                                    channel).await?
         }
     };
     if let Some(cmd) = find_command(&command) {

--- a/components/hab/src/command/sup.rs
+++ b/components/hab/src/command/sup.rs
@@ -1,74 +1,38 @@
-use std::ffi::OsString;
-
-use crate::common::ui::UI;
-
-use crate::error::Result;
+use crate::{common::ui::UI,
+            error::{Error,
+                    Result},
+            exec,
+            hcore::{crypto::init,
+                    env as henv,
+                    fs::find_command,
+                    os::process,
+                    package::PackageIdent},
+            VERSION};
+use std::{ffi::OsString,
+          path::PathBuf,
+          str::FromStr};
 
 pub const SUP_CMD: &str = "hab-sup";
 pub const SUP_CMD_ENVVAR: &str = "HAB_SUP_BINARY";
 pub const SUP_PKG_IDENT: &str = "core/hab-sup";
 
-pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> { inner::start(ui, args).await }
-
-#[cfg(not(target_os = "macos"))]
-mod inner {
-    use std::{ffi::OsString,
-              path::PathBuf,
-              str::FromStr};
-
-    use crate::{common::ui::UI,
-                hcore::{crypto::init,
-                        env as henv,
-                        fs::find_command,
-                        os::process,
-                        package::PackageIdent}};
-
-    use super::{SUP_CMD,
-                SUP_CMD_ENVVAR,
-                SUP_PKG_IDENT};
-    use crate::{error::{Error,
-                        Result},
-                exec,
-                VERSION};
-
-    pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
-        let command = match henv::var(SUP_CMD_ENVVAR) {
-            Ok(command) => PathBuf::from(command),
-            Err(_) => {
-                init()?;
-                let version: Vec<&str> = VERSION.split('/').collect();
-                exec::command_from_min_pkg(ui,
-                                           SUP_CMD,
-                                           &PackageIdent::from_str(&format!("{}/{}",
-                                                                            SUP_PKG_IDENT,
-                                                                            version[0]))?).await?
-            }
-        };
-        if let Some(cmd) = find_command(&command) {
-            process::become_command(cmd, args)?;
-            Ok(())
-        } else {
-            Err(Error::ExecCommandNotFound(command))
+pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
+    let command = match henv::var(SUP_CMD_ENVVAR) {
+        Ok(command) => PathBuf::from(command),
+        Err(_) => {
+            init()?;
+            let version: Vec<&str> = VERSION.split('/').collect();
+            exec::command_from_min_pkg(ui,
+                                       SUP_CMD,
+                                       &PackageIdent::from_str(&format!("{}/{}",
+                                                                        SUP_PKG_IDENT,
+                                                                        version[0]))?).await?
         }
-    }
-}
-
-#[cfg(target_os = "macos")]
-mod inner {
-    use std::{env,
-              ffi::OsString};
-
-    use crate::common::ui::{UIWriter,
-                            UI};
-
-    use crate::error::{Error,
-                       Result};
-
-    pub async fn start(ui: &mut UI, _args: &[OsString]) -> Result<()> {
-        let subcmd = env::args().nth(1).unwrap_or("<unknown>".to_string());
-        ui.warn("Launching a native Supervisor on this operating system is not yet supported. \
-                 Try running this command again on 64-bit Linux or Windows.")?;
-        ui.br()?;
-        Err(Error::SubcommandNotSupported(subcmd))
+    };
+    if let Some(cmd) = find_command(&command) {
+        process::become_command(cmd, args)?;
+        Ok(())
+    } else {
+        Err(Error::ExecCommandNotFound(command))
     }
 }

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -25,6 +25,21 @@ use std::path::PathBuf;
 const RETRY_LIMIT: usize = 5;
 const INTERNAL_TOOLING_CHANNEL_ENVVAR: &str = "HAB_INTERNAL_BLDR_CHANNEL";
 
+pub async fn command_from_min_pkg(ui: &mut UI,
+                                  command: impl Into<PathBuf>,
+                                  ident: &PackageIdent)
+                                  -> Result<PathBuf> {
+    command_from_min_pkg_with_optional_channel(ui, command, ident, None).await
+}
+
+pub async fn command_from_min_pkg_with_channel(ui: &mut UI,
+                                               command: impl Into<PathBuf>,
+                                               ident: &PackageIdent,
+                                               channel: ChannelIdent)
+                                               -> Result<PathBuf> {
+    command_from_min_pkg_with_optional_channel(ui, command, ident, Some(channel)).await
+}
+
 /// Returns the absolute path to the given command from a package no
 /// older than the given package identifier.
 ///
@@ -35,9 +50,12 @@ const INTERNAL_TOOLING_CHANNEL_ENVVAR: &str = "HAB_INTERNAL_BLDR_CHANNEL";
 /// # Notes on Package Installation
 ///
 /// By default, Habitat will install packages from the `stable`
-/// channel. However, if you'd rather use unstable (particularly if
-/// you're developing Habitat), you'll need to set the
-/// `INTERNAL_TOOLING_CHANNEL_ENVVAR` appropriately.
+/// channel or will use a channel specific to a particular context (eg
+/// `hab sup run --internal-channel`) passed with the `channel`
+/// parameter of this function. However, if you'd rather use a
+/// different channel (particularly if you're developing Habitat),
+/// you'll need to set the `INTERNAL_TOOLING_CHANNEL_ENVVAR`
+/// appropriately.
 ///
 /// Note that this environment variable *only* applies to packages
 /// installed through this function. As a result, this function should
@@ -57,10 +75,11 @@ const INTERNAL_TOOLING_CHANNEL_ENVVAR: &str = "HAB_INTERNAL_BLDR_CHANNEL";
 /// * If the package is installed but the command cannot be found in the package
 /// * If an error occurs when loading the local package from disk
 /// * If the maximum number of installation retries has been exceeded
-pub async fn command_from_min_pkg(ui: &mut UI,
-                                  command: impl Into<PathBuf>,
-                                  ident: &PackageIdent)
-                                  -> Result<PathBuf> {
+async fn command_from_min_pkg_with_optional_channel(ui: &mut UI,
+                                                    command: impl Into<PathBuf>,
+                                                    ident: &PackageIdent,
+                                                    channel: Option<ChannelIdent>)
+                                                    -> Result<PathBuf> {
     let command = command.into();
     let fs_root_path = FS_ROOT_PATH.as_path();
     let pi = match PackageInstall::load_at_least(ident, Some(fs_root_path)) {
@@ -68,11 +87,13 @@ pub async fn command_from_min_pkg(ui: &mut UI,
         Err(hcore::Error::PackageNotFound(_)) => {
             ui.status(Status::Missing, format!("package for {}", &ident))?;
 
+            let channel = internal_tooling_channel(channel);
+
             // JB TODO - Does an auth token need to be plumbed into here?  Not 100% sure.
             retry::retry_future!(delay::NoDelay.take(RETRY_LIMIT), async {
                 common::command::package::install::start(ui,
                                                          &default_bldr_url(),
-                                                         &internal_tooling_channel(),
+                                                         &channel,
                                                          &(ident.clone(),
                                                            PackageTarget::active_target())
                                                                                           .into(),
@@ -100,9 +121,10 @@ pub async fn command_from_min_pkg(ui: &mut UI,
                                                          })
 }
 
-/// Determine the channel from which to install Habitat-specific
-/// packages.
-fn internal_tooling_channel() -> ChannelIdent {
-    hcore::env::var(INTERNAL_TOOLING_CHANNEL_ENVVAR).map(ChannelIdent::from)
+/// Determine the channel from which to install Habitat-specific packages.
+fn internal_tooling_channel(channel: Option<ChannelIdent>) -> ChannelIdent {
+    hcore::env::var(INTERNAL_TOOLING_CHANNEL_ENVVAR).ok()
+                                                    .map(ChannelIdent::from)
+                                                    .or(channel)
                                                     .unwrap_or_default()
 }

--- a/components/hab/src/exec.rs
+++ b/components/hab/src/exec.rs
@@ -51,11 +51,10 @@ pub async fn command_from_min_pkg_with_channel(ui: &mut UI,
 ///
 /// By default, Habitat will install packages from the `stable`
 /// channel or will use a channel specific to a particular context (eg
-/// `hab sup run --internal-channel`) passed with the `channel`
-/// parameter of this function. However, if you'd rather use a
-/// different channel (particularly if you're developing Habitat),
-/// you'll need to set the `INTERNAL_TOOLING_CHANNEL_ENVVAR`
-/// appropriately.
+/// `hab sup run --channel`) passed with the `channel` parameter of
+/// this function. However, if you'd rather use a different channel
+/// (particularly if you're developing Habitat), you'll need to set the
+/// `INTERNAL_TOOLING_CHANNEL_ENVVAR` appropriately.
 ///
 /// Note that this environment variable *only* applies to packages
 /// installed through this function. As a result, this function should

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -180,10 +180,10 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                     }
                 }
                 #[cfg(not(target_os = "macos"))]
-                Hab::Run(_) => {
+                Hab::Run(sup_run) => {
                     ui.warn("'hab run' as an alias for 'hab sup run' is deprecated. Please \
                              update your automation and processes accordingly.")?;
-                    return command::launcher::start(ui, &args_after_first(1)).await;
+                    return command::launcher::start(ui, sup_run, &args_after_first(1)).await;
                 }
                 Hab::Studio(studio) => {
                     return command::studio::enter::start(ui, studio.args()).await;
@@ -201,8 +201,8 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                                 Sup::Bash | Sup::Sh | Sup::Term => {
                                     return command::sup::start(ui, &args).await;
                                 }
-                                Sup::Run(_) => {
-                                    return command::launcher::start(ui, &args).await;
+                                Sup::Run(sup_run) => {
+                                    return command::launcher::start(ui, sup_run, &args).await;
                                 }
                             }
                         }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -179,6 +179,7 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                         }
                     }
                 }
+                #[cfg(not(target_os = "macos"))]
                 Hab::Run(_) => {
                     ui.warn("'hab run' as an alias for 'hab sup run' is deprecated. Please \
                              update your automation and processes accordingly.")?;
@@ -189,6 +190,7 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                 }
                 Hab::Sup(sup) => {
                     match sup {
+                        #[cfg(not(target_os = "macos"))]
                         HabSup::Sup(sup) => {
                             // These commands are handled by the `hab-sup` or `hab-launch` binaries.
                             // We need to pass the subcommand that was issued to the underlying
@@ -239,6 +241,7 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
                         }
                     }
                 }
+                #[cfg(not(target_os = "macos"))]
                 Hab::Term => {
                     ui.warn("'hab term' as an alias for 'hab sup term' is deprecated. Please \
                              update your automation and processes accordingly.")?;


### PR DESCRIPTION
Resolves #7833

This PR has two parts:

1. Make it impossible to run the supervisor on MacOS using conditional compilation on the CLI. Previously the user would get an error when issuing `hab sup run` (as well as a few other commands) on MacOS now that CLI option is not even available.
2. Pull `core/hab-sup` and `core/hab-launch` from the `--channel` argument on `hab sup run`

Future work could add an `--internal-channel` argument to `hab sup run` to avoid the overloading of the `--channel` argument. It is used for both pulling internal packages and the package loaded on Supervisor startup. Note, the `--channel` argument was overloaded before this PR by the `hab-sup` updater.