### PR TITLE
Expose HAB_FALLBACK_CHANNEL in plan build

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -322,7 +322,7 @@ function Install-Dependency($dependency, $install_args = $null) {
         $cmd = "$HAB_BIN pkg install -u $env:HAB_BLDR_URL --channel $env:HAB_BLDR_CHANNEL $dependency $install_args"
         if($env:HAB_FEAT_IGNORE_LOCAL -eq "true") { $cmd += " --ignore-local" }
         Invoke-Expression $cmd
-        if ($LASTEXITCODE -ne 0 -and ($env:HAB_BLDR_URL -ne $FALLBACK_CHANNEL)) {
+        if ($LASTEXITCODE -ne 0 -and ($env:HAB_BLDR_CHANNEL -ne $FALLBACK_CHANNEL)) {
             Write-BuildLine "Trying to install '$dependency' from '$FALLBACK_CHANNEL'"
             $cmd = "$HAB_BIN pkg install -u $env:HAB_BLDR_URL --channel $FALLBACK_CHANNEL $dependency $install_args"
             if($env:HAB_FEAT_IGNORE_LOCAL -eq "true") { $cmd += " --ignore-local" }

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -75,7 +75,17 @@ $env:HAB_BLDR_URL = "$script:HAB_BLDR_URL"
 if (!(Test-Path Env:\HAB_BLDR_CHANNEL)) {
     $env:HAB_BLDR_CHANNEL = "stable"
 }
-$script:FALLBACK_CHANNEL = "stable"
+# Fall back here if package can't be installed from $HAB_BLDR_CHANNEL
+# This is overridable with the sole intention of supporting core plans
+# refresh evaluations (where we want to pull dependencies from a
+# separate channel, and not "stable").
+#
+# Also note that this only really comes into play if HAB_BLDR_CHANNEL
+# has been set to something different.
+$env:HAB_FALLBACK_CHANNEL = "$script:HAB_FALLBACK_CHANNEL"
+if (!(Test-Path Env:\HAB_FALLBACK_CHANNEL)) {
+    $env:HAB_FALLBACK_CHANNEL = "stable"
+}
 # The value of `$env:Path` on initial start of this program
 $script:INITIAL_PATH = "$env:Path"
 # The full target tuple this plan will be built for
@@ -322,9 +332,9 @@ function Install-Dependency($dependency, $install_args = $null) {
         $cmd = "$HAB_BIN pkg install -u $env:HAB_BLDR_URL --channel $env:HAB_BLDR_CHANNEL $dependency $install_args"
         if($env:HAB_FEAT_IGNORE_LOCAL -eq "true") { $cmd += " --ignore-local" }
         Invoke-Expression $cmd
-        if ($LASTEXITCODE -ne 0 -and ($env:HAB_BLDR_CHANNEL -ne $FALLBACK_CHANNEL)) {
-            Write-BuildLine "Trying to install '$dependency' from '$FALLBACK_CHANNEL'"
-            $cmd = "$HAB_BIN pkg install -u $env:HAB_BLDR_URL --channel $FALLBACK_CHANNEL $dependency $install_args"
+        if ($LASTEXITCODE -ne 0 -and ($env:HAB_BLDR_CHANNEL -ne $HAB_FALLBACK_CHANNEL)) {
+            Write-BuildLine "Trying to install '$dependency' from '$HAB_FALLBACK_CHANNEL'"
+            $cmd = "$HAB_BIN pkg install -u $env:HAB_BLDR_URL --channel $HAB_FALLBACK_CHANNEL $dependency $install_args"
             if($env:HAB_FEAT_IGNORE_LOCAL -eq "true") { $cmd += " --ignore-local" }
             Invoke-Expression $cmd
         }

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -356,7 +356,13 @@ export HAB_BLDR_URL
 # Export Builder channel so all other programs and subshells use this same one
 export HAB_BLDR_CHANNEL
 # Fall back here if package can't be installed from $HAB_BLDR_CHANNEL
-FALLBACK_CHANNEL="stable"
+# This is overridable with the sole intention of supporting core plans
+# refresh evaluations (where we want to pull dependencies from a
+# separate channel, and not "stable").
+#
+# Also note that this only really comes into play if HAB_BLDR_CHANNEL
+# has been set to something different.
+: "${HAB_FALLBACK_CHANNEL=stable}"
 # The value of `$PATH` on initial start of this program
 INITIAL_PATH="$PATH"
 # The value of `pwd` on initial start of this program
@@ -727,9 +733,9 @@ _install_dependency() {
         IGNORE_LOCAL="--ignore-local"
     fi
     $HAB_BIN pkg install -u $HAB_BLDR_URL --channel $HAB_BLDR_CHANNEL ${IGNORE_LOCAL:-} "$@" || {
-      if [[ "$HAB_BLDR_CHANNEL" != "$FALLBACK_CHANNEL" ]]; then
-        build_line "Trying to install '$dep' from '$FALLBACK_CHANNEL'"
-        $HAB_BIN pkg install -u $HAB_BLDR_URL --channel "$FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
+      if [[ "$HAB_BLDR_CHANNEL" != "$HAB_FALLBACK_CHANNEL" ]]; then
+        build_line "Trying to install '$dep' from '$HAB_FALLBACK_CHANNEL'"
+        $HAB_BIN pkg install -u $HAB_BLDR_URL --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
       fi
     }
   fi


### PR DESCRIPTION
This was an internal variable before; this merely exposes it
externally in case it should ever be needed.

It is not currently intended that anyone outside of Chef would use
this, and thus will not be formally documented. It is being introduced
as an aid for helping to evaluate core plans refresh candidates
(specifically, to help our existing release pipeline to build our
Habitat packages with dependencies from a refresh channel, rather than
`stable`).

Signed-off-by: Christopher Maier <cmaier@chef.io>