### PR TITLE
additional validation for PackageIdent fields

### DIFF
--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -219,7 +219,7 @@ impl fmt::Display for Error {
             }
             Error::ConfigInvalidIdent(ref f) => {
                 format!("Invalid package identifier string value in config, field={}. (example: \
-                         \"core/redis\")",
+                         \"core/redis/1.2.3/20200820140808\")",
                         f)
             }
             Error::ConfigInvalidIpAddr(ref f) => {

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -819,14 +819,12 @@ mod tests {
         let valid1 = PackageIdent::new("acme", "rocket", Some("1.2.3"), Some("1234"));
         let valid2 = PackageIdent::new("acme", "rocket-one", Some("1.2.3"), Some("1234"));
         let valid3 = PackageIdent::new("acme", "rocket_one", Some("1.2.3"), Some("1234"));
-        let valid4 = PackageIdent::new("acme", "rocket_one", Some("foo-bar"), Some("1234"));
         let invalid1 = PackageIdent::new("acme", "rocket.one", Some("1.2.3"), Some("1234"));
         let invalid2 = PackageIdent::new("acme", "rocket%one", Some("1.2.3"), Some("1234"));
 
         assert!(valid1.valid());
         assert!(valid2.valid());
         assert!(valid3.valid());
-        assert!(valid4.valid());
         assert!(!invalid1.valid());
         assert!(!invalid2.valid());
     }

--- a/components/hab/src/command/pkg/sign.rs
+++ b/components/hab/src/command/pkg/sign.rs
@@ -1,14 +1,27 @@
-use std::path::Path;
+use std::path::{Path,
+                PathBuf};
 
 use crate::{common::ui::{Status,
                          UIWriter,
                          UI},
-            hcore::crypto::{artifact,
-                            SigKeyPair}};
+            hcore::{crypto::{artifact,
+                             SigKeyPair},
+                    package::{Identifiable,
+                              PackageArchive}}};
 
 use crate::error::Result;
 
 pub fn start(ui: &mut UI, origin: &SigKeyPair, src: &Path, dst: &Path) -> Result<()> {
+    // Detect if what we're about to sign is in fact a PackageArchive and
+    // if so, we need to do some basic PackageIdent field validation.
+    if let Ok(mut archive) = PackageArchive::new(PathBuf::from(dst)) {
+        let ident = archive.ident()?;
+        ui.status(Status::Verifying,
+                  format!("{} has valid PackageIdent fields", ident))?;
+        if !ident.valid() {
+            ident.validate_fields()?;
+        }
+    }
     ui.begin(format!("Signing {}", src.display()))?;
     ui.status(Status::Signing,
               format!("{} with {} to create {}",
@@ -16,6 +29,7 @@ pub fn start(ui: &mut UI, origin: &SigKeyPair, src: &Path, dst: &Path) -> Result
                       &origin.name_with_rev(),
                       dst.display()))?;
     artifact::sign(src, dst, origin)?;
+
     ui.end(format!("Signed artifact {}.", dst.display()))?;
     Ok(())
 }


### PR DESCRIPTION
Closes https://github.com/habitat-sh/builder/issues/1407

This will prevent bad `PackageIdent` version or release fields from
creating an inoperable situation on either the filesystem or via HTTP
calls to Builder.

In both cases, sequences such as '/../' or '/./' or even '/..1/' in the package name
create problems for operations on the CLI or Builder API as those have
special meaning and result in an inoperable or unintended outcome.

For all intents and purposes, `.` should not exist:

- at the start of a  field
- end of field
- or more than once, in a repeated sequence anywhere in a field

We prevent the above patterns in new packages by using `PackageIdent` field validation in the package signing (executed during builds). Validation will also be picked up by Builder [here](https://github.com/habitat-sh/builder/blob/2d1db94bba7ae3b4a1854ca77220134460d9e6c7/components/builder-api/src/server/resources/pkgs.rs#L504-L507) and will prevent such packages from being uploaded.

Signed-off-by: Jeremy J. Miller <jm@chef.io>
