### PR TITLE
Add About Habitat index page

### DIFF
--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -1,0 +1,54 @@
++++
+title = "About Chef Habitat"
+
+[menu]
+  [menu.habitat]
+    title = "About Chef Habitat"
+    identifier = "habitat/About Chef Habitat"
+    parent = "habitat"
+    weight = 5
++++
+
+Chef Habitat centers application configuration, management, and behavior around
+the application itself, not the infrastructure that the app runs on.
+It provides automation that can programmatically and declaratively build,
+deploy, and manage your application and services, both stateful and stateless.
+And it can be deployed and run on various infrastructure environments
+including bare metal, VM, containers, and PaaS.
+
+## Chef Habitat Builder
+
+[Chef Habitat Builder]({{< relref "builder-overview" >}}) acts as the core of
+Chef’s Application Delivery Enterprise hub. You can run Chef Habitat Builder as
+a cloud-based service or on premises.
+
+Habitat Builder provides package storage, search, and an API for clients.
+
+Plan files are stored in the Chef Habitat Builder SaaS where they can be viewed
+and accessed by the Chef Habitat community. The plan files can also be shared with
+the on-premises version of Bilder and then be copied and maintained locally.
+
+## Plans
+
+A [plan]({{< relref "plan-overview" >}}) is a directory comprised of shell scripts
+and optional configuration files that define how you download, configure, make,
+install, and manage the lifecycle of the software in the artifact.
+
+## Supervisor
+
+The Supervisor is a process manager that has two primary responsibilities. First,
+it starts and monitors child services defined in the plan it is running. Second,
+it receives and acts upon information from the other Supervisors to which it is
+connected.
+
+## Services
+
+A [service]({{< relref "about_services" >}}) is a Chef Habitat package running under a Chef
+Habitat Supervisor. Services can be joined together in a [service group]({{< relref "service_groups" >}}),
+which is a group of services with the same package and topology type connected together
+across a Supervisor network.
+
+## Installing Chef Habitat
+
+The Chef Habitat CLI can be [installed]({{< relref "install-habitat" >}}) on
+Linux, Mac, and Windows.

--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -9,46 +9,33 @@ title = "About Chef Habitat"
     weight = 5
 +++
 
-Chef Habitat centers application configuration, management, and behavior around
-the application itself, not the infrastructure that the app runs on.
-It provides automation that can programmatically and declaratively build,
-deploy, and manage your application and services, both stateful and stateless.
-And it can be deployed and run on various infrastructure environments
-including bare metal, VM, containers, and PaaS.
+Chef Habitat centers application configuration, management, and behavior around the application itself, not the infrastructure that the app runs on.
+It provides automation that can programmatically and declaratively build, deploy, and manage your application and services, both stateful and stateless.
+You can deploy and run your Chef Habitat app on many different infrastructure environments including bare metal, VM, containers, and PaaS.
 
 ## Chef Habitat Builder
 
-[Chef Habitat Builder]({{< relref "builder-overview" >}}) acts as the core of
-Chef’s Application Delivery Enterprise hub. You can run Chef Habitat Builder as
-a cloud-based service or on premises.
+[Chef Habitat Builder]({{< relref "builder-overview" >}}) acts as the core of Chef's Application Delivery Enterprise hub. You can run Chef Habitat Builder as a cloud-based service or on-premises.
 
-Habitat Builder provides package storage, search, and an API for clients.
+Chef Habitat Builder provides package storage, search, and an API for clients.
 
-Plan files are stored in the Chef Habitat Builder SaaS where they can be viewed
-and accessed by the Chef Habitat community. The plan files can also be shared with
-the on-premises version of Bilder and then be copied and maintained locally.
+The contents of your app are stored in the Chef Habitat Builder SaaS, where the Chef Habitat community can view and access them. You can also use the on-prem version of Chef Habitat Builder, where you can store and maintain your apps locally.
 
 ## Plans
 
-A [plan]({{< relref "plan-overview" >}}) is a directory comprised of shell scripts
-and optional configuration files that define how you download, configure, make,
-install, and manage the lifecycle of the software in the artifact.
+A [plan]({{< relref "plan-overview" >}}) is the file where you define how you will build, deploy, and manage your app. A plan file is named `plan.sh` for Linux systems or `plan.ps1` for Windows, and your app can have plan files for both Linux and Windows operating systems. You can find your plan file in the `habitat` directory, which you install at the root of your app with `hab plan init`.
 
 ## Supervisor
 
-The Supervisor is a process manager that has two primary responsibilities. First,
-it starts and monitors child services defined in the plan it is running. Second,
-it receives and acts upon information from the other Supervisors to which it is
-connected.
+A Supervisor is a process manager that runs the app packages that you defined in your plan. A Supervisor has two primary responsibilities:
+
+1. A Supervisor is a process manager and is responsible for running your app's services. It starts, stops, updates, and monitors the services according to your plan.
+1. Supervisors can talk to each other. You can connect Supervisors together into a network and instruct them to send information to each other and take actions based on that information.
 
 ## Services
 
-A [service]({{< relref "about_services" >}}) is a Chef Habitat package running under a Chef
-Habitat Supervisor. Services can be joined together in a [service group]({{< relref "service_groups" >}}),
-which is a group of services with the same package and topology type connected together
-across a Supervisor network.
+A [service]({{< relref "services" >}}) is your Chef Habitat package that is run and managed by a Supervisor. Services can be joined together into a [service group]({{< relref "service_groups" >}}), which is a collection of services with the same package and topology type that are connected together across a Supervisor network.
 
 ## Installing Chef Habitat
 
-The Chef Habitat CLI can be [installed]({{< relref "install-habitat" >}}) on
-Linux, Mac, and Windows.
+The Chef Habitat CLI can be [installed]({{< relref "install-habitat" >}}) on Linux, Mac, and Windows.

--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -1,6 +1,8 @@
 +++
 title = "About Chef Habitat"
 
+aliases = ["/habitat/reference/", "/habitat/glossary/", "/habitat/diagrams/"]
+
 [menu]
   [menu.habitat]
     title = "About Chef Habitat"
@@ -15,7 +17,7 @@ You can deploy and run your Chef Habitat app on many different infrastructure en
 
 ## Chef Habitat Builder
 
-[Chef Habitat Builder]({{< relref "builder-overview" >}}) acts as the core of Chef's Application Delivery Enterprise hub. You can run Chef Habitat Builder as a cloud-based service or on-premises.
+[Chef Habitat Builder]({{< relref "builder_overview" >}}) acts as the core of Chef's Application Delivery Enterprise hub. You can run Chef Habitat Builder as a cloud-based service or on-premises.
 
 Chef Habitat Builder provides package storage, search, and an API for clients.
 
@@ -23,7 +25,7 @@ The contents of your app are stored in the Chef Habitat Builder SaaS, where the 
 
 ## Plans
 
-A [plan]({{< relref "plan-overview" >}}) is the file where you define how you will build, deploy, and manage your app. A plan file is named `plan.sh` for Linux systems or `plan.ps1` for Windows, and your app can have plan files for both Linux and Windows operating systems. You can find your plan file in the `habitat` directory, which you install at the root of your app with `hab plan init`.
+A [plan]({{< relref "plan_writing" >}}) is the file where you define how you will build, deploy, and manage your app. A plan file is named `plan.sh` for Linux systems or `plan.ps1` for Windows, and your app can have plan files for both Linux and Windows operating systems. You can find your plan file in the `habitat` directory, which you install at the root of your app with `hab plan init`.
 
 ## Supervisor
 
@@ -38,4 +40,4 @@ A [service]({{< relref "services" >}}) is your Chef Habitat package that is run 
 
 ## Installing Chef Habitat
 
-The Chef Habitat CLI can be [installed]({{< relref "install-habitat" >}}) on Linux, Mac, and Windows.
+The Chef Habitat CLI can be [installed]({{< relref "install_habitat" >}}) on Linux, Mac, and Windows.


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

We need in `_index.md` page. I'm not sure if this is the best text, but it's a start.

