### PR TITLE
[BUG] Update actix-web calling conventions

### DIFF
--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -123,7 +123,7 @@ fn authentication_middleware<S>(req: ServiceRequest,
                                 -> impl Future<Output = Result<ServiceResponse<Body>, Error>>
     where S: Service<Request = ServiceRequest, Response = ServiceResponse<Body>, Error = Error>
 {
-    let current_token = &req.app_data::<AppState>()
+    let current_token = &req.app_data::<Data<AppState>>()
                             .expect("app data")
                             .authentication_token;
     let current_token = if let Some(t) = current_token {
@@ -171,7 +171,7 @@ fn metrics_middleware<S>(req: ServiceRequest,
     HTTP_GATEWAY_REQUESTS.with_label_values(label_values).inc();
     let timer = HTTP_GATEWAY_REQUEST_DURATION.with_label_values(label_values)
                                              .start_timer();
-    req.app_data::<AppState>()
+    req.app_data::<Data<AppState>>()
        .expect("app data")
        .timer
        .set(Some(timer));
@@ -196,7 +196,7 @@ fn redact_http_middleware<S>(req: ServiceRequest,
                              -> impl Future<Output = Result<ServiceResponse<Body>, Error>>
     where S: Service<Request = ServiceRequest, Response = ServiceResponse<Body>, Error = Error>
 {
-    if req.app_data::<AppState>()
+    if req.app_data::<Data<AppState>>()
           .expect("app data")
           .feature_flags
           .contains(FeatureFlag::REDACT_HTTP)


### PR DESCRIPTION
Per [the migration guide][1] this wraps `AppState` as `Data<AppState>`
to prevent panics in the HTTP gateway.

The rest of the code currently assumes the data is returned in this
way; future refactorings may allow us to drop the `Data` wrapper
entirely, but this is the minimal change for now.

Actix 3.0 was introduced in #7949 / #7923.

[1]: https://github.com/actix/actix-web/blob/master/MIGRATION.md#300

Signed-off-by: Christopher Maier <cmaier@chef.io>