### PR TITLE
do not add c:/hab/bin to persistent path in ci

### DIFF
--- a/.expeditor/scripts/shared.ps1
+++ b/.expeditor/scripts/shared.ps1
@@ -39,10 +39,6 @@ function Get-RustfmtToolchain {
 }
 
 function Install-Habitat {
-    # Make sure c:\hab\bin is on both the current path and the permanent machine path
-    $machinePath = [System.Environment]::GetEnvironmentVariable("PATH", "Machine")
-    $machinePath = New-PathString -StartingPath $machinePath -Path "c:\hab\bin"
-    [System.Environment]::SetEnvironmentVariable("PATH", $machinePath, "Machine")
     $env:path = New-PathString -StartingPath $env:path -Path "c:\hab\bin"
 
     if (Get-Command -Name hab -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
Adding the persistent path was failing on docker based e2e tests most likely because the user was not an admin. Upon deeper reflection, we should not need this set persistently for CI.

Signed-off-by: mwrock <matt@mattwrock.com>