### PR TITLE
eliminate usages of `hab install` alias in plan-build-ps1

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -319,12 +319,12 @@ function Set-HabBin {
 
 function Install-Dependency($dependency, $install_args = $null) {
     if (!$env:NO_INSTALL_DEPS) {
-        $cmd = "$HAB_BIN install -u $env:HAB_BLDR_URL --channel $env:HAB_BLDR_CHANNEL $dependency $install_args"
+        $cmd = "$HAB_BIN pkg install -u $env:HAB_BLDR_URL --channel $env:HAB_BLDR_CHANNEL $dependency $install_args"
         if($env:HAB_FEAT_IGNORE_LOCAL -eq "true") { $cmd += " --ignore-local" }
         Invoke-Expression $cmd
         if ($LASTEXITCODE -ne 0 -and ($env:HAB_BLDR_URL -ne $FALLBACK_CHANNEL)) {
             Write-BuildLine "Trying to install '$dependency' from '$FALLBACK_CHANNEL'"
-            $cmd = "$HAB_BIN install -u $env:HAB_BLDR_URL --channel $FALLBACK_CHANNEL $dependency $install_args"
+            $cmd = "$HAB_BIN pkg install -u $env:HAB_BLDR_URL --channel $FALLBACK_CHANNEL $dependency $install_args"
             if($env:HAB_FEAT_IGNORE_LOCAL -eq "true") { $cmd += " --ignore-local" }
             Invoke-Expression $cmd
         }


### PR DESCRIPTION
Just noticed deprecation warnings in a windows build.

Signed-off-by: mwrock <matt@mattwrock.com>