### PR TITLE
Fix text in e2e test

### DIFF
--- a/test/end-to-end/hup-does-not-abandon-services.exp
+++ b/test/end-to-end/hup-does-not-abandon-services.exp
@@ -112,7 +112,7 @@ assert { $redis_parent == $launcher_pid } "Didn't do that right!"
 # we shut down.
 exec kill -HUP $launcher_pid
 expect {
-    "Supervisor shutting down for signal" {
+    "Supervisor shutting down for restart" {
         log "Supervisor got HUPped"
     }
     timeout {


### PR DESCRIPTION
The Supervisor used to log the message `Supervisor shutting down for signal` it now logs `Supervisor shutting down for restart` because it could also restart due to the `hab sup restart` command. This fixes the text we look for in a test. 

Signed-off-by: David McNeil <mcneil.david2@gmail.com>