### PR TITLE
Keep the code inside of the window

### DIFF
--- a/www/source/stylesheets/_code.scss
+++ b/www/source/stylesheets/_code.scss
@@ -4,6 +4,7 @@ pre {
   border: 1px solid $hab-gray-dark;
   padding: 0.125rem 0.3125rem 0.0625rem;
   margin-bottom: 15px;
+  white-space: pre-wrap;
 
   code {
     background-color: transparent;


### PR DESCRIPTION
Long code lines in our samples extend past the edge of the terminal. I added `white-space: pre-wrap` to the code styling and now users won't have to scroll to see long code samples.

Before:

<img width="783" alt="Screen Shot 2020-08-26 at 6 44 04 PM" src="https://user-images.githubusercontent.com/4400151/91483859-2f37a580-e85d-11ea-89b4-afe1e1e2e37b.png">

After:

<img width="856" alt="Screen Shot 2020-08-27 at 11 57 05 AM" src="https://user-images.githubusercontent.com/4400151/91483886-3a8ad100-e85d-11ea-9ca8-9974bbcc3261.png">

Copies as:
```
pkg_name=sqlite
pkg_version=3130000
pkg_origin=core
pkg_license=('Public Domain')
pkg_maintainer="The Chef Habitat Maintainers <humans@habitat.sh>"
pkg_description="A software library that implements a self-contained, serverless, zero-configuration, transactional SQL database engine."
pkg_upstream_url=https://www.sqlite.org/
pkg_source=https://www.sqlite.org/2016/${pkg_name}-autoconf-${pkg_version}.tar.gz
pkg_filename=${pkg_name}-autoconf-${pkg_version}.tar.gz
pkg_dirname=${pkg_name}-autoconf-${pkg_version}
pkg_shasum=e2797026b3310c9d08bd472f6d430058c6dd139ff9d4e30289884ccd9744086b
pkg_deps=(core/glibc core/readline)
pkg_build_deps=(core/gcc core/make core/coreutils)
pkg_lib_dirs=(lib)
pkg_include_dirs=(include)
pkg_bin_dirs=(bin)
```


Signed-off-by: kagarmoe <kgarmoe@chef.io>