### PR TITLE
readonly pkg_release and ensure pkg_version is semver

### DIFF
--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -575,8 +575,8 @@ _ensure_origin_key_present() {
 # The checks for dots as just described, prevent inoperable or unexpected results when operating
 # the hab CLI or interacting with Builder HTTP APIs as the dots have special meaning in a URI.
 _validate_pkg_version() {
-  local wellformed_re="^([[[:digit:]]\.]*[[:digit:]]+)(.+)?"
   local inoperable_re="^\.+|\.$|\.{2,}"
+  local wellformed_re="^([[[:digit:]]\.]*[[:digit:]]+)(.+)?"
 
   if [[ ! $pkg_version =~ $wellformed_re ]] || [[ $pkg_version =~ $inoperable_re ]]; then
      exit_with "Found pkg_version with an invalid format, aborting! See: https://semver.org/"


### PR DESCRIPTION
Fixes https://github.com/habitat-sh/builder/issues/1407

This should help prevent packages with invalid `pkg_version` or `pkg_release` from being created and uploaded to Builder. It enforces adherance to a semver format that we already require internally in Builder's table views.
