### PR TITLE
fix studio failure building outside system drive

### DIFF
--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -280,7 +280,11 @@ mod inner {
                                                "-File"].into_iter()
                                                        .map(Into::into)
                                                        .collect();
-        cmd_args.push(studio_command.into());
+        if let Some(cmd) = find_command(&studio_command) {
+            cmd_args.push(cmd.into());
+        } else {
+            return Err(Error::ExecCommandNotFound(studio_command));
+        }
         cmd_args.extend_from_slice(args);
 
         if let Some(cmd) = find_command(&pwsh_command) {

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -230,7 +230,7 @@ function New-Studio {
         try {
             if(!(Test-Path artifacts)) {
                 mkdir artifacts | Out-Null
-                New-Item -Name artifacts -ItemType Junction -target "/hab/cache/artifacts" | Out-Null
+                New-Item -Name artifacts -ItemType Junction -target "$env:SYSTEMDRIVE/hab/cache/artifacts" | Out-Null
             }
         } finally {
             Pop-Location

--- a/test/end-to-end/test_studio_can_build_packages.ps1
+++ b/test/end-to-end/test_studio_can_build_packages.ps1
@@ -41,6 +41,20 @@ Describe "Studio build" {
         "/hab/cache/artifacts/$pkg_artifact" | Should -Exist
     }
 
+    It "builds plan in non system drive" {
+        subst x: $env:USERPROFILE
+        $cd = Get-Location
+        $dir = Split-Path -Leaf $cd.Path
+        Push-Location x:\
+        New-Item -Name $dir -ItemType Junction -target $cd.Path
+        Set-Location $dir
+        hab pkg build test/fixtures/minimal-package
+        $exitCode = $LASTEXITCODE
+        Pop-Location
+
+        $exitCode | Should -Be 0
+    }
+
     It "strips hook extension" {
         Invoke-BuildAndInstall hook-extension-plan
         . ./results/last_build.ps1


### PR DESCRIPTION
Trying to build a package or enter a studio when not in the same drive as hab, will result in failure. This makes sure that the studio command (`hab-studio.ps1`) is correctly rooted in its lettered directory and also makes sure to mount the artifacts from the correct target path on `c:`.

Signed-off-by: mwrock <matt@mattwrock.com>