### PR TITLE
fix prompting to stop launcher when closing windows docker studio

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -450,14 +450,14 @@ function Enter-Studio {
             if($habSvc -and ($habSvc.Status -eq "Running")) {
                 Stop-Service Habitat
             } elseif(Test-Path "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK") {
-                Stop-Process -Id (Get-Content "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK")
+                Stop-Process -Id (Get-Content "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK") -Force
                 Remove-Item "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK" -Force -ErrorAction SilentlyContinue
             }
         }
 
         Register-EngineEvent -SourceIdentifier PowerShell.Exiting -SupportEvent -Action {
-            if($env:startedNativeStudioSup -and (Test-Path "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK")) {
-                Stop-Process -Id (Get-Content "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK")
+            if($env:startedNativeStudioSup -eq $true -and (Test-Path "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK")) {
+                Stop-Process -Id (Get-Content "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK") -Force
                 $retry = 0
                 while(($retry -lt 5) -and (Test-Path "$env:HAB_STUDIO_ENTER_ROOT\hab\sup\default\LOCK")) {
                     $retry += 1


### PR DESCRIPTION
Just noticed that exiting the latest windows docker studio prompts the user to stop the launcher:

```
[HAB-STUDIO] Habitat:\src> exit

Confirm
Are you sure you want to perform the Stop-Process operation on the following item: hab-launch(1908)?
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"): a
Waiting for Supervisor to finish...
```

 There are 2 key changes here:

1. Add the `-Force` arg to `Stop-Process` to suppress any such prompting
2. Check if `env:startedNativeStudioSup` is `$true` and not simply if it is set.

In docker we should never even get to the `Stop-Process`. I mean, when the container dies, rest assured, all processes will be stopped. There was a flaw in my understanding of `if(!$env:env:startedNativeStudioSup)` where I figured that would evaluate to true if the variable was false.

Signed-off-by: mwrock <matt@mattwrock.com>