### PR TITLE
[CI] Capture Supervisor logs from e2e tests 

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -33,6 +33,8 @@ steps:
   - label: "[:linux: test_hab_help_doesnt_install_hab_sup]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_hab_help_doesnt_install_hab_sup
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -69,6 +71,8 @@ steps:
   - label: "[:windows: hab-svc-load]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_load_service
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -83,6 +87,8 @@ steps:
   - label: "[:windows: Start-Service]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_windows_service
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -97,6 +103,8 @@ steps:
   - label: "[:windows: cleanly-shutdown-supervisor]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_windows_shutdown
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -111,6 +119,8 @@ steps:
   - label: "[:windows: hab-svc-load-with-svc-user]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_load_service_with_password
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -125,6 +135,8 @@ steps:
   - label: "[:windows: test_supervisor_binds]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_binds
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -139,6 +151,8 @@ steps:
   - label: "[:linux: test_supervisor_binds]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supervisor_binds
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -151,6 +165,8 @@ steps:
   - label: "[:windows: test_supervisor_term]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_term
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -162,6 +178,8 @@ steps:
   - label: "[:linux: test_supervisor_term]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supervisor_term
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -174,6 +192,8 @@ steps:
   - label: "[:windows: hab-svc-load-with-hab-user]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_load_with_hab_user
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -189,7 +209,7 @@ steps:
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_launcher_checks_supervisor_version
     artifact_paths:
-      - sup.log
+      - "*.log"
     soft_fail: true
     expeditor:
       executor:
@@ -204,7 +224,7 @@ steps:
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_launcher_exits_on_supervisor_connection_failure
     artifact_paths:
-      - sup.log
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -216,7 +236,7 @@ steps:
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_launcher_exits_on_supervisor_startup_failure
     artifact_paths:
-      - sup.log
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -228,7 +248,7 @@ steps:
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supervisor_restarts
     artifact_paths:
-      - sup.log
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -239,6 +259,8 @@ steps:
   - label: "[:linux: test_socket_file_cleanup]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_socket_file_cleanup
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -249,6 +271,8 @@ steps:
   - label: "[:linux: test_tar_export]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_tar_export
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -259,6 +283,8 @@ steps:
   - label: "[:windows: test_tar_export]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_tar_export
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -273,6 +299,8 @@ steps:
   - label: "[:linux: test_studio_auto_installs]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_auto_installs
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -285,6 +313,8 @@ steps:
   - label: "[:linux: test_studio_with_ssl_cert_file_envvar_set]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_with_ssl_cert_file_envvar_set
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -297,6 +327,8 @@ steps:
   - label: "[:windows: test_studio_with_ssl_cert_file_envvar_set]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_with_ssl_cert_file_envvar_set
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -312,6 +344,8 @@ steps:
   - label: "[:linux: :docker: test_studio_with_ssl_cert_file_envvar_set]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_with_ssl_cert_file_envvar_set
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
       STUDIO_DOCKER_TEST: true
@@ -324,6 +358,8 @@ steps:
   - label: "[:windows: test_studio_version]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_version
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -339,6 +375,8 @@ steps:
   - label: "[:windows: 2019 :docker: test_studio_version]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_version
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-windows
       DOCKER_STUDIO_TEST: true
@@ -352,6 +390,8 @@ steps:
   - label: "[:windows: 2016 :docker: test_studio_version]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_version
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-windows
       DOCKER_STUDIO_TEST: true
@@ -366,6 +406,8 @@ steps:
   - label: "[:linux: test_studio_version]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_version
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -379,6 +421,8 @@ steps:
   - label: "[:linux: :docker: test_studio_version]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_version
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
       DOCKER_STUDIO_TEST: true
@@ -392,6 +436,8 @@ steps:
   - label: "[:windows: test_studio_supervisor]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_supervisor
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -407,6 +453,8 @@ steps:
   - label: "[:windows: :docker: test_studio_supervisor]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_supervisor
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-windows
       DOCKER_STUDIO_TEST: true
@@ -420,6 +468,8 @@ steps:
   - label: "[:windows: test_studio_profile]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_profile
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -435,6 +485,8 @@ steps:
   - label: "[:windows: :docker: test_studio_profile]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_profile
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-windows
       DOCKER_STUDIO_TEST: true
@@ -449,6 +501,8 @@ steps:
   - label: "[:linux: test_fresh_install_can_communicate_with_builder]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_fresh_install_can_communicate_with_builder
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -460,6 +514,8 @@ steps:
   - label: "[:linux: test_studio_can_build_packages]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_can_build_packages
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -471,6 +527,8 @@ steps:
   - label: "[:windows: test_studio_can_build_packages]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_can_build_packages
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -486,6 +544,8 @@ steps:
   - label: "[:windows: test_studio_can_build_packages_with_pkg_version_function]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_can_build_packages_with_pkg_version_function
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -501,6 +561,8 @@ steps:
   - label: "[:windows: test_studio_can_build_scaffolded_package]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_can_build_scaffolded_package
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -516,6 +578,8 @@ steps:
   - label: "[:linux: test_studio_unmount_with_long_filesystem]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_unmount_with_long_filesystem
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:
@@ -527,6 +591,8 @@ steps:
   - label: "[:linux: test_self_signed_cert_is_loaded_by_hab]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_self_signed_cert_is_loaded_by_hab
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -537,6 +603,8 @@ steps:
   - label: "[:windows: test_windows_service_stops_on_launcher_termination]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_windows_service_stops_on_launcher_termination
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -551,6 +619,8 @@ steps:
   - label: "[:windows: test_ssl_certificate_loading]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_ssl_certificate_loading
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -566,6 +636,8 @@ steps:
   - label: "[:windows: test_pkg_install]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_pkg_install
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -581,6 +653,8 @@ steps:
   - label: "[:linux: test_pkg_install]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_install
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -591,6 +665,8 @@ steps:
   - label: "[:linux: test_pkg_download]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_download
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -601,6 +677,8 @@ steps:
   - label: "[:linux: test_pkg_bulkupload]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_bulkupload
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -613,6 +691,8 @@ steps:
   - label: "[:linux: test_simple_hooks]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_simple_hooks
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -623,6 +703,8 @@ steps:
   - label: "[:windows: test_simple_hooks]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_simple_hooks
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -637,6 +719,8 @@ steps:
   - label: "[:linux: test pids from Launcher with compatible Launcher]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_service_pids_come_from_new_launcher
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -647,6 +731,8 @@ steps:
   - label: "[:linux: test service PID files with old Launcher]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_service_pids_written_to_file_using_old_launcher
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -657,6 +743,8 @@ steps:
   - label: "[:linux: test_event_stream]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_event_stream
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -667,6 +755,8 @@ steps:
   - label: "[:linux: test_at_once_service_updater]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_at_once_service_updater
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -679,6 +769,8 @@ steps:
   - label: "[:linux: test_self_keep_latest_packages]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_self_keep_latest_packages
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -689,6 +781,8 @@ steps:
   - label: "[:linux: test_pkg_uninstall]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_uninstall
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -699,6 +793,8 @@ steps:
   - label: "[:linux: test_pkg_uninstall_hook]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_pkg_uninstall_hook
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -709,6 +805,8 @@ steps:
   - label: "[:windows: test_pkg_uninstall_hook]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_pkg_uninstall_hook
+    artifact_paths:
+      - "*.log"
     expeditor:
       executor:
         docker:
@@ -724,6 +822,8 @@ steps:
   - label: "[:linux: test_container_exporter]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_container_exporter
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:
@@ -735,6 +835,8 @@ steps:
   - label: "[:windows: test_container_exporter]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_container_exporter
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-windows
     expeditor:
@@ -746,6 +848,8 @@ steps:
   - label: "[:linux: test_svc_update]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_svc_update
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:
@@ -759,6 +863,8 @@ steps:
   - label: "[:windows: test_svc_update]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_svc_update
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-windows
     expeditor:
@@ -776,6 +882,8 @@ steps:
   - label: "[:linux: test_config_files]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_config_files
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:
@@ -789,6 +897,8 @@ steps:
   - label: "[:windows: test_config_files]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_config_files
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-windows
     expeditor:
@@ -806,6 +916,8 @@ steps:
   - label: "[:linux: test_alternate_error_exit_codes]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_alternate_error_exit_codes
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:
@@ -819,6 +931,8 @@ steps:
   - label: "[:windows: test_alternate_error_exit_codes]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_alternate_error_exit_codes
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-windows
     expeditor:
@@ -836,6 +950,8 @@ steps:
   - label: "[:linux: test_supplemental_groups]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supplemental_groups
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:
@@ -848,6 +964,8 @@ steps:
   - label: "[:linux: test_license]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_license
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:
@@ -860,6 +978,8 @@ steps:
   - label: "[:linux: test_external_binaries]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_external_binaries
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:
@@ -873,6 +993,8 @@ steps:
   - label: "[:windows: test_external_binaries]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_external_binaries
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-windows
     expeditor:
@@ -890,6 +1012,8 @@ steps:
   - label: "[:linux: test_cli_config_file]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_cli_config_file
+    artifact_paths:
+      - "*.log"
     env:
       BUILD_PKG_TARGET: x86_64-linux
     expeditor:

--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -91,7 +91,26 @@ function Wait-StopSupervisor($Timeout = 10, $port = 9631) {
     Write-Host "Supervisor is now stopped."
 }
 
-function Start-Supervisor($Timeout = 1, $LogFile = (New-TemporaryFile), $SupArgs = @()) {
+# Generate a new unique log file name, given a base name.
+#
+# The base name should be something descriptive that allows you to
+# trace a given log file back to the test case that generated it.
+#
+# This is used instead of the standard `New-TemporaryFile`, since that
+# does not seem to allow you to specify any non-random components,
+# which we will need for both correlating outputs to tests, as well as
+# easily collecting log outputs in Buildkite.
+#
+# Example:
+#
+#    > New-SupervisorLogFile "monkeypants"
+#    monkeypants-oqUwJ.log
+#
+function New-SupervisorLogFile($BaseName) {
+     Join-String -OutputPrefix "$BaseName-" -OutputSuffix ".log" -InputObject (-join ((65..90) + (97..122) | Get-Random -Count 5 | Foreach-Object {[char]$_}))
+}
+
+function Start-Supervisor($LogFile, $Timeout = 1, $SupArgs = @()) {
     Add-Type -TypeDefinition (Get-Content "$PSScriptroot/SupervisorRunner.cs" | Out-String)
     $sup = New-Object SupervisorRunner
     $supPid = $sup.Run($LogFile, $SupArgs)

--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -107,7 +107,7 @@ function Wait-StopSupervisor($Timeout = 10, $port = 9631) {
 #    monkeypants-oqUwJ.log
 #
 function New-SupervisorLogFile($BaseName) {
-     Join-String -OutputPrefix "$BaseName-" -OutputSuffix ".log" -InputObject (-join ((65..90) + (97..122) | Get-Random -Count 5 | Foreach-Object {[char]$_}))
+    Join-String -OutputPrefix "$BaseName-" -OutputSuffix ".log" -InputObject (-join ((65..90) + (97..122) | Get-Random -Count 5 | ForEach-Object {[char]$_}))
 }
 
 function Start-Supervisor($LogFile, $Timeout = 1, $SupArgs = @()) {

--- a/test/end-to-end/test_at_once_service_updater.ps1
+++ b/test/end-to-end/test_at_once_service_updater.ps1
@@ -5,7 +5,7 @@
 
 $env:HAB_AUTH_TOKEN = $env:PIPELINE_HAB_AUTH_TOKEN
 
-$supLog = New-TemporaryFile
+$supLog = New-SupervisorLogFile("test_at_once_service_updater")
 Start-Supervisor -LogFile $supLog -Timeout 45 -SupArgs @( `
         "--keep-latest-packages=1"
 ) | Out-Null

--- a/test/end-to-end/test_cli_config_file.ps1
+++ b/test/end-to-end/test_cli_config_file.ps1
@@ -6,7 +6,8 @@ Describe "reading from supervisor and service config files" {
     BeforeAll {
         Remove-Item -Force -Recurse -ErrorAction Ignore $configPath
         New-Item -ItemType directory -Force -Path $etcPath
-        Start-Supervisor -Timeout 45
+        $supLog = New-SupervisorLogFile("cli_config_file")
+        Start-Supervisor -LogFile $supLog -Timeout 45
         $script:ctlSecret = Get-Content -Path $ctlSecretPath
     }
 

--- a/test/end-to-end/test_config_files.ps1
+++ b/test/end-to-end/test_config_files.ps1
@@ -21,17 +21,17 @@ Describe "reading from supervisor and service config files" {
         $out = hab sup run --generate-config
         Set-Content -Path $supConfig -Force -Value $out
         Get-Content -Path $supConfig | Should -Contain "### The listen address for the Gossip Gateway"
-
-        Start-Supervisor -Timeout 45
+        $supLog = New-SupervisorLogFile("supervisor_starts_with_output_of_hab_sup_run_--generate-config")
+        Start-Supervisor -LogFile $supLog -Timeout 45
     }
 
     Stop-Supervisor
 
     It "Supervisor starts with correctly configured gossip address" {
-        $supLog = New-TemporaryFile
         $address = "127.0.0.1:1234"
         Set-Content -Path $supConfig -Force -Value "listen_gossip = '$address'"
 
+        $supLog = New-SupervisorLogFile("supervisor_starts_with_correctly_configured_gossip_address")
         Start-Supervisor -Timeout 45 -LogFile $supLog
         Start-Sleep -Seconds 3
 
@@ -42,7 +42,7 @@ Describe "reading from supervisor and service config files" {
     Stop-Supervisor
 
     It "Supervisor does not start with invalid config file" {
-        $supLog = New-TemporaryFile
+        $supLog = New-SupervisorLogFile("supervisor_does_not_start_with_invalid_config_file")
         Set-Content -Path $supBadConfig -Force -Value "a bad confg"
 
         {
@@ -53,7 +53,8 @@ Describe "reading from supervisor and service config files" {
     }
 
     Stop-Supervisor
-    Start-Supervisor -Timeout 45
+    $supLog = New-SupervisorLogFile("test_config_files")
+    Start-Supervisor -LogFile $supLog -Timeout 45
 
     It "service does not start without ident" {
         $out = hab svc load --generate-config
@@ -85,7 +86,8 @@ Describe "reading from supervisor and service config files" {
     Stop-Supervisor
 
     It "service starts on Supervisor startup" {
-        Start-Supervisor
+        $supLog = New-SupervisorLogFile("service_starts_on_supervisor_startup")
+        Start-Supervisor -LogFile $supLog
         Wait-SupervisorService $svcName
     }
 

--- a/test/end-to-end/test_event_stream.ps1
+++ b/test/end-to-end/test_event_stream.ps1
@@ -9,7 +9,8 @@ Describe "event stream connection to nats" {
 
     It "fails to start with no NATS server and --event-stream-connect-timeout set" {
         {
-            Start-Supervisor -Timeout 3 -SupArgs @( `
+            $supLog = New-SupervisorLogFile("event_stream-fails_to_start_with_no_NATS_server_with_timeout")
+            Start-Supervisor -LogFile $supLog -Timeout 3 -SupArgs @( `
                     "--event-stream-application=MY_APP", `
                     "--event-stream-environment=MY_ENV", `
                     "--event-stream-site=MY_SITE", `
@@ -21,7 +22,7 @@ Describe "event stream connection to nats" {
     }
 
     # Start the supervisor but do not require an initial event stream connection
-    $supLog = New-TemporaryFile
+    $supLog =  New-SupervisorLogFile("test_event_stream")
     Start-Supervisor -Timeout 45 -LogFile $supLog -SupArgs @( `
             "--event-stream-application=MY_APP", `
             "--event-stream-environment=MY_ENV", `

--- a/test/end-to-end/test_launcher_checks_supervisor_version.ps1
+++ b/test/end-to-end/test_launcher_checks_supervisor_version.ps1
@@ -19,12 +19,13 @@ echo "hab-sup $version"
     $binary
 }
 
-function Test-LauncherFailure($version) {
+function Test-LauncherFailure($version, $testName) {
     $sup_binary = New-BinaryStub $version
 
     $env:HAB_SUP_BINARY=$sup_binary
     $sup = New-Object SupervisorRunner
-    $supPid = $sup.Run("sup.log")
+    $supLog = New-SupervisorLogFile($testName)
+    $supPid = $sup.Run($supLog)
 
     $retries=0
     $max_retries=3
@@ -46,20 +47,20 @@ hab pkg install core/hab-launcher --channel $HAB_BLDR_CHANNEL
 
 Describe "Launcher version check" {
     It "Exits with error when running an incompatible supervisor version" {
-        Test-LauncherFailure "0.55.0/20180321222338" | Should -Be $true
+        Test-LauncherFailure "0.55.0/20180321222338" "exits_with_error_with_incompatible_supervisor" | Should -Be $true
     }
     It "Does not exit with error running an incompatible supervisor version and skipping version check" {
         $env:HAB_LAUNCH_NO_SUP_VERSION_CHECK=1
-        Test-LauncherFailure "0.55.0/20180321222338" | Should -Be $false
+        Test-LauncherFailure "0.55.0/20180321222338" "no_error_with_incompatible_supervisor_and_skipping_version_check" | Should -Be $false
     }
     It "Does not exit with error when running a compatible supervisor version" {
-        Test-LauncherFailure "0.56.0/20180530235935" | Should -Be $false
+        Test-LauncherFailure "0.56.0/20180530235935" "no_error_with_compatible_supervisor" | Should -Be $false
     }
     It "Does not exit with error when running a dev supervisor version" {
-        Test-LauncherFailure "0.62.0-dev" | Should -Be $false
+        Test-LauncherFailure "0.62.0-dev" "no_error_with_dev_supervisor" | Should -Be $false
     }
     It "Exits with error when running a supervisor with an invalid version" {
-        Test-LauncherFailure "one-point-twenty-one" | Should -Be $true
+        Test-LauncherFailure "one-point-twenty-one" "exits_with_error_with_invalid_version" | Should -Be $true
     }
     AfterEach {
         $env:HAB_LAUNCH_NO_SUP_VERSION_CHECK=$null

--- a/test/end-to-end/test_launcher_exits_on_supervisor_connection_failure.ps1
+++ b/test/end-to-end/test_launcher_exits_on_supervisor_connection_failure.ps1
@@ -9,8 +9,6 @@ $env:HAB_LAUNCH_NO_SUP_VERSION_CHECK="true"
 
 Add-Type -TypeDefinition (Get-Content "$PSScriptroot/../../.expeditor/scripts/end_to_end/SupervisorRunner.cs" | Out-String)
 
-$sup_log = "sup.log"
-
 # Preinstall these packages. If we don't, then we spend the bulk of
 # our time in the following `while` loop downloading them, rather than
 # actually exercising the functionality we're after. That leads to
@@ -22,7 +20,8 @@ hab pkg install core/hab-launcher --channel="${env:HAB_BLDR_CHANNEL}"
 
 Describe "Supervisor boot failure" {
     $sup = New-Object SupervisorRunner
-    $supPid = $sup.Run($sup_log)
+    $supLog = New-SupervisorLogFile("supervisor_boot_failure")
+    $supPid = $sup.Run($supLog)
 
     It "exits launcher before timeout" {
         $retries=0
@@ -41,6 +40,6 @@ Describe "Supervisor boot failure" {
         $supPid.ExitCode | Should -Not -Be 0
     }
     It "logs connection failure" {
-        $sup_log | Should -FileContentMatch "Unable to accept connection from Supervisor"
+        $supLog | Should -FileContentMatch "Unable to accept connection from Supervisor"
     }
 }

--- a/test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.ps1
+++ b/test/end-to-end/test_launcher_exits_on_supervisor_startup_failure.ps1
@@ -15,7 +15,8 @@ hab pkg install core/hab-launcher
 Describe "Supervisor startup failure" {
     chmod -R a-w $env:FS_ROOT
     $sup = New-Object SupervisorRunner
-    $supPid = $sup.Run("sup.log")
+    $supLog = New-SupervisorLogFile("supervisor_startup_failure")
+    $supPid = $sup.Run($supLog)
 
     It "exits launcher before timeout" {
         $retries=0

--- a/test/end-to-end/test_self_keep_latest_packages.ps1
+++ b/test/end-to-end/test_self_keep_latest_packages.ps1
@@ -12,7 +12,7 @@ Describe "Supervisor package cleanup" {
     }
 
     Context "start the Supervisor without package cleanup" {
-        $supLog = New-TemporaryFile
+        $supLog = New-SupervisorLogFile("start_the_supervisor_without_package_cleanup")
         Start-Supervisor -LogFile $supLog -Timeout 45 | Out-Null
 
         It "does not remove old Supervisor packages" {
@@ -23,7 +23,7 @@ Describe "Supervisor package cleanup" {
     }
 
     Context "start the Supervisor with package cleanup" {
-        $supLog = New-TemporaryFile
+        $supLog = New-SupervisorLogFile("start_the_supervisor_with_package_cleanup")
         $expected = hab pkg list core/hab-sup | Select-Object -Last 2
         Start-Supervisor -LogFile $supLog -Timeout 45 -SupArgs @( `
                 "--keep-latest-packages=2"

--- a/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
+++ b/test/end-to-end/test_service_pids_come_from_new_launcher.ps1
@@ -2,7 +2,9 @@
 # files for the services it manages.
 
 Describe "Service PIDs from Launcher feature" {
-    Start-Supervisor -Timeout 20
+    $supLog = New-SupervisorLogFile("service_pids_come_from_launcher_feature")
+    Start-Supervisor -LogFile $supLog -Timeout 20
+
     Load-SupervisorService -PackageName "core/redis"
     Wait-Process redis-server -Timeout 10
 

--- a/test/end-to-end/test_service_pids_written_to_file_using_old_launcher.ps1
+++ b/test/end-to-end/test_service_pids_written_to_file_using_old_launcher.ps1
@@ -7,7 +7,8 @@ Describe "Using a Launcher that cannot provide service PIDs" {
     # being able to provide service PIDs to the Supervisor directly.
     hab pkg install core/hab-launcher/12605/20191112144831
 
-    Start-Supervisor -Timeout 20
+    $supLog = New-SupervisorLogFile("using_a_launcher_that_cannot_provide_service_pids")
+    Start-Supervisor -LogFile $supLog -Timeout 20
     Load-SupervisorService -PackageName "core/redis"
     Wait-Process redis-server -Timeout 10
 

--- a/test/end-to-end/test_simple_hooks.ps1
+++ b/test/end-to-end/test_simple_hooks.ps1
@@ -1,6 +1,6 @@
 $TestStartTime = Get-Date
-$sup_log = New-TemporaryFile
-Start-Supervisor -LogFile $sup_log -Timeout 45 | Out-Null
+$supLog = New-SupervisorLogFile("test_simple_hooks")
+Start-Supervisor -LogFile $supLog -Timeout 45 | Out-Null
 
 $pkg = "$(Get-EndToEndTestingOrigin)/simple-hooks"
 
@@ -21,7 +21,7 @@ Describe "Simple hooks output" {
     }
 
     It "Has correct 'run' hook stdout" {
-        $out = Get-Content $sup_log
+        $out = Get-Content $supLog
         $out | Should -Contain "$svc.default(O): run hook $svc"
     }
 

--- a/test/end-to-end/test_socket_file_cleanup.ps1
+++ b/test/end-to-end/test_socket_file_cleanup.ps1
@@ -9,7 +9,8 @@ Describe "Supervisor shutdown" {
     $socket_files_before = New-TemporaryFile
     Get-SocketFile | Out-File $socket_files_before
 
-    $launcher_proc = Start-Supervisor -Timeout 60
+    $supLog = New-SupervisorLogFile("test_socket_file_cleanup")
+    $launcher_proc = Start-Supervisor -LogFile $supLog -Timeout 60
     hab sup term
     $launcher_proc.WaitForExit()
 

--- a/test/end-to-end/test_supervisor_binds.ps1
+++ b/test/end-to-end/test_supervisor_binds.ps1
@@ -4,8 +4,8 @@ Describe "Supervisor binds" {
 
         Invoke-BuildAndInstall testpkgbindproducer
         Invoke-BuildAndInstall testpkgbindconsumer
-
-        Start-Supervisor -Timeout 45 | Out-Null
+        $supLog = New-SupervisorLogFile("test_supervisor_binds")
+        Start-Supervisor -LogFile $supLog -Timeout 45 | Out-Null
     }
 
     It "consumer bind to producer export" {

--- a/test/end-to-end/test_supervisor_restarts.ps1
+++ b/test/end-to-end/test_supervisor_restarts.ps1
@@ -7,7 +7,8 @@
 Describe "Supervisor restarts on abrupt exit" {
     $exit_file = New-TemporaryFile
     $env:HAB_FEAT_TEST_EXIT = $exit_file
-    $launcher_proc = Start-Supervisor -Timeout 45 -LogFile "sup.log"
+    $supLog = New-SupervisorLogFile("supervisor_restarts_on_abrupt_exit")
+    $launcher_proc = Start-Supervisor -Timeout 45 -LogFile $supLog
     $supervisor_proc = Get-Process hab-sup
     Set-Content $exit_file -Value 1
 
@@ -38,7 +39,8 @@ Describe "Supervisor restarts on abrupt exit" {
 }
 
 Describe "Supervisor restarts on 'hab sup restart'" {
-    $launcher_proc = Start-Supervisor -Timeout 45 -LogFile "sup.log"
+    $supLog = New-SupervisorLogFile("supervisor_restarts_on_hab_sup_restart")
+    $launcher_proc = Start-Supervisor -Timeout 45 -LogFile $supLog
     $supervisor_proc = Get-Process hab-sup
     Invoke-NativeCommand hab sup restart
 

--- a/test/end-to-end/test_supervisor_term.ps1
+++ b/test/end-to-end/test_supervisor_term.ps1
@@ -1,5 +1,6 @@
 $tempFile = Join-Path ([System.IO.Path]::GetTempPath()) "testpkgstophook.out"
-$launcherProc = Start-Supervisor -Timeout 45
+$supLog = New-SupervisorLogFile("test_supervisor_term")
+$launcherProc = Start-Supervisor -LogFile $supLog -Timeout 45
 
 Describe "hab sup term" {
     BeforeAll {

--- a/test/end-to-end/test_supplemental_groups.ps1
+++ b/test/end-to-end/test_supplemental_groups.ps1
@@ -42,7 +42,8 @@ Describe "supplemental group behavior" {
         Stop-Supervisor
     }
 
-    Start-Supervisor -Timeout 45
+    $supLog = New-SupervisorLogFile("test_supplemental_groups")
+    Start-Supervisor -LogFile $supLog -Timeout 45
 
     It "should be able to run a service that depends on supplemental groups being set" {
         # Install the package first so we don't have to wait during

--- a/test/end-to-end/test_svc_update.ps1
+++ b/test/end-to-end/test_svc_update.ps1
@@ -24,7 +24,8 @@ Describe "hab svc update" {
         Stop-Supervisor
     }
 
-    Start-Supervisor -Timeout 45
+    $supLog = New-SupervisorLogFile("test_svc_update")
+    Start-Supervisor -LogFile $supLog -Timeout 45
     Load-SupervisorService $nginx_release
     Wait-Release -Ident $nginx_release
 


### PR DESCRIPTION
When e2e tests fail, it's often really nice to have access to the logs
of the Supervisor to help debug things. Unfortunately, we had no way
to do that previously.

Some tests captured Supervisor output to a named file (like
"sup.log"), while others captured it to a randomly-named temporary
file. The former is bad because some test suites start up the
Supervisor multiple times (thus clobbering logs of any prior
Supervisor processes), and the latter is bad because we never knew
what the name of the file actually was. And both cases were bad
because Buildkite didn't know how to capture either of them!

Here, we add a custom function to generate a log file name. It takes a
label, used to distinguish different Supervisor runs within a test
suite, and appends a random suffix, along with the `.log`
extension. All uses of the `Start-Supervisor` function (as well as
some other functions) are modified to use this filename function for
logs. Finally, Buildkite has been instructed to capture all `*.log`
files in the top-level directory as build artifacts, making them
available in the Artifacts tab of each individual test step.

Signed-off-by: Christopher Maier <cmaier@chef.io>