### PR TITLE
[CI] Enable core plans refresh evaluation in pipelines

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -11,6 +11,13 @@ expeditor:
       env:
         HAB_ORIGIN: "habitat-testing" # just to be safe
         HAB_BLDR_URL: "https://bldr.habitat.sh"
+
+        # In "real" runs of this pipeline, these channels must always
+        # be "dev". They are extracted here as environment variables
+        # (thus making them overridable) in order to facilitate ad-hoc
+        # testing of artifacts from arbitrary channels (e.g., as part
+        # of validating a core plans refresh). Both values should
+        # always be the same.
         HAB_BLDR_CHANNEL: "dev"
         HAB_INTERNAL_BLDR_CHANNEL: "dev"
 
@@ -22,7 +29,7 @@ steps:
   - label: ":docker: Docker End-to-End Supervisor Tests"
     command:
       - cd test/end-to-end/multi-supervisor
-      - ./run_all.sh dev
+      - ./run_all.sh \$HAB_BLDR_CHANNEL
     expeditor:
       executor:
         linux:
@@ -32,7 +39,7 @@ steps:
 
   - label: "[:linux: test_hab_help_doesnt_install_hab_sup]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_hab_help_doesnt_install_hab_sup
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_hab_help_doesnt_install_hab_sup
     artifact_paths:
       - "*.log"
     expeditor:
@@ -44,7 +51,7 @@ steps:
 
   - label: "[:linux: hup-does-not-abandon-services]"
     command:
-      - .expeditor/scripts/end_to_end/setup_environment.sh dev
+      - .expeditor/scripts/end_to_end/setup_environment.sh \$HAB_BLDR_CHANNEL
       - hab pkg install --binlink --channel=stable core/expect
       - hab pkg install --channel=\$HAB_BLDR_CHANNEL core/hab-sup core/hab-launcher
       - test/end-to-end/hup-does-not-abandon-services.exp
@@ -57,7 +64,7 @@ steps:
 
   - label: "[:linux: hab-svc-load]"
     command:
-      - .expeditor/scripts/end_to_end/setup_environment.sh dev
+      - .expeditor/scripts/end_to_end/setup_environment.sh \$HAB_BLDR_CHANNEL
       - hab pkg install --binlink --channel=stable core/expect
       - hab pkg install --channel=\$HAB_BLDR_CHANNEL core/hab-sup core/hab-launcher
       - test/end-to-end/hab-svc-load.exp
@@ -70,7 +77,7 @@ steps:
 
   - label: "[:windows: hab-svc-load]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_load_service
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_supervisor_load_service
     artifact_paths:
       - "*.log"
     expeditor:
@@ -86,7 +93,7 @@ steps:
 
   - label: "[:windows: Start-Service]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_windows_service
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_supervisor_windows_service
     artifact_paths:
       - "*.log"
     expeditor:
@@ -102,7 +109,7 @@ steps:
 
   - label: "[:windows: cleanly-shutdown-supervisor]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_windows_shutdown
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_supervisor_windows_shutdown
     artifact_paths:
       - "*.log"
     expeditor:
@@ -118,7 +125,7 @@ steps:
 
   - label: "[:windows: hab-svc-load-with-svc-user]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_load_service_with_password
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_supervisor_load_service_with_password
     artifact_paths:
       - "*.log"
     expeditor:
@@ -134,7 +141,7 @@ steps:
 
   - label: "[:windows: test_supervisor_binds]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_binds
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_supervisor_binds
     artifact_paths:
       - "*.log"
     expeditor:
@@ -150,7 +157,7 @@ steps:
 
   - label: "[:linux: test_supervisor_binds]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supervisor_binds
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_supervisor_binds
     artifact_paths:
       - "*.log"
     expeditor:
@@ -159,12 +166,12 @@ steps:
           privileged: true
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
-            - HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL="dev"
-            - HAB_STUDIO_SECRET_CI_OVERRIDE_CHANNEL="dev"
+            - HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL=\$HAB_BLDR_CHANNEL
+            - HAB_STUDIO_SECRET_CI_OVERRIDE_CHANNEL=\$HAB_BLDR_CHANNEL
 
   - label: "[:windows: test_supervisor_term]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_term
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_supervisor_term
     artifact_paths:
       - "*.log"
     expeditor:
@@ -177,7 +184,7 @@ steps:
 
   - label: "[:linux: test_supervisor_term]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supervisor_term
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_supervisor_term
     artifact_paths:
       - "*.log"
     expeditor:
@@ -186,12 +193,12 @@ steps:
           privileged: true
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
-            - HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL="dev"
-            - HAB_STUDIO_SECRET_CI_OVERRIDE_CHANNEL="dev"
+            - HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL=\$HAB_BLDR_CHANNEL
+            - HAB_STUDIO_SECRET_CI_OVERRIDE_CHANNEL=\$HAB_BLDR_CHANNEL
 
   - label: "[:windows: hab-svc-load-with-hab-user]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_load_with_hab_user
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_supervisor_load_with_hab_user
     artifact_paths:
       - "*.log"
     expeditor:
@@ -207,7 +214,7 @@ steps:
 
   - label: "[:linux: test_launcher_checks_supervisor_version]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_launcher_checks_supervisor_version
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_launcher_checks_supervisor_version
     artifact_paths:
       - "*.log"
     soft_fail: true
@@ -217,12 +224,12 @@ steps:
           privileged: true
           environment:
             - BUILD_PKG_TARGET=x86_64-linux
-            - HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL="dev"
-            - HAB_STUDIO_SECRET_CI_OVERRIDE_CHANNEL="dev"
+            - HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL=\$HAB_BLDR_CHANNEL
+            - HAB_STUDIO_SECRET_CI_OVERRIDE_CHANNEL=\$HAB_BLDR_CHANNEL
 
   - label: "[:linux: test_launcher_exits_on_supervisor_connection_failure]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_launcher_exits_on_supervisor_connection_failure
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_launcher_exits_on_supervisor_connection_failure
     artifact_paths:
       - "*.log"
     expeditor:
@@ -234,7 +241,7 @@ steps:
 
   - label: "[:linux: test_launcher_exits_on_supervisor_startup_failure]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_launcher_exits_on_supervisor_startup_failure
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_launcher_exits_on_supervisor_startup_failure
     artifact_paths:
       - "*.log"
     expeditor:
@@ -246,7 +253,7 @@ steps:
 
   - label: "[:linux: test_supervisor_restarts]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supervisor_restarts
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_supervisor_restarts
     artifact_paths:
       - "*.log"
     expeditor:
@@ -258,7 +265,7 @@ steps:
 
   - label: "[:linux: test_socket_file_cleanup]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_socket_file_cleanup
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_socket_file_cleanup
     artifact_paths:
       - "*.log"
     expeditor:
@@ -270,7 +277,7 @@ steps:
 
   - label: "[:linux: test_tar_export]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_tar_export
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_tar_export
     artifact_paths:
       - "*.log"
     expeditor:
@@ -282,7 +289,7 @@ steps:
 
   - label: "[:windows: test_tar_export]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_tar_export
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_tar_export
     artifact_paths:
       - "*.log"
     expeditor:
@@ -298,7 +305,7 @@ steps:
 
   - label: "[:linux: test_studio_auto_installs]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_auto_installs
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_studio_auto_installs
     artifact_paths:
       - "*.log"
     expeditor:
@@ -312,7 +319,7 @@ steps:
 
   - label: "[:linux: test_studio_with_ssl_cert_file_envvar_set]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_with_ssl_cert_file_envvar_set
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_studio_with_ssl_cert_file_envvar_set
     artifact_paths:
       - "*.log"
     expeditor:
@@ -326,7 +333,7 @@ steps:
 
   - label: "[:windows: test_studio_with_ssl_cert_file_envvar_set]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_with_ssl_cert_file_envvar_set
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_with_ssl_cert_file_envvar_set
     artifact_paths:
       - "*.log"
     expeditor:
@@ -343,7 +350,7 @@ steps:
 
   - label: "[:linux: :docker: test_studio_with_ssl_cert_file_envvar_set]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_with_ssl_cert_file_envvar_set
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_studio_with_ssl_cert_file_envvar_set
     artifact_paths:
       - "*.log"
     env:
@@ -357,7 +364,7 @@ steps:
 
   - label: "[:windows: test_studio_version]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_version
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_version
     artifact_paths:
       - "*.log"
     expeditor:
@@ -374,7 +381,7 @@ steps:
 
   - label: "[:windows: 2019 :docker: test_studio_version]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_version
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_version
     artifact_paths:
       - "*.log"
     env:
@@ -389,7 +396,7 @@ steps:
 
   - label: "[:windows: 2016 :docker: test_studio_version]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_version
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_version
     artifact_paths:
       - "*.log"
     env:
@@ -405,7 +412,7 @@ steps:
 
   - label: "[:linux: test_studio_version]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_version
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_studio_version
     artifact_paths:
       - "*.log"
     expeditor:
@@ -416,17 +423,17 @@ steps:
             - BUILD_PKG_TARGET=x86_64-linux
             - HAB_BLDR_URL
             - HAB_ORIGIN
-            - HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL=dev
+            - HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL=\$HAB_BLDR_CHANNEL
 
   - label: "[:linux: :docker: test_studio_version]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_version
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_studio_version
     artifact_paths:
       - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
       DOCKER_STUDIO_TEST: true
-      HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL: dev
+      HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL: \$HAB_BLDR_CHANNEL
     expeditor:
       executor:
         linux:
@@ -435,7 +442,7 @@ steps:
 
   - label: "[:windows: test_studio_supervisor]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_supervisor
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_supervisor
     artifact_paths:
       - "*.log"
     expeditor:
@@ -452,7 +459,7 @@ steps:
 
   - label: "[:windows: :docker: test_studio_supervisor]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_supervisor
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_supervisor
     artifact_paths:
       - "*.log"
     env:
@@ -467,7 +474,7 @@ steps:
 
   - label: "[:windows: test_studio_profile]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_profile
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_profile
     artifact_paths:
       - "*.log"
     expeditor:
@@ -484,7 +491,7 @@ steps:
 
   - label: "[:windows: :docker: test_studio_profile]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_profile
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_profile
     artifact_paths:
       - "*.log"
     env:
@@ -500,7 +507,7 @@ steps:
 
   - label: "[:linux: test_fresh_install_can_communicate_with_builder]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_fresh_install_can_communicate_with_builder
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_fresh_install_can_communicate_with_builder
     artifact_paths:
       - "*.log"
     expeditor:
@@ -513,7 +520,7 @@ steps:
 
   - label: "[:linux: test_studio_can_build_packages]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_can_build_packages
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_studio_can_build_packages
     artifact_paths:
       - "*.log"
     expeditor:
@@ -526,7 +533,7 @@ steps:
 
   - label: "[:windows: test_studio_can_build_packages]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_can_build_packages
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_can_build_packages
     artifact_paths:
       - "*.log"
     expeditor:
@@ -543,7 +550,7 @@ steps:
 
   - label: "[:windows: test_studio_can_build_packages_with_pkg_version_function]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_can_build_packages_with_pkg_version_function
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_can_build_packages_with_pkg_version_function
     artifact_paths:
       - "*.log"
     expeditor:
@@ -560,7 +567,7 @@ steps:
 
   - label: "[:windows: test_studio_can_build_scaffolded_package]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_can_build_scaffolded_package
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_studio_can_build_scaffolded_package
     artifact_paths:
       - "*.log"
     expeditor:
@@ -577,7 +584,7 @@ steps:
 
   - label: "[:linux: test_studio_unmount_with_long_filesystem]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_unmount_with_long_filesystem
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_studio_unmount_with_long_filesystem
     artifact_paths:
       - "*.log"
     env:
@@ -590,7 +597,7 @@ steps:
 
   - label: "[:linux: test_self_signed_cert_is_loaded_by_hab]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_self_signed_cert_is_loaded_by_hab
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_self_signed_cert_is_loaded_by_hab
     artifact_paths:
       - "*.log"
     expeditor:
@@ -602,7 +609,7 @@ steps:
 
   - label: "[:windows: test_windows_service_stops_on_launcher_termination]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_windows_service_stops_on_launcher_termination
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_windows_service_stops_on_launcher_termination
     artifact_paths:
       - "*.log"
     expeditor:
@@ -618,7 +625,7 @@ steps:
 
   - label: "[:windows: test_ssl_certificate_loading]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_ssl_certificate_loading
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_ssl_certificate_loading
     artifact_paths:
       - "*.log"
     expeditor:
@@ -635,7 +642,7 @@ steps:
 
   - label: "[:windows: test_pkg_install]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_pkg_install
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_pkg_install
     artifact_paths:
       - "*.log"
     expeditor:
@@ -652,7 +659,7 @@ steps:
 
   - label: "[:linux: test_pkg_install]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_install
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_pkg_install
     artifact_paths:
       - "*.log"
     expeditor:
@@ -664,7 +671,7 @@ steps:
 
   - label: "[:linux: test_pkg_download]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_download
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_pkg_download
     artifact_paths:
       - "*.log"
     expeditor:
@@ -676,7 +683,7 @@ steps:
 
   - label: "[:linux: test_pkg_bulkupload]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_bulkupload
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_pkg_bulkupload
     artifact_paths:
       - "*.log"
     expeditor:
@@ -690,7 +697,7 @@ steps:
 
   - label: "[:linux: test_simple_hooks]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_simple_hooks
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_simple_hooks
     artifact_paths:
       - "*.log"
     expeditor:
@@ -702,7 +709,7 @@ steps:
 
   - label: "[:windows: test_simple_hooks]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_simple_hooks
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_simple_hooks
     artifact_paths:
       - "*.log"
     expeditor:
@@ -718,7 +725,7 @@ steps:
 
   - label: "[:linux: test pids from Launcher with compatible Launcher]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_service_pids_come_from_new_launcher
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_service_pids_come_from_new_launcher
     artifact_paths:
       - "*.log"
     expeditor:
@@ -730,7 +737,7 @@ steps:
 
   - label: "[:linux: test service PID files with old Launcher]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_service_pids_written_to_file_using_old_launcher
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_service_pids_written_to_file_using_old_launcher
     artifact_paths:
       - "*.log"
     expeditor:
@@ -742,7 +749,7 @@ steps:
 
   - label: "[:linux: test_event_stream]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_event_stream
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_event_stream
     artifact_paths:
       - "*.log"
     expeditor:
@@ -754,7 +761,7 @@ steps:
 
   - label: "[:linux: test_at_once_service_updater]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_at_once_service_updater
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_at_once_service_updater
     artifact_paths:
       - "*.log"
     expeditor:
@@ -768,7 +775,7 @@ steps:
 
   - label: "[:linux: test_self_keep_latest_packages]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_self_keep_latest_packages
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_self_keep_latest_packages
     artifact_paths:
       - "*.log"
     expeditor:
@@ -780,7 +787,7 @@ steps:
 
   - label: "[:linux: test_pkg_uninstall]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_uninstall
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_pkg_uninstall
     artifact_paths:
       - "*.log"
     expeditor:
@@ -792,7 +799,7 @@ steps:
 
   - label: "[:linux: test_pkg_uninstall_hook]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_uninstall_hook
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_pkg_uninstall_hook
     artifact_paths:
       - "*.log"
     expeditor:
@@ -804,7 +811,7 @@ steps:
 
   - label: "[:windows: test_pkg_uninstall_hook]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_pkg_uninstall_hook
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_pkg_uninstall_hook
     artifact_paths:
       - "*.log"
     expeditor:
@@ -821,7 +828,7 @@ steps:
 
   - label: "[:linux: test_container_exporter]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_container_exporter
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_container_exporter
     artifact_paths:
       - "*.log"
     env:
@@ -834,7 +841,7 @@ steps:
 
   - label: "[:windows: test_container_exporter]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_container_exporter
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_container_exporter
     artifact_paths:
       - "*.log"
     env:
@@ -847,7 +854,7 @@ steps:
 
   - label: "[:linux: test_svc_update]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_svc_update
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_svc_update
     artifact_paths:
       - "*.log"
     env:
@@ -862,7 +869,7 @@ steps:
 
   - label: "[:windows: test_svc_update]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_svc_update
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_svc_update
     artifact_paths:
       - "*.log"
     env:
@@ -881,7 +888,7 @@ steps:
 
   - label: "[:linux: test_config_files]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_config_files
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_config_files
     artifact_paths:
       - "*.log"
     env:
@@ -896,7 +903,7 @@ steps:
 
   - label: "[:windows: test_config_files]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_config_files
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_config_files
     artifact_paths:
       - "*.log"
     env:
@@ -915,7 +922,7 @@ steps:
 
   - label: "[:linux: test_alternate_error_exit_codes]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_alternate_error_exit_codes
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_alternate_error_exit_codes
     artifact_paths:
       - "*.log"
     env:
@@ -930,7 +937,7 @@ steps:
 
   - label: "[:windows: test_alternate_error_exit_codes]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_alternate_error_exit_codes
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_alternate_error_exit_codes
     artifact_paths:
       - "*.log"
     env:
@@ -949,7 +956,7 @@ steps:
 
   - label: "[:linux: test_supplemental_groups]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supplemental_groups
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_supplemental_groups
     artifact_paths:
       - "*.log"
     env:
@@ -963,7 +970,7 @@ steps:
 
   - label: "[:linux: test_license]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_license
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_license
     artifact_paths:
       - "*.log"
     env:
@@ -977,7 +984,7 @@ steps:
 
   - label: "[:linux: test_external_binaries]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_external_binaries
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_external_binaries
     artifact_paths:
       - "*.log"
     env:
@@ -992,7 +999,7 @@ steps:
 
   - label: "[:windows: test_external_binaries]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_external_binaries
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_external_binaries
     artifact_paths:
       - "*.log"
     env:
@@ -1011,7 +1018,7 @@ steps:
 
   - label: "[:linux: test_cli_config_file]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_cli_config_file
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_cli_config_file
     artifact_paths:
       - "*.log"
     env:
@@ -1026,7 +1033,7 @@ steps:
 
   - label: "[:linux: test_tls_ctl_gateway]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_tls_ctl_gateway
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_tls_ctl_gateway
     artifact_paths:
       - "*.log"
     env:
@@ -1041,7 +1048,7 @@ steps:
 
   - label: "[:linux: test_health_check_output_of_http_gateway]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_health_check_output_of_http_gateway
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_health_check_output_of_http_gateway
     artifact_paths:
       - "*.log"
     env:
@@ -1056,7 +1063,7 @@ steps:
 
   - label: "[:windows: test_health_check_output_of_http_gateway]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_health_check_output_of_http_gateway
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_health_check_output_of_http_gateway
     artifact_paths:
       - "*.log"
     env:
@@ -1072,7 +1079,7 @@ steps:
 
   - label: "[:linux: test_supervisor_lock_file_behavior]"
     command:
-      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supervisor_lock_file_behavior
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh \$HAB_BLDR_CHANNEL test_supervisor_lock_file_behavior
     artifact_paths:
       - "*.log"
     env:
@@ -1087,7 +1094,7 @@ steps:
 
   - label: "[:windows: test_supervisor_lock_file_behavior]"
     command:
-      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_lock_file_behavior
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 \$HAB_BLDR_CHANNEL test_supervisor_lock_file_behavior
     artifact_paths:
       - "*.log"
     env:
@@ -1105,7 +1112,12 @@ steps:
 
   - label: "[:habicat: Promote to Acceptance]"
     command:
-      - .expeditor/scripts/buildkite_promote.sh dev acceptance
+      # Using $HAB_BLDR_CHANNEL here, rather than hard-coding "dev"
+      # for overall consistency. However, that means that the `if`
+      # condition limiting this to only Expeditor-initiated runs is
+      # VERY IMPORTANT. "Real" runs of this pipeline should only use
+      # "dev" as the channel to pull from!
+      - .expeditor/scripts/buildkite_promote.sh \$HAB_BLDR_CHANNEL acceptance
     if: build.creator.name == 'Chef Expeditor'
     expeditor:
       executor:

--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -15,6 +15,18 @@ expeditor:
         # Necessary to prevent old studios from poisoning builds after core plans refreshes
         HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL: "true"
 
+        # If you wish to build these packages as part of an evaluation
+        # of a core plans refresh, initiate a manual ad-hoc build of
+        # this pipeline, setting the HAB_FALLBACK_CHANNEL environment
+        # variable to the channel with the refresh packages.
+        #
+        # DO NOT change HAB_FALLBACK_CHANNEL in any other scenario.
+        #
+        # Similarly, if you want to collect any packages built from
+        # such a manual pipeline run, you will want to set the
+        # COLLECTION_CHANNEL environment variable to something
+        # meaningful.
+
 steps:
 #######################################################################
 # Release!
@@ -441,6 +453,24 @@ steps:
       - .expeditor/scripts/release_habitat/promote_artifacts_to_dev.sh habitat-release-$BUILDKITE_BUILD_ID
     # Only "real" executions of this pipeline, initiated by Expeditor, should promote anything
     if: build.creator.name == 'Chef Expeditor'
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+
+  # This is ONLY done if the COLLECTION_CHANNEL variable has been set; in
+  # normal everyday executions of this pipeline, it will not be set.
+  #
+  # Be aware that `hab bldr channel promote` moves ALL packages in the
+  # source channel to the destination channel. Normally we would be
+  # wary of such an operation, but it's of no concern here, since the
+  # source channel was created specifically for this pipeline, and
+  # only contains the packages we created here, which is precisely
+  # what we want.
+  - label: "[:habicat: Promote to custom collection channel]"
+    command:
+      - hab bldr channel promote habitat-release-\$BUILDKITE_BUILD_ID \$COLLECTION_CHANNEL --auth=\$PIPELINE_HAB_AUTH_TOKEN --url=\$PIPELINE_HAB_BLDR_URL --origin=\$HAB_ORIGIN
+    if: build.env("COLLECTION_CHANNEL") != null
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
This PR makes minimal changes to our release and e2e test pipelines to allow for mostly-automated-but-still-manual testing builds of key Habitat packages based on dependencies from a core plans refresh candidate channel, rather than the standard `stable` channel.

This is done by exposing a `HAB_FALLBACK_CHANNEL` environment variable in the plan build logic. With this, we can initiate manual runs of our release pipeline, setting that variable to the appropriate release candidate channel.

Additionally, we introduce a `COLLECTION_CHANNEL` environment in the release pipeline. This should also be set for these manual evaluation runs, to whatever value you want. All the generated packages will be promoted into this channel at the end of the pipeline. If you set this to `stable`, you will be hunted down like the filthy animal you are.

Finally, the e2e pipeline is tightened up to parameterize `HAB_BLDR_CHANNEL` everywhere. Previously, the `dev` channel was hardcoded everywhere. Now, you can initiate a manual build of the e2e channel, setting `HAB_BLDR_CHANNEL` to the value you specified for `COLLECTION_CHANNEL` earlier, and run e2e tests on the same packages.

This is obviously not optimal, but it's the minimal change to help make evaluating core plans refresh candidates a little bit easier. In an ideal future, we could have more automation set up around all this.

![](https://media.giphy.com/media/26gsxJfJgIyYXNoD6/giphy.gif)