### PR TITLE
re-add removed else condition logic for hab pkg download

### DIFF
--- a/components/hab/src/command/pkg/download.rs
+++ b/components/hab/src/command/pkg/download.rs
@@ -337,6 +337,7 @@ impl<'a> DownloadTask<'a> {
                    ident);
             ui.status(Status::Custom(Glyph::Elipses, String::from("Using cached")),
                       format!("{}", ident))?;
+        } else {
             self.fetch_artifact(ui, ident, target).await?;
         }
 


### PR DESCRIPTION
During some PR feedback refactor I missed an else branch statement. This was preventing `hab pkg download` from actually fetching the remote artifact.

Signed-off-by: Jeremy J. Miller <jm@chef.io>