### PR TITLE
[FIX] Minimal change to enable non-root containers again

### DIFF
--- a/components/pkg-export-container/defaults/Dockerfile.hbs
+++ b/components/pkg-export-container/defaults/Dockerfile.hbs
@@ -42,7 +42,12 @@ RUN \
     # communication pipe.
     mkdir /root && chmod 750 root && \
     mkdir /tmp && chmod 1777 /tmp && \
-    mkdir -p /var/tmp && chmod 1777 /var/tmp
+    mkdir -p /var/tmp && chmod 1777 /var/tmp && \
+
+    # This is currently needed in order for non-root containers to
+    # function... this ends up being their home directory, and we
+    # expect to find key cache directory there right now.
+    mkdir -p /.hab/cache/keys && chmod -R 770 /.hab
 
 # Ensure our custom /etc content (notably `passwd` and `group` files,
 # but also our linked cacerts in /etc/ssl) are present.

--- a/test/end-to-end/test_container_exporter.ps1
+++ b/test/end-to-end/test_container_exporter.ps1
@@ -17,7 +17,7 @@ function New-Image() {
     )
 
     # NOTE: the container exporter is installed in setup_environment.{sh,ps1}
-    Write-Host (hab pkg export container core/nginx --tag-custom=$tag $extra_args | Out-String)
+    Write-Host (hab pkg export container --base-pkgs-channel=$env:HAB_BLDR_CHANNEL core/nginx --tag-custom=$tag $extra_args | Out-String)
     "core/nginx:$tag"
 }
 
@@ -60,7 +60,7 @@ function Confirm-ContainerBehavior() {
 Describe "Old 'hab pkg export docker' alias" {
     BeforeAll {
         $tag = New-CustomTag
-        Write-Host (hab pkg export docker core/nginx --tag-custom=$tag | Out-String)
+        Write-Host (hab pkg export docker --base-pkgs-channel=$env:HAB_BLDR_CHANNEL core/nginx --tag-custom=$tag | Out-String)
         $script:image = "core/nginx:$tag"
     }
 
@@ -167,7 +167,7 @@ if ($IsLinux) {
     Describe "hab pkg export container --engine=buildah" {
         It "Runs successfully" {
             $tag = New-CustomTag
-            Invoke-NativeCommand hab pkg export container core/nginx --engine=buildah --tag-custom="$tag"
+            Invoke-NativeCommand hab pkg export container --base-pkgs-channel=$env:HAB_BLDR_CHANNEL core/nginx --engine=buildah --tag-custom="$tag"
             Invoke-NativeCommand hab pkg exec core/buildah buildah rmi "core/nginx:$tag"
         }
     }


### PR DESCRIPTION
With the changes in #7887 for how key cache directories were handled,
we inadvertently broke non-root containers. The Supervisor creates a
cache directory explicitly when it starts (previously, it was
implicitly created). However, when running as a non-root user, there
isn't a suitable directory present.

Here, we modify the Dockerfile template to create a cache directory
for the non-root Supervisor to use.

Further cleanup and reconsideration of this pattern should be done at
some point.

There's also a tweak to the e2e test to help catch things like this earlier.

![](https://media.giphy.com/media/seOifWTy7468E/giphy.gif)