### PR TITLE
adding missing else branch to install from cache when present

### DIFF
--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -670,8 +670,9 @@ impl<'a> InstallTask<'a> {
                    ident);
         } else if self.is_offline() {
             return Err(Error::OfflineArtifactNotFound(ident.as_ref().clone()));
+        } else {
+            self.fetch_artifact(ui, (ident, target), token).await?;
         }
-        self.fetch_artifact(ui, (ident, target), token).await?;
 
         let mut artifact = PackageArchive::new(self.cached_artifact_path(ident))?;
         ui.status(Status::Verifying, artifact.ident()?)?;


### PR DESCRIPTION
This was present before but was unfortunately removed during a PR refactor [here](https://github.com/habitat-sh/habitat/pull/7874/files#diff-d026201ad4bd6dd675541223a2b27009R674). I've audited the rest of the original PR and don not see any other occurrences of this problem.

This should fix the errors in our release pipeline: https://buildkite.com/chef/habitat-sh-habitat-master-end-to-end/builds/726#2ca1c095-0607-41e2-953f-f191553950f2

Signed-off-by: Jeremy J. Miller <jm@chef.io>