### PR TITLE
Fix `hab sup --version` after `structopt` refactoring

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -857,9 +857,9 @@ steps:
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
 
-  - label: "[:linux: test_pkg_exporters_help]"
+  - label: "[:linux: test_external_binaries]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_exporters_help
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_external_binaries
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:
@@ -870,9 +870,9 @@ steps:
             - BUILD_PKG_TARGET=x86_64-linux
             - PIPELINE_HAB_AUTH_TOKEN
 
-  - label: "[:windows: test_pkg_exporters_help]"
+  - label: "[:windows: test_external_binaries]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_pkg_exporters_help
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_external_binaries
     env:
       BUILD_PKG_TARGET: x86_64-windows
     expeditor:

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -70,7 +70,7 @@ pub enum HabSup {
 
 // Supervisor commands handled by the `hab-sup` binary
 #[derive(ConfigOpt, StructOpt)]
-#[structopt(name = "sup",
+#[structopt(name = "hab-sup",
             version = VERSION,
             about = "The Habitat Supervisor",
             author = "\nThe Habitat Maintainers <humans@habitat.sh>\n",

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -153,6 +153,21 @@ async fn start(ui: &mut UI, feature_flags: FeatureFlag) -> Result<()> {
         }
     }
 
+    // We must manually detect a supervisor version check and call the `hab-sup` binary to get the
+    // true Supervisor version.
+    // TODO (DM): This is an ugly consequence of having `hab sup` subcommands handled by both the
+    // `hab` binary and the `hab-sup` binary. Potential fixes:
+    // 1. Handle all `hab sup` subcommands with the `hab-sup` binary
+    // 2. Have a dedicated subcommand for commands handled by the `hab-sup` binary
+    let mut args = env::args();
+    if matches!((args.next().unwrap_or_default().as_str(),
+                 args.next().unwrap_or_default().as_str(),
+                 args.next().unwrap_or_default().as_str()),
+                 (_, "sup", "--version") | (_, "sup", "-V"))
+    {
+        return command::sup::start(ui, &args_after_first(2)).await;
+    }
+
     license::check_for_license_acceptance_and_prompt(ui)?;
 
     // Parse and handle commands which have been migrated to use `structopt` here. Once everything

--- a/test/end-to-end/test_external_binaries.ps1
+++ b/test/end-to-end/test_external_binaries.ps1
@@ -1,5 +1,4 @@
-
-Describe "`hab pkg export` executes the correct external command" {
+Describe "`hab` correctly executes external binaries" {
     It "container exporter help" {
         $out = hab pkg export container --help
         $LastExitCode | Should -Be 0
@@ -37,6 +36,15 @@ Describe "`hab pkg export` executes the correct external command" {
     It "`hab pkg export` with bad exporter" {
         hab pkg export a_bad_exporter --help
         $LastExitCode | Should -Be 1
+    }
+
+    It "`hab sup --version` correctly reports version" {
+        # Install an use an old supervisor to ensure version match
+        Invoke-NativeCommand hab pkg install "core/hab-sup/1.6.56"
+        $env:HAB_SUP_BINARY = "$(hab pkg path core/hab-sup/1.6.56)/bin/hab-sup"
+        $out = hab sup --version | Join-String
+        $out | Should -BeLike "*1.6.56*"
+        $env:HAB_SUP_BINARY = ""
     }
 }
 


### PR DESCRIPTION
The changes have a comment explaining why this is necessary.

Signed-off-by: David McNeil <mcneil.david2@gmail.com>