### PR TITLE
Report errors when getting user and group

### DIFF
--- a/components/common/src/templating/config.rs
+++ b/components/common/src/templating/config.rs
@@ -613,10 +613,12 @@ mod test {
 
     fn curr_username() -> String {
         users::get_current_username().expect("Can get current username")
+                                     .expect("Can get current username")
     }
 
     fn curr_groupname() -> String {
         users::get_current_groupname().expect("Can get current groupname")
+                                      .expect("Can get current groupname")
     }
 
     fn toml_from_str(content: &str) -> toml::value::Table {

--- a/components/common/src/templating/config.rs
+++ b/components/common/src/templating/config.rs
@@ -612,13 +612,13 @@ mod test {
     use tempfile::TempDir;
 
     fn curr_username() -> String {
-        users::get_current_username().expect("Can get current username")
-                                     .expect("Can get current username")
+        users::get_current_username().expect("Failed to get username")
+                                     .expect("No username found")
     }
 
     fn curr_groupname() -> String {
-        users::get_current_groupname().expect("Can get current groupname")
-                                      .expect("Can get current groupname")
+        users::get_current_groupname().expect("Failed to get groupname")
+                                      .expect("No groupname found")
     }
 
     fn toml_from_str(content: &str) -> toml::value::Table {

--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -329,7 +329,7 @@ pub trait PackageMaintenanceHookExt: Hook<ExitValue = ExitStatus> + Sync {
                 let mut pkg = Pkg::from_install(package).await?;
                 // Hooks do not have access to svc_passwords so we execute them under the current
                 // user account.
-                if let Some(user) = habitat_core::os::users::get_current_username() {
+                if let Some(user) = habitat_core::os::users::get_current_username()? {
                     pkg.svc_user = user;
                 }
                 pkg

--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -254,10 +254,10 @@ pub trait Hook: fmt::Debug + Sized + Send {
         let ids = if process::can_run_services_as_svc_user() {
             // If we can SETUID/SETGID, then run the script as the service
             // user; otherwise, we'll just run it as ourselves.
-            let uid = users::get_uid_by_name(&pkg.svc_user)
+            let uid = users::get_uid_by_name(&pkg.svc_user)?
                 .map(Uid::from_raw)
                 .ok_or_else(|| {Error::PermissionFailed(format!("No uid for user '{}' could be found", &pkg.svc_user))})?;
-            let gid = users::get_gid_by_name(&pkg.svc_group)
+            let gid = users::get_gid_by_name(&pkg.svc_group)?
                 .map(Gid::from_raw)
                 .ok_or_else(|| {Error::PermissionFailed(format!("No gid for group '{}' could be found", &pkg.svc_group))})?;
             Some((uid, gid))

--- a/components/common/src/templating/package.rs
+++ b/components/common/src/templating/package.rs
@@ -226,8 +226,8 @@ fn get_pkg_user_and_group(pkg_install: &PackageInstall) -> Result<Option<(String
 /// checks to see if hab/hab exists, if not, fall back to
 /// current user/group. If that fails, then return an error.
 fn default_user_and_group() -> Result<(String, String)> {
-    let uid = users::get_uid_by_name(DEFAULT_USER);
-    let gid = users::get_gid_by_name(DEFAULT_GROUP);
+    let uid = users::get_uid_by_name(DEFAULT_USER)?;
+    let gid = users::get_gid_by_name(DEFAULT_GROUP)?;
     match (uid, gid) {
         (Some(_), Some(_)) => Ok((DEFAULT_USER.to_string(), DEFAULT_GROUP.to_string())),
         _ => {
@@ -238,8 +238,8 @@ fn default_user_and_group() -> Result<(String, String)> {
 }
 
 fn current_user_and_group() -> Result<(String, String)> {
-    let user = users::get_current_username();
-    let group = users::get_current_groupname();
+    let user = users::get_current_username()?;
+    let group = users::get_current_groupname()?;
     match (user, group) {
         (Some(user), Some(group)) => {
             debug!("Running as {}/{}", user, group);

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -114,6 +114,8 @@ pub enum Error {
     MetaFileNotFound(package::metadata::MetaFile),
     /// When an IO error while accessing a MetaFile.
     MetaFileIO(io::Error),
+    #[cfg(not(windows))]
+    Nix(nix::Error),
     /// Occurs when we can't find an outbound IP address
     NoOutboundIpAddr(io::Error),
     /// Occurs when a call to OpenDesktopW fails
@@ -313,6 +315,8 @@ impl fmt::Display for Error {
             }
             Error::MetaFileNotFound(ref e) => format!("Couldn't read MetaFile: {}, not found", e),
             Error::MetaFileIO(ref e) => format!("IO error while accessing MetaFile: {:?}", e),
+            #[cfg(not(windows))]
+            Error::Nix(ref e) => format!("{}", e),
             Error::NoOutboundIpAddr(ref e) => {
                 format!("Failed to discover this host's outbound IP address: {}", e)
             }
@@ -381,6 +385,11 @@ impl From<str::Utf8Error> for Error {
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Self { Error::IO(err) }
+}
+
+#[cfg(not(windows))]
+impl From<nix::Error> for Error {
+    fn from(err: nix::Error) -> Self { Error::Nix(err) }
 }
 
 impl From<num::ParseIntError> for Error {

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -172,7 +172,7 @@ impl ServiceCredential {
     }
 
     pub fn is_current_user(&self) -> bool {
-        self.user == get_current_username().unwrap_or_default()
+        self.user == get_current_username().ok().flatten().unwrap_or_default()
     }
 
     pub fn user_wide(&self) -> WideCString { WideCString::from_str(self.user.as_str()).unwrap() }

--- a/components/core/src/os/users/unix.rs
+++ b/components/core/src/os/users/unix.rs
@@ -1,51 +1,48 @@
-use crate::{error::{Error,
-                    Result},
-            ok_warn};
+use crate::error::{Error,
+                   Result};
 use nix::unistd::{Group,
                   User};
 use std::path::PathBuf;
 
-pub fn get_uid_by_name(owner: &str) -> Option<u32> {
-    ok_warn!(User::from_name(owner)).flatten()
-                                    .map(|u| u.uid.as_raw())
+pub fn get_uid_by_name(owner: &str) -> Result<Option<u32>> {
+    Ok(User::from_name(owner)?.map(|u| u.uid.as_raw()))
 }
 
-pub fn get_gid_by_name(group: &str) -> Option<u32> {
-    ok_warn!(Group::from_name(group)).flatten()
-                                     .map(|g| g.gid.as_raw())
+pub fn get_gid_by_name(group: &str) -> Result<Option<u32>> {
+    Ok(Group::from_name(group)?.map(|g| g.gid.as_raw()))
 }
 
 /// Any members that fail conversion from OsString to string will be omitted
-pub fn get_members_by_groupname(group: &str) -> Option<Vec<String>> {
-    ok_warn!(Group::from_name(group)).flatten().map(|g| g.mem)
+pub fn get_members_by_groupname(group: &str) -> Result<Option<Vec<String>>> {
+    Ok(Group::from_name(group)?.map(|g| g.mem))
 }
 
-pub fn get_current_username() -> Option<String> {
+pub fn get_current_username() -> Result<Option<String>> {
     let uid = nix::unistd::getuid();
-    ok_warn!(User::from_uid(uid)).flatten().map(|u| u.name)
+    Ok(User::from_uid(uid)?.map(|u| u.name))
 }
 
-pub fn get_current_groupname() -> Option<String> {
+pub fn get_current_groupname() -> Result<Option<String>> {
     let gid = nix::unistd::getgid();
-    ok_warn!(Group::from_gid(gid)).flatten().map(|g| g.name)
+    Ok(Group::from_gid(gid)?.map(|g| g.name))
 }
 
-pub fn get_effective_username() -> Option<String> {
+pub fn get_effective_username() -> Result<Option<String>> {
     let euid = nix::unistd::geteuid();
-    ok_warn!(User::from_uid(euid)).flatten().map(|u| u.name)
+    Ok(User::from_uid(euid)?.map(|u| u.name))
 }
 
 pub fn get_effective_uid() -> u32 { nix::unistd::geteuid().as_raw() }
 
 pub fn get_effective_gid() -> u32 { nix::unistd::getegid().as_raw() }
 
-pub fn get_effective_groupname() -> Option<String> {
+pub fn get_effective_groupname() -> Result<Option<String>> {
     let egid = nix::unistd::getegid();
-    ok_warn!(Group::from_gid(egid)).flatten().map(|g| g.name)
+    Ok(Group::from_gid(egid)?.map(|g| g.name))
 }
 
-pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
-    ok_warn!(User::from_name(username)).flatten().map(|u| u.dir)
+pub fn get_home_for_user(username: &str) -> Result<Option<PathBuf>> {
+    Ok(User::from_name(username)?.map(|u| u.dir))
 }
 
 /// This function checks to see if a user and group and if:
@@ -53,21 +50,21 @@ pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
 ///     b) we are the specified user:group
 ///     c) fail otherwise
 pub fn assert_pkg_user_and_group(user: &str, group: &str) -> Result<()> {
-    if get_uid_by_name(user).is_none() {
+    if get_uid_by_name(user)?.is_none() {
         return Err(Error::PermissionFailed(format!("Package requires user \
                                                     {} to exist, but it \
                                                     doesn't",
                                                    user)));
     }
-    if get_gid_by_name(&group).is_none() {
+    if get_gid_by_name(&group)?.is_none() {
         return Err(Error::PermissionFailed(format!("Package requires group \
                                                     {} to exist, but it \
                                                     doesn't",
                                                    group)));
     }
 
-    let current_user = get_current_username();
-    let current_group = get_current_groupname();
+    let current_user = get_current_username()?;
+    let current_group = get_current_groupname()?;
 
     if current_user.is_none() {
         return Err(Error::PermissionFailed("Can't determine current user".to_string()));

--- a/components/core/src/os/users/windows.rs
+++ b/components/core/src/os/users/windows.rs
@@ -20,20 +20,20 @@ fn get_sid_by_name(name: &str) -> Option<String> {
     }
 }
 
-pub fn get_uid_by_name(owner: &str) -> Option<String> { get_sid_by_name(owner) }
+pub fn get_uid_by_name(owner: &str) -> Result<Option<String>> { Ok(get_sid_by_name(owner)) }
 
 // this is a no-op on windows
-pub fn get_gid_by_name(group: &str) -> Option<String> { Some(String::new()) }
+pub fn get_gid_by_name(group: &str) -> Result<Option<String>> { Ok(Some(String::new())) }
 
-pub fn get_current_username() -> Option<String> {
+pub fn get_current_username() -> Result<Option<String>> {
     match helper::current_user() {
-        Some(username) => Some(username.to_lowercase()),
-        None => None,
+        Some(username) => Ok(Some(username.to_lowercase())),
+        None => Ok(None),
     }
 }
 
 // this is a no-op on windows
-pub fn get_current_groupname() -> Option<String> { Some(String::new()) }
+pub fn get_current_groupname() -> Result<Option<String>> { Ok(Some(String::new())) }
 
 pub fn get_effective_uid() -> u32 { unsafe { GetUserTokenStatus() } }
 
@@ -44,7 +44,7 @@ pub fn get_home_for_user(username: &str) -> Option<PathBuf> {
 /// Windows does not have a concept of "group" in a Linux sense
 /// So we just validate the user
 pub fn assert_pkg_user_and_group(user: &str, _group: &str) -> Result<()> {
-    match get_uid_by_name(user) {
+    match get_uid_by_name(user)? {
         Some(_) => Ok(()),
         None => {
             Err(Error::PermissionFailed(format!("Package requires user \
@@ -61,7 +61,8 @@ mod tests {
 
     #[test]
     fn get_uid_of_current_user() {
-        assert!(get_current_username().map(|s| get_uid_by_name(&s))
+        assert!(get_current_username().unwrap()
+                                      .map(|s| get_uid_by_name(&s))
                                       .is_some())
     }
 }

--- a/components/core/src/util/posix_perm.rs
+++ b/components/core/src/util/posix_perm.rs
@@ -16,7 +16,7 @@ pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> 
            &owner.as_ref(),
            &group.as_ref());
 
-    let uid = match users::get_uid_by_name(&owner.as_ref()) {
+    let uid = match users::get_uid_by_name(&owner.as_ref())? {
         Some(user) => user,
         None => {
             let msg = format!("Can't change owner of {:?} to {:?}:{:?}, error getting user.",
@@ -27,7 +27,7 @@ pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> 
         }
     };
 
-    let gid = match users::get_gid_by_name(&group.as_ref()) {
+    let gid = match users::get_gid_by_name(&group.as_ref())? {
         Some(group) => group,
         None => {
             let msg = format!("Can't change owner of {:?} to {:?}:{:?}, error getting group.",

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -207,16 +207,16 @@ mod inner {
         false
     }
 
-    fn has_docker_group() -> bool {
-        let current_user = users::get_current_username().unwrap();
-        let docker_members = users::get_members_by_groupname("docker");
-        docker_members.map_or(false, |d| d.contains(&current_user))
+    fn has_docker_group() -> Result<bool> {
+        let current_user = users::get_current_username()?.unwrap();
+        let docker_members = users::get_members_by_groupname("docker")?;
+        Ok(docker_members.map_or(false, |d| d.contains(&current_user)))
     }
 
     fn rerun_with_sudo_if_needed(ui: &mut UI, args: &[OsString]) -> Result<()> {
         // If I have root permissions or if I am executing a docker studio
         // and have the appropriate group - early return, we are done.
-        if am_i_root() || (is_docker_studio(args) && has_docker_group()) {
+        if am_i_root() || (is_docker_studio(args) && has_docker_group()?) {
             return Ok(());
         }
 

--- a/components/hab/src/license.rs
+++ b/components/hab/src/license.rs
@@ -58,12 +58,12 @@ pub struct LicenseData {
 }
 
 impl LicenseData {
-    pub fn new() -> Self {
-        LicenseData { date_accepted: Utc::now(),
-                      accepting_product: String::from("hab"),
-                      accepting_product_version: super::VERSION.to_string(),
-                      user: get_current_username(),
-                      file_format: String::from(LICENSE_FILE_FORMAT_VERSION), }
+    pub fn new() -> Result<Self> {
+        Ok(LicenseData { date_accepted: Utc::now(),
+                         accepting_product: String::from("hab"),
+                         accepting_product_version: super::VERSION.to_string(),
+                         user: get_current_username()?,
+                         file_format: String::from(LICENSE_FILE_FORMAT_VERSION), })
     }
 }
 
@@ -192,7 +192,7 @@ fn acceptance_from_env_var() -> Result<LicenseAcceptance> {
 }
 
 fn write_license_file() -> Result<()> {
-    let license = LicenseData::new();
+    let license = LicenseData::new()?;
     let content = serde_yaml::to_string(&license)?;
     fs::create_dir_all(writeable_license_path())?;
     let mut file = File::create(license_file(&writeable_license_path()))?;

--- a/components/launcher/src/error.rs
+++ b/components/launcher/src/error.rs
@@ -1,11 +1,10 @@
-use crate::protocol;
+use crate::{protocol,
+            SUP_CMD,
+            SUP_PACKAGE_IDENT};
 use std::{error,
           fmt,
           io,
           result};
-
-use crate::{SUP_CMD,
-            SUP_PACKAGE_IDENT};
 
 #[derive(Debug)]
 pub enum Error {
@@ -13,6 +12,7 @@ pub enum Error {
     Connect(io::Error),
     ExecWait(io::Error),
     GroupNotFound(String),
+    HabitatCore(habitat_core::Error),
     OpenPipe(io::Error),
     Protocol(protocol::Error),
     Send(ipc_channel::Error),
@@ -36,6 +36,7 @@ impl fmt::Display for Error {
             }
             Error::ExecWait(ref e) => format!("Error waiting on PID, {}", e),
             Error::GroupNotFound(ref e) => format!("No GID for group '{}' could be found", e),
+            Error::HabitatCore(ref err) => err.to_string(),
             Error::OpenPipe(ref e) => format!("Unable to open Launcher's comm channel, {}", e),
             Error::Protocol(ref e) => format!("{}", e),
             Error::Send(ref e) => format!("Unable to send to Launcher's comm channel, {}", e),
@@ -74,4 +75,8 @@ impl From<protocol::Error> for Error {
 
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error { Error::Spawn(err) }
+}
+
+impl From<habitat_core::Error> for Error {
+    fn from(err: habitat_core::Error) -> Error { Error::HabitatCore(err) }
 }

--- a/components/launcher/src/sys/unix/service.rs
+++ b/components/launcher/src/sys/unix/service.rs
@@ -73,7 +73,7 @@ pub fn run(msg: protocol::Spawn) -> Result<Service> {
     let user_id = if let Some(suid) = msg.svc_user_id {
         suid
     } else if let Some(suser) = &msg.svc_user {
-        os::users::get_uid_by_name(&suser).ok_or_else(|| Error::UserNotFound(suser.to_string()))?
+        os::users::get_uid_by_name(&suser)?.ok_or_else(|| Error::UserNotFound(suser.to_string()))?
     } else {
         return Err(Error::UserNotFound(String::from("")));
     };
@@ -82,7 +82,9 @@ pub fn run(msg: protocol::Spawn) -> Result<Service> {
     let group_id = if let Some(sgid) = msg.svc_group_id {
         sgid
     } else if let Some(sgroup) = &msg.svc_group {
-        os::users::get_gid_by_name(&sgroup).ok_or_else(|| Error::GroupNotFound(sgroup.to_string()))?
+        os::users::get_gid_by_name(&sgroup)?.ok_or_else(|| {
+                                                Error::GroupNotFound(sgroup.to_string())
+                                            })?
     } else {
         return Err(Error::GroupNotFound(String::from("")));
     };

--- a/components/launcher/src/sys/windows/service.rs
+++ b/components/launcher/src/sys/windows/service.rs
@@ -154,7 +154,7 @@ fn spawn_pwsh(ps_binary_name: &str, msg: protocol::Spawn) -> Result<Service> {
             // remove this when we are confident everyone is on a recent supervisor
             // and launcher.
             let mut username = u.to_string();
-            if get_current_username() == Some("system".to_string()) {
+            if get_current_username()? == Some("system".to_string()) {
                 if let Ok(cn) = env::var("COMPUTERNAME") {
                     if u == &(cn.to_lowercase() + "$") {
                         username = "system".to_string();

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -321,7 +321,7 @@ impl Service {
     async fn resolve_pkg(package: &PackageInstall, spec: &ServiceSpec) -> Result<Pkg> {
         let mut pkg = Pkg::from_install(&package).await?;
         if spec.svc_encrypted_password.is_none() && pkg.svc_user == DEFAULT_USER {
-            if let Some(user) = users::get_current_username() {
+            if let Some(user) = users::get_current_username()? {
                 pkg.svc_user = user;
             }
         }

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -138,14 +138,14 @@ impl Supervisor {
         if process::can_run_services_as_svc_user() {
             // We have the ability to run services as a user / group other
             // than ourselves, so they better exist
-            let uid = users::get_uid_by_name(&pkg.svc_user).ok_or_else(|| {
-                                                               Error::UserNotFound(pkg.svc_user
-                                                                                      .to_string())
-                                                           })?;
-            let gid = users::get_gid_by_name(&pkg.svc_group).ok_or_else(|| {
-                                                                Error::GroupNotFound(pkg.svc_group
-                                                                                  .to_string())
+            let uid = users::get_uid_by_name(&pkg.svc_user)?.ok_or_else(|| {
+                                                                Error::UserNotFound(pkg.svc_user
+                                                                                       .to_string())
                                                             })?;
+            let gid = users::get_gid_by_name(&pkg.svc_group)?.ok_or_else(|| {
+                                                                 Error::GroupNotFound(pkg.svc_group
+                                                                                  .to_string())
+                                                             })?;
 
             Ok(UserInfo { username:  Some(pkg.svc_user.clone()),
                           uid:       Some(uid),
@@ -155,9 +155,9 @@ impl Supervisor {
             // We DO NOT have the ability to run as other users!  Also
             // note that we legitimately may not have a username or
             // groupname.
-            let username = users::get_effective_username();
+            let username = users::get_effective_username()?;
             let uid = users::get_effective_uid();
-            let groupname = users::get_effective_groupname();
+            let groupname = users::get_effective_groupname()?;
             let gid = users::get_effective_gid();
 
             let name_for_logging = username.clone()

--- a/components/sup/tests/utils/mod.rs
+++ b/components/sup/tests/utils/mod.rs
@@ -121,18 +121,15 @@ fn write_default_svc_user_and_group_metafiles<S, T>(hab_root: &HabRoot, pkg_orig
 
     if !svc_user_metafile.is_file() {
         write_metafile(svc_user_metafile,
-                       users::get_current_username().expect("Could not determine current \
-                                                             username")
-                                                    .expect("Could not determine current username")
+                       users::get_current_username().expect("Failed to get username")
+                                                    .expect("No username found")
                                                     .as_str());
     }
 
     if !svc_group_metafile.is_file() {
         write_metafile(svc_group_metafile,
-                       users::get_current_groupname().expect("Could not determine current \
-                                                              groupname")
-                                                     .expect("Could not determine current \
-                                                              groupname")
+                       users::get_current_groupname().expect("Failed to get groupname")
+                                                     .expect("No groupname found")
                                                      .as_str());
     }
 }

--- a/components/sup/tests/utils/mod.rs
+++ b/components/sup/tests/utils/mod.rs
@@ -123,12 +123,15 @@ fn write_default_svc_user_and_group_metafiles<S, T>(hab_root: &HabRoot, pkg_orig
         write_metafile(svc_user_metafile,
                        users::get_current_username().expect("Could not determine current \
                                                              username")
+                                                    .expect("Could not determine current username")
                                                     .as_str());
     }
 
     if !svc_group_metafile.is_file() {
         write_metafile(svc_group_metafile,
                        users::get_current_groupname().expect("Could not determine current \
+                                                              groupname")
+                                                     .expect("Could not determine current \
                                                               groupname")
                                                      .as_str());
     }


### PR DESCRIPTION
Resolves #7298 

This improves our APIs used to get users and groups by returning `Result<Option<T>>` instead of simply an `Option<T>`. This means we should now report an error instead of simply assuming there is no group in the case that the buffer is not large (or any other error). Users should then be able to increase the buffer size appropriately with the [`_SC_GETGR_R_SIZE_MAX` setting](https://github.com/nix-rust/nix/blob/96054b6933404b4c1d5dbd49db7ec7c7a26e44de/src/unistd.rs#L2707).