### PR TITLE
[REFACTOR] Utilize the `Origin` type more broadly

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -444,7 +444,7 @@ impl BuilderAPIClient {
     /// * Remote Builder is not available
     /// * File cannot be created and written to
     pub async fn fetch_origin_public_encryption_key<'a>(&'a self,
-                                                        origin: &'a str,
+                                                        origin: &'a Origin,
                                                         token: &'a str,
                                                         dst_path: &'a Path,
                                                         progress: Option<Box<dyn DisplayProgress>>)
@@ -484,7 +484,7 @@ impl BuilderAPIClient {
     ///
     /// * Remote Builder is not available
     pub async fn create_origin_secret(&self,
-                                      origin: &str,
+                                      origin: &Origin,
                                       token: &str,
                                       key_name: &str,
                                       secret: &AnonymousBox)
@@ -512,7 +512,7 @@ impl BuilderAPIClient {
     ///
     /// * Remote Builder is not available
     pub async fn delete_origin_secret(&self,
-                                      origin: &str,
+                                      origin: &Origin,
                                       token: &str,
                                       key_name: &str)
                                       -> Result<()> {
@@ -804,7 +804,7 @@ impl BuilderAPIClient {
     /// # Failures
     ///
     /// * Remote Builder is not available
-    pub async fn list_origin_secrets(&self, origin: &str, token: &str) -> Result<Vec<String>> {
+    pub async fn list_origin_secrets(&self, origin: &Origin, token: &str) -> Result<Vec<String>> {
         debug!("Listing origin secret: {}", origin);
 
         let path = format!("depot/origins/{}/secret", origin);
@@ -850,7 +850,7 @@ impl BuilderAPIClient {
     /// * Remote Builder is not available
     /// * File cannot be created and written to
     pub async fn fetch_secret_origin_key<'a>(&'a self,
-                                             origin: &'a str,
+                                             origin: &'a Origin,
                                              token: &'a str,
                                              dst_path: &'a Path,
                                              progress: Option<Box<dyn DisplayProgress>>)
@@ -864,7 +864,7 @@ impl BuilderAPIClient {
             .await
     }
 
-    pub async fn show_origin_keys(&self, origin: &str) -> Result<Vec<OriginKeyIdent>> {
+    pub async fn show_origin_keys(&self, origin: &Origin) -> Result<Vec<OriginKeyIdent>> {
         debug!("Showing origin keys: {}", origin);
 
         let resp = self.0.get(&origin_keys_path(origin)).send().await?;
@@ -1259,7 +1259,7 @@ impl BuilderAPIClient {
     ///
     /// * Remote Builder is not available
     pub async fn create_channel(&self,
-                                origin: &str,
+                                origin: &Origin,
                                 channel: &ChannelIdent,
                                 token: &str)
                                 -> Result<()> {
@@ -1276,7 +1276,7 @@ impl BuilderAPIClient {
     ///
     /// * Remote Builder is not available
     pub async fn delete_channel(&self,
-                                origin: &str,
+                                origin: &Origin,
                                 channel: &ChannelIdent,
                                 token: &str)
                                 -> Result<()> {
@@ -1293,7 +1293,7 @@ impl BuilderAPIClient {
     ///
     /// * Remote Builder is not available
     pub async fn promote_channel_packages(&self,
-                                          origin: &str,
+                                          origin: &Origin,
                                           token: &str,
                                           source_channel: &ChannelIdent,
                                           target_channel: &ChannelIdent)
@@ -1320,7 +1320,7 @@ impl BuilderAPIClient {
     ///
     /// * Remote Builder is not available
     pub async fn demote_channel_packages(&self,
-                                         origin: &str,
+                                         origin: &Origin,
                                          token: &str,
                                          source_channel: &ChannelIdent,
                                          target_channel: &ChannelIdent)
@@ -1361,7 +1361,7 @@ impl BuilderAPIClient {
     /// * Remote Builder is not available
     /// * Authorization token was not set on client
     pub async fn list_channels(&self,
-                               origin: &str,
+                               origin: &Origin,
                                include_sandbox_channels: bool)
                                -> Result<Vec<String>> {
         debug!("Listing channels for origin {}", origin);
@@ -1471,7 +1471,7 @@ macro_rules! retry_builder_api {
     };
 }
 
-fn origin_keys_path(origin: &str) -> String { format!("depot/origins/{}/keys", origin) }
+fn origin_keys_path(origin: &Origin) -> String { format!("depot/origins/{}/keys", origin) }
 
 fn package_download(package: &PackageIdent) -> String {
     format!("{}/download", package_path(package))

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -1024,7 +1024,10 @@ impl<'a> InstallTask<'a> {
                                          -> Result<Vec<(String, String)>> {
         let mut res = Vec::new();
 
-        let channels = match self.api_client.list_channels(ident.origin(), false).await {
+        let channels = match self.api_client
+                                 .list_channels(&ident.hacky_get_origin(), false)
+                                 .await
+        {
             Ok(channels) => channels,
             Err(e) => {
                 debug!("Failed to get channel list: {:?}", e);

--- a/components/core/src/crypto/artifact.rs
+++ b/components/core/src/crypto/artifact.rs
@@ -240,7 +240,8 @@ mod test {
     #[should_panic(expected = "Corrupt payload, can\\'t read hash type")]
     fn verify_empty_hash_type() {
         let (cache, dir) = new_cache();
-        let (public, _secret) = cache.new_signing_pair("unicorn").unwrap();
+        let origin = "unicorn".parse().unwrap();
+        let (public, _secret) = cache.new_signing_pair(&origin).unwrap();
 
         let dst = dir.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -254,7 +255,8 @@ mod test {
     #[should_panic(expected = "Unsupported signature type: BESTEST")]
     fn verify_invalid_hash_type() {
         let (cache, dir) = new_cache();
-        let (public, _secret) = cache.new_signing_pair("unicorn").unwrap();
+        let origin = "unicorn".parse().unwrap();
+        let (public, _secret) = cache.new_signing_pair(&origin).unwrap();
 
         let dst = dir.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -268,7 +270,8 @@ mod test {
     #[should_panic(expected = "Corrupt payload, can\\'t read signature")]
     fn verify_empty_signature() {
         let (cache, dir) = new_cache();
-        let (public, _secret) = cache.new_signing_pair("unicorn").unwrap();
+        let origin = "unicorn".parse().unwrap();
+        let (public, _secret) = cache.new_signing_pair(&origin).unwrap();
 
         let dst = dir.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -282,7 +285,8 @@ mod test {
     #[should_panic(expected = "Can\\'t decode signature")]
     fn verify_invalid_signature_decode() {
         let (cache, dir) = new_cache();
-        let (public, _secret) = cache.new_signing_pair("unicorn").unwrap();
+        let origin = "unicorn".parse().unwrap();
+        let (public, _secret) = cache.new_signing_pair(&origin).unwrap();
 
         let dst = dir.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -297,7 +301,8 @@ mod test {
     #[should_panic(expected = "Corrupt payload, can\\'t find end of header")]
     fn verify_missing_end_of_header() {
         let (cache, dir) = new_cache();
-        let (public, _secret) = cache.new_signing_pair("unicorn").unwrap();
+        let origin = "unicorn".parse().unwrap();
+        let (public, _secret) = cache.new_signing_pair(&origin).unwrap();
 
         let dst = dir.path().join("signed.dat");
         let mut f = File::create(&dst).unwrap();
@@ -312,7 +317,8 @@ mod test {
     #[should_panic(expected = "Habitat artifact is invalid")]
     fn verify_corrupted_archive() {
         let (cache, dir) = new_cache();
-        let (_public, secret) = cache.new_signing_pair("unicorn").unwrap();
+        let origin = "unicorn".parse().unwrap();
+        let (_public, secret) = cache.new_signing_pair(&origin).unwrap();
 
         let dst = dir.path().join("signed.dat");
         let dst_corrupted = dir.path().join("corrupted.dat");
@@ -343,7 +349,8 @@ mod test {
     #[test]
     fn get_archive_reader_working() {
         let (cache, dir) = new_cache();
-        let (_public, secret) = cache.new_signing_pair("unicorn").unwrap();
+        let origin = "unicorn".parse().unwrap();
+        let (_public, secret) = cache.new_signing_pair(&origin).unwrap();
 
         let src = dir.path().join("src.in");
         let dst = dir.path().join("src.signed");
@@ -360,7 +367,8 @@ mod test {
     #[test]
     fn verify_get_artifact_header() {
         let (cache, dir) = new_cache();
-        let (_public, secret) = cache.new_signing_pair("unicorn").unwrap();
+        let origin = "unicorn".parse().unwrap();
+        let (_public, secret) = cache.new_signing_pair(&origin).unwrap();
 
         let src = dir.path().join("src.in");
         let dst = dir.path().join("src.signed");

--- a/components/core/src/crypto/keys/encryption/origin_key.rs
+++ b/components/core/src/crypto/keys/encryption/origin_key.rs
@@ -25,7 +25,8 @@ use crate::{crypto::keys::{encryption::{primitives,
                            NamedRevision},
             error::{Error,
                     Result},
-            fs::Permissions};
+            fs::Permissions,
+            origin::Origin};
 
 /// Given the name of an origin, generate a new encryption key pair.
 ///
@@ -36,9 +37,9 @@ use crate::{crypto::keys::{encryption::{primitives,
 /// encryption keys should never be created in the Supervisor or the
 /// CLI.
 pub fn generate_origin_encryption_key_pair(
-    origin_name: &str)
+    origin: &Origin)
     -> (OriginPublicEncryptionKey, OriginSecretEncryptionKey) {
-    let named_revision = NamedRevision::new(origin_name.to_string());
+    let named_revision = NamedRevision::new(origin.to_string());
     let (pk, sk) = primitives::gen_keypair();
 
     let public = OriginPublicEncryptionKey { named_revision: named_revision.clone(),

--- a/components/core/src/crypto/keys/signing.rs
+++ b/components/core/src/crypto/keys/signing.rs
@@ -5,7 +5,8 @@ use crate::{crypto::{hash,
                      SECRET_SIG_KEY_VERSION},
             error::{Error,
                     Result},
-            fs::Permissions};
+            fs::Permissions,
+            origin::Origin};
 use std::{io::Read,
           path::Path};
 
@@ -23,9 +24,9 @@ mod primitives {
 ///
 /// The resulting keys will need to be saved to a cache in order to
 /// persist.
-pub fn generate_signing_key_pair(origin_name: &str)
+pub fn generate_signing_key_pair(origin: &Origin)
                                  -> (PublicOriginSigningKey, SecretOriginSigningKey) {
-    let named_revision = NamedRevision::new(origin_name.to_string());
+    let named_revision = NamedRevision::new(origin.to_string());
     let (pk, sk) = primitives::gen_keypair();
 
     let public = PublicOriginSigningKey { named_revision: named_revision.clone(),
@@ -193,7 +194,8 @@ mod tests {
     /// maintain that behavior for backwards compatibility reasons.
     #[test]
     fn signing_inputs_case_is_significant() {
-        let (_public, secret) = generate_signing_key_pair("test-origin");
+        let origin = "test-origin".parse().unwrap();
+        let (_public, secret) = generate_signing_key_pair(&origin);
 
         let lower_case = "20590a52c4f00588c500328b16d466c982a26fabaa5fa4dcc83052dd0a84f233";
         let upper_case = "20590A52C4F00588C500328B16D466C982A26FABAA5FA4DCC83052DD0A84F233";

--- a/components/core/src/crypto/keys/util.rs
+++ b/components/core/src/crypto/keys/util.rs
@@ -199,7 +199,8 @@ mod tests {
 
         #[test]
         fn origin_keys() {
-            let (public, secret) = generate_origin_encryption_key_pair("my-origin");
+            let origin = "my-origin".parse().unwrap();
+            let (public, secret) = generate_origin_encryption_key_pair(&origin);
             assert_parse_round_trip!(OriginPublicEncryptionKey, public);
             assert_parse_round_trip!(OriginSecretEncryptionKey, secret);
         }
@@ -213,7 +214,8 @@ mod tests {
 
         #[test]
         fn signing_keys() {
-            let (public, secret) = generate_signing_key_pair("my-origin");
+            let origin = "my-origin".parse().unwrap();
+            let (public, secret) = generate_signing_key_pair(&origin);
             assert_parse_round_trip!(PublicOriginSigningKey, public);
             assert_parse_round_trip!(SecretOriginSigningKey, secret);
         }
@@ -322,8 +324,9 @@ mod tests {
 
                 #[test]
                 fn origin_encryption_keys_can_parse_as_all_other_encryption_keys() {
+                    let origin = "test-origin".parse().unwrap();
                     let (origin_public, origin_secret) =
-                        generate_origin_encryption_key_pair("test-origin");
+                        generate_origin_encryption_key_pair(&origin);
                     assert_public_key_equivalence!(origin_public);
                     assert_secret_key_equivalence!(origin_secret);
                 }
@@ -355,7 +358,8 @@ mod tests {
 
         #[test]
         fn origin_keys() {
-            let (public, secret) = generate_origin_encryption_key_pair("my-origin");
+            let origin = "my-origin".parse().unwrap();
+            let (public, secret) = generate_origin_encryption_key_pair(&origin);
 
             assert_eq!(format!("OriginPublicEncryptionKey my-origin-{}",
                                public.named_revision().revision()),
@@ -379,7 +383,8 @@ mod tests {
 
         #[test]
         fn signing_keys() {
-            let (public, secret) = generate_signing_key_pair("my-origin");
+            let origin = "my-origin".parse().unwrap();
+            let (public, secret) = generate_signing_key_pair(&origin);
             assert_eq!(format!("PublicOriginSigningKey my-origin-{}",
                                public.named_revision().revision()),
                        format!("{:?}", public));
@@ -454,7 +459,8 @@ mod tests {
 
             #[test]
             fn origin_keys() {
-                let (public, secret) = generate_origin_encryption_key_pair("my-origin");
+                let origin = "my-origin".parse().unwrap();
+                let (public, secret) = generate_origin_encryption_key_pair(&origin);
                 assert_eq!(PathBuf::from(&format!("{}.pub", public.named_revision())),
                            public.own_filename());
                 assert_eq!(PathBuf::from(&format!("{}.box.key", secret.named_revision())),
@@ -473,7 +479,8 @@ mod tests {
 
             #[test]
             fn signing_keys() {
-                let (public, secret) = generate_signing_key_pair("my-origin");
+                let origin = "my-origin".parse().unwrap();
+                let (public, secret) = generate_signing_key_pair(&origin);
                 assert_eq!(PathBuf::from(&format!("{}.pub", public.named_revision())),
                            public.own_filename());
                 assert_eq!(PathBuf::from(&format!("{}.sig.key", secret.named_revision())),

--- a/components/core/src/origin.rs
+++ b/components/core/src/origin.rs
@@ -6,7 +6,7 @@ use std::{fmt,
           result,
           str::FromStr};
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Origin(String);
 
 impl Origin {
@@ -39,6 +39,10 @@ impl std::convert::TryFrom<&str> for Origin {
     type Error = Error;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> { Self::from_str(s) }
+}
+
+impl AsRef<str> for Origin {
+    fn as_ref(&self) -> &str { &self.0 }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/components/core/src/package/ident.rs
+++ b/components/core/src/package/ident.rs
@@ -1,5 +1,6 @@
 use crate::{error::{Error,
                     Result},
+            origin::Origin,
             package::PackageTarget};
 use regex::Regex;
 use serde_derive::{Deserialize,
@@ -22,6 +23,16 @@ pub struct PackageIdent {
     pub name:    String,
     pub version: Option<String>,
     pub release: Option<String>,
+}
+
+impl PackageIdent {
+    /// This is a *temporary* function in place until `PackageIdent`
+    /// returns a `&Origin` natively.
+    pub fn hacky_get_origin(&self) -> Origin {
+        self.origin
+            .parse()
+            .expect("A PackageIdent should always have a valid Origin name")
+    }
 }
 
 pub trait Identifiable: fmt::Display {

--- a/components/hab/src/command/bldr/channel/create.rs
+++ b/components/hab/src/command/bldr/channel/create.rs
@@ -2,17 +2,17 @@ use crate::{api_client::Client,
             common::ui::{Status,
                          UIWriter,
                          UI},
-            hcore::ChannelIdent};
-
-use crate::{error::{Error,
+            error::{Error,
                     Result},
             PRODUCT,
             VERSION};
+use habitat_core::{origin::Origin,
+                   ChannelIdent};
 
 pub async fn start(ui: &mut UI,
                    bldr_url: &str,
                    token: &str,
-                   origin: &str,
+                   origin: &Origin,
                    channel: &ChannelIdent)
                    -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;

--- a/components/hab/src/command/bldr/channel/demote.rs
+++ b/components/hab/src/command/bldr/channel/demote.rs
@@ -7,11 +7,12 @@ use crate::{api_client::Client,
             hcore::ChannelIdent,
             PRODUCT,
             VERSION};
+use habitat_core::origin::Origin;
 
 pub async fn start(ui: &mut UI,
                    bldr_url: &str,
                    token: &str,
-                   origin: &str,
+                   origin: &Origin,
                    source_channel: &ChannelIdent,
                    target_channel: &ChannelIdent)
                    -> Result<()> {

--- a/components/hab/src/command/bldr/channel/destroy.rs
+++ b/components/hab/src/command/bldr/channel/destroy.rs
@@ -2,17 +2,17 @@ use crate::{api_client::Client,
             common::ui::{Status,
                          UIWriter,
                          UI},
-            hcore::ChannelIdent};
-
-use crate::{error::{Error,
+            error::{Error,
                     Result},
             PRODUCT,
             VERSION};
+use habitat_core::{origin::Origin,
+                   ChannelIdent};
 
 pub async fn start(ui: &mut UI,
                    bldr_url: &str,
                    token: &str,
-                   origin: &str,
+                   origin: &Origin,
                    channel: &ChannelIdent)
                    -> Result<()> {
     let bldr_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;

--- a/components/hab/src/command/bldr/channel/list.rs
+++ b/components/hab/src/command/bldr/channel/list.rs
@@ -1,14 +1,14 @@
 use crate::{api_client::Client,
             common::ui::{Status,
                          UIWriter,
-                         UI}};
-
-use crate::{error::{Error,
+                         UI},
+            error::{Error,
                     Result},
             PRODUCT,
             VERSION};
+use habitat_core::origin::Origin;
 
-pub async fn start(ui: &mut UI, bldr_url: &str, origin: &str) -> Result<()> {
+pub async fn start(ui: &mut UI, bldr_url: &str, origin: &Origin) -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
 
     ui.status(Status::Determining, format!("channels for {}.", origin))?;

--- a/components/hab/src/command/bldr/channel/promote.rs
+++ b/components/hab/src/command/bldr/channel/promote.rs
@@ -2,17 +2,17 @@ use crate::{api_client::Client,
             common::ui::{Status,
                          UIWriter,
                          UI},
-            hcore::ChannelIdent};
-
-use crate::{error::{Error,
+            error::{Error,
                     Result},
             PRODUCT,
             VERSION};
+use habitat_core::{origin::Origin,
+                   ChannelIdent};
 
 pub async fn start(ui: &mut UI,
                    bldr_url: &str,
                    token: &str,
-                   origin: &str,
+                   origin: &Origin,
                    source_channel: &ChannelIdent,
                    target_channel: &ChannelIdent)
                    -> Result<()> {

--- a/components/hab/src/command/origin/key/download.rs
+++ b/components/hab/src/command/origin/key/download.rs
@@ -13,14 +13,15 @@ use crate::{api_client::{self,
                     Result},
             PRODUCT,
             VERSION};
-use habitat_core::crypto::keys::{KeyCache,
-                                 NamedRevision};
+use habitat_core::{crypto::keys::{KeyCache,
+                                  NamedRevision},
+                   origin::Origin};
 use reqwest::StatusCode;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn start(ui: &mut UI,
                    bldr_url: &str,
-                   origin: &str,
+                   origin: &Origin,
                    revision: Option<&str>,
                    secret: bool,
                    encryption: bool,
@@ -40,7 +41,7 @@ pub async fn start(ui: &mut UI,
 
 async fn handle_public(ui: &mut UI,
                        api_client: &BuilderAPIClient,
-                       origin: &str,
+                       origin: &Origin,
                        revision: Option<&str>,
                        token: Option<&str>,
                        key_cache: &KeyCache)
@@ -82,7 +83,7 @@ async fn handle_public(ui: &mut UI,
 
 async fn handle_secret(ui: &mut UI,
                        api_client: &BuilderAPIClient,
-                       origin: &str,
+                       origin: &Origin,
                        token: Option<&str>,
                        key_cache: &KeyCache)
                        -> Result<()> {
@@ -93,13 +94,13 @@ async fn handle_secret(ui: &mut UI,
 
     ui.begin(format!("Downloading secret origin keys for {}", origin))?;
     download_secret_key(ui, &api_client, origin, token.unwrap(), key_cache).await?; // unwrap is safe because we already checked it above
-    ui.end(format!("Download of {} secret origin keys completed.", &origin))?;
+    ui.end(format!("Download of {} secret origin keys completed.", origin))?;
     Ok(())
 }
 
 async fn handle_encryption(ui: &mut UI,
                            api_client: &BuilderAPIClient,
-                           origin: &str,
+                           origin: &Origin,
                            token: Option<&str>,
                            key_cache: &KeyCache)
                            -> Result<()> {
@@ -116,13 +117,13 @@ async fn handle_encryption(ui: &mut UI,
 
 pub async fn download_public_encryption_key(ui: &mut UI,
                                             api_client: &BuilderAPIClient,
-                                            name: &str,
+                                            origin: &Origin,
                                             token: &str,
                                             key_cache: &KeyCache)
                                             -> Result<()> {
     retry_builder_api!(async {
         ui.status(Status::Downloading, "latest public encryption key")?;
-        let key_path = api_client.fetch_origin_public_encryption_key(name,
+        let key_path = api_client.fetch_origin_public_encryption_key(origin,
                                                                      token,
                                                                      key_cache.as_ref(),
                                                                      ui.progress())
@@ -133,7 +134,7 @@ pub async fn download_public_encryption_key(ui: &mut UI,
     }).await
       .map_err(|e| {
           APIClientError(APIFailure::DownloadLatestKeyFailed(API_RETRY_COUNT,
-                                                             name.to_string(),
+                                                             origin.to_string(),
                                                              Box::new(e)))
       })?;
     Ok(())
@@ -141,14 +142,14 @@ pub async fn download_public_encryption_key(ui: &mut UI,
 
 async fn download_secret_key(ui: &mut UI,
                              api_client: &BuilderAPIClient,
-                             name: &str,
+                             origin: &Origin,
                              token: &str,
                              key_cache: &KeyCache)
                              -> Result<()> {
     retry_builder_api!(async {
         ui.status(Status::Downloading, "latest secret key")?;
         let key_path =
-            api_client.fetch_secret_origin_key(name, token, key_cache.as_ref(), ui.progress())
+            api_client.fetch_secret_origin_key(origin, token, key_cache.as_ref(), ui.progress())
                       .await?;
         ui.status(Status::Cached,
                   key_path.file_name().unwrap().to_str().unwrap() /* lol */)?;
@@ -156,7 +157,7 @@ async fn download_secret_key(ui: &mut UI,
     }).await
       .map_err(|e| {
           APIClientError(APIFailure::DownloadLatestKeyFailed(API_RETRY_COUNT,
-                                                             name.to_string(),
+                                                             origin.to_string(),
                                                              Box::new(e)))
       })?;
     Ok(())

--- a/components/hab/src/command/origin/key/export.rs
+++ b/components/hab/src/command/origin/key/export.rs
@@ -1,11 +1,12 @@
 use crate::{cli::KeyType,
             error::Result};
-use habitat_core::crypto::keys::{KeyCache,
-                                 KeyFile};
+use habitat_core::{crypto::keys::{KeyCache,
+                                  KeyFile},
+                   origin::Origin};
 use std::{io,
           io::Write};
 
-pub fn start(origin: &str, key_type: KeyType, key_cache: &KeyCache) -> Result<()> {
+pub fn start(origin: &Origin, key_type: KeyType, key_cache: &KeyCache) -> Result<()> {
     match key_type {
         KeyType::Public => {
             let key = key_cache.latest_public_origin_signing_key(origin)?;

--- a/components/hab/src/command/origin/key/generate.rs
+++ b/components/hab/src/command/origin/key/generate.rs
@@ -1,19 +1,13 @@
 use crate::{common::ui::{UIWriter,
                          UI},
-            error::{Error,
-                    Result}};
+            error::Result};
 use habitat_core::{crypto::keys::{Key,
                                   KeyCache},
-                   package::ident,
-                   Error::InvalidOrigin};
+                   origin::Origin};
 
-pub fn start(ui: &mut UI, origin: &str, key_cache: &KeyCache) -> Result<()> {
-    if ident::is_valid_origin_name(origin) {
-        ui.begin(format!("Generating origin key for {}", &origin))?;
-        let (public, _secret) = key_cache.new_signing_pair(origin)?;
-        ui.end(format!("Generated origin key pair {}.", public.named_revision()))?;
-        Ok(())
-    } else {
-        Err(Error::from(InvalidOrigin(origin.to_string())))
-    }
+pub fn start(ui: &mut UI, origin: &Origin, key_cache: &KeyCache) -> Result<()> {
+    ui.begin(format!("Generating origin key for {}", origin))?;
+    let (public, _secret) = key_cache.new_signing_pair(origin)?;
+    ui.end(format!("Generated origin key pair {}.", public.named_revision()))?;
+    Ok(())
 }

--- a/components/hab/src/command/origin/key/upload_latest.rs
+++ b/components/hab/src/command/origin/key/upload_latest.rs
@@ -7,16 +7,17 @@ use crate::{api_client::{self,
                     Result},
             PRODUCT,
             VERSION};
-use habitat_core::crypto::keys::{Key,
-                                 KeyCache,
-                                 PublicOriginSigningKey,
-                                 SecretOriginSigningKey};
+use habitat_core::{crypto::keys::{Key,
+                                  KeyCache,
+                                  PublicOriginSigningKey,
+                                  SecretOriginSigningKey},
+                   origin::Origin};
 use reqwest::StatusCode;
 
 pub async fn start(ui: &mut UI,
                    bldr_url: &str,
                    token: &str,
-                   origin: &str,
+                   origin: &Origin,
                    with_secret: bool,
                    key_cache: &KeyCache)
                    -> Result<()> {

--- a/components/hab/src/command/origin/secret/delete.rs
+++ b/components/hab/src/command/origin/secret/delete.rs
@@ -1,17 +1,17 @@
 use crate::{api_client::Client,
             common::ui::{Status,
                          UIWriter,
-                         UI}};
-
-use crate::{error::{Error,
+                         UI},
+            error::{Error,
                     Result},
             PRODUCT,
             VERSION};
+use habitat_core::origin::Origin;
 
 pub async fn start(ui: &mut UI,
                    bldr_url: &str,
                    token: &str,
-                   origin: &str,
+                   origin: &Origin,
                    key: &str)
                    -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;

--- a/components/hab/src/command/origin/secret/list.rs
+++ b/components/hab/src/command/origin/secret/list.rs
@@ -1,14 +1,14 @@
 use crate::{api_client::Client,
             common::ui::{Status,
                          UIWriter,
-                         UI}};
-
-use crate::{error::{Error,
+                         UI},
+            error::{Error,
                     Result},
             PRODUCT,
             VERSION};
+use habitat_core::origin::Origin;
 
-pub async fn start(ui: &mut UI, bldr_url: &str, token: &str, origin: &str) -> Result<()> {
+pub async fn start(ui: &mut UI, bldr_url: &str, token: &str, origin: &Origin) -> Result<()> {
     let api_client = Client::new(bldr_url, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
 
     ui.status(Status::Determining, format!("secrets for {}.", origin))?;

--- a/components/hab/src/command/origin/secret/upload.rs
+++ b/components/hab/src/command/origin/secret/upload.rs
@@ -7,12 +7,13 @@ use crate::{api_client::Client,
                     Result},
             PRODUCT,
             VERSION};
-use habitat_core::crypto::keys::KeyCache;
+use habitat_core::{crypto::keys::KeyCache,
+                   origin::Origin};
 
 pub async fn start(ui: &mut UI,
                    bldr_url: &str,
                    token: &str,
-                   origin: &str,
+                   origin: &Origin,
                    key: &str,
                    secret: &str,
                    key_cache: &KeyCache)

--- a/components/hab/src/command/pkg/build.rs
+++ b/components/hab/src/command/pkg/build.rs
@@ -1,16 +1,17 @@
+use crate::{command::studio,
+            common::ui::UI,
+            error::Result};
+use habitat_core::origin::Origin;
 use std::ffi::OsString;
 
-use crate::common::ui::UI;
-
-use crate::{command::studio,
-            error::Result};
-
+/// origins - origins whose secret signing keys should be made
+///           available in the build
 #[allow(clippy::too_many_arguments)]
 pub async fn start(ui: &mut UI,
                    plan_context: &str,
                    root: Option<&str>,
                    src: Option<&str>,
-                   keys: Option<&str>,
+                   origins: &[Origin],
                    reuse: bool,
                    docker: bool)
                    -> Result<()> {
@@ -23,10 +24,16 @@ pub async fn start(ui: &mut UI,
         args.push("-s".into());
         args.push(src.into());
     }
-    if let Some(keys) = keys {
+
+    if !origins.is_empty() {
+        let signing_key_names = origins.iter()
+                                       .map(AsRef::as_ref)
+                                       .collect::<Vec<&str>>()
+                                       .join(",");
         args.push("-k".into());
-        args.push(keys.into());
+        args.push(signing_key_names.into());
     }
+
     args.push("build".into());
     if studio::native_studio_support() && reuse {
         args.push("-R".into());

--- a/components/hab/src/command/pkg/promote.rs
+++ b/components/hab/src/command/pkg/promote.rs
@@ -42,7 +42,7 @@ pub async fn start(ui: &mut UI,
     ui.begin(format!("Promoting {} ({}) to channel '{}'", ident, target, channel))?;
 
     if channel != &ChannelIdent::stable() && channel != &ChannelIdent::unstable() {
-        match api_client.create_channel(&ident.origin, channel, token)
+        match api_client.create_channel(&ident.hacky_get_origin(), channel, token)
                         .await
         {
             Ok(_) => (),

--- a/components/hab/src/command/pkg/upload.rs
+++ b/components/hab/src/command/pkg/upload.rs
@@ -199,7 +199,7 @@ async fn promote_to_channel(ui: &mut UI,
     ui.begin(format!("Promoting {} to channel '{}'", ident, channel))?;
 
     if channel != ChannelIdent::stable() && channel != ChannelIdent::unstable() {
-        match api_client.create_channel(&ident.origin, &channel, token)
+        match api_client.create_channel(&ident.hacky_get_origin(), &channel, token)
                         .await
         {
             Ok(_) => (),

--- a/components/hab/src/command/plan/init.rs
+++ b/components/hab/src/command/plan/init.rs
@@ -1,3 +1,10 @@
+use crate::{common::ui::{Status,
+                         UIWriter,
+                         UI},
+            error::Result};
+use habitat_core::{origin::Origin,
+                   package::PackageIdent};
+use handlebars::Handlebars;
 use std::{collections::HashMap,
           env,
           fs::{canonicalize,
@@ -8,14 +15,6 @@ use std::{collections::HashMap,
                BufReader,
                Write},
           path::Path};
-
-use crate::hcore::package::PackageIdent;
-use handlebars::Handlebars;
-
-use crate::{common::ui::{Status,
-                         UIWriter,
-                         UI},
-            error::Result};
 
 const PLAN_TEMPLATE_SH: &str =
     include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/static/template_plan.sh"));
@@ -32,7 +31,7 @@ const DEFAULT_PKG_VERSION: &str = "0.1.0";
 
 #[allow(clippy::too_many_arguments)]
 pub fn start(ui: &mut UI,
-             origin: String,
+             origin: &Origin,
              minimal: bool,
              scaffolding_ident: Option<PackageIdent>,
              maybe_name: Option<String>)
@@ -63,7 +62,7 @@ pub fn start(ui: &mut UI,
     let handlebars = Handlebars::new();
     let mut data = HashMap::new();
     data.insert("pkg_name".to_string(), name);
-    data.insert("pkg_origin".to_string(), origin);
+    data.insert("pkg_origin".to_string(), origin.to_string());
     data.insert("pkg_version".to_string(), DEFAULT_PKG_VERSION.to_string());
 
     if let Some(ident) = scaffolding_ident {

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -73,7 +73,9 @@ pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
                             config.auth_token,
                             Sensitivity::NoPrintValue);
     set_env_var_from_config(BLDR_URL_ENVVAR, config.bldr_url, Sensitivity::PrintValue);
-    set_env_var_from_config(ORIGIN_ENVVAR, config.origin, Sensitivity::PrintValue);
+    set_env_var_from_config(ORIGIN_ENVVAR,
+                            config.origin.map(|o| o.to_string()),
+                            Sensitivity::PrintValue);
 
     if config.ctl_secret.is_some() {
         ui.warn("Your Supervisor CtlGateway secret is not being copied to the Studio \

--- a/components/hab/src/config.rs
+++ b/components/hab/src/config.rs
@@ -4,7 +4,8 @@ use crate::{error::{Error,
                     fs::{am_i_root,
                          FS_ROOT_PATH}},
             CTL_SECRET_ENVVAR};
-use habitat_core::env as henv;
+use habitat_core::{env as henv,
+                   origin::Origin};
 use habitat_sup_client::SrvClient;
 use std::{fs::{self,
                File},
@@ -25,7 +26,7 @@ lazy_static::lazy_static! {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Config {
     pub auth_token: Option<String>,
-    pub origin:     Option<String>,
+    pub origin:     Option<Origin>,
     pub ctl_secret: Option<String>,
     pub bldr_url:   Option<String>,
 }


### PR DESCRIPTION
There's no guarantee that this covers *all* uses of origins in the
codebase. Rather, I started with the key-related interfaces, switching
all `String` or `&str` uses that were really Origin names into
`Origin` types. This ended up cascading out to a number of other
places, which are all addressed in this PR.

Mainly, this amounted to a lot of type switches, with a handful of
less-mechanical changes.

* Add an `AsRef<str>` implementation to `Origin`
* Add `hacky_get_origin` to `PackageIdent`
  Ultimately, we'll store an `Origin` in the `PackageIdent` type, at
  which point, we'll return `&Origin` from the `origin()`
  method. Until then, this intentionally-named method is used to
  centralize the "parse-and-expect" logic of converting the internal
  `String` into an `Origin`. We will, of course, remove this method
  soon :)
* The logic for populating a `hab pkg build` invocation with secret
  signing keys has been updated. In particular, the logic for creating
  the comma-delimited string we pass to the executable is pushed closer
  to the invocation site.

Signed-off-by: Christopher Maier <cmaier@chef.io>