### PR TITLE
Specify winapi version more tightly

### DIFF
--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -34,7 +34,7 @@ uuid = { version = "*", features = ["v4"] }
 zmq = { git = "https://github.com/habitat-sh/rust-zmq", branch = "v0.8-symlinks-removed" }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "*", features = ["handleapi", "winbase"] }
+winapi = { version = "^0.3.9", features = ["handleapi", "winbase"] }
 
 [dev-dependencies]
 mktemp = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -55,7 +55,7 @@ valico = "*"
 nix = "*"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "*", features = ["consoleapi", "processenv"] }
+winapi = { version = "^0.3.9", features = ["consoleapi", "processenv"] }
 
 [features]
 default = []

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -64,7 +64,7 @@ features = ["v4"]
 
 [target.'cfg(windows)'.dependencies]
 widestring = "*"
-winapi = { version = "*", features = ["winuser", "windef"] }
+winapi = { version = "^0.3.9", features = ["winuser", "windef"] }
 winreg = "*"
 
 [dev-dependencies]

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -25,4 +25,4 @@ semver = "*"
 nix = "*"
 
 [target.'cfg(windows)'.dependencies]
-winapi =  { version = "*", features = ["tlhelp32"] }
+winapi =  { version = "^0.3.9", features = ["tlhelp32"] }

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -80,7 +80,7 @@ mio-named-pipes = "*"
 # See https://github.com/habitat-sh/habitat/issues/7522
 mio = "0.6.21"
 uuid = { version = "*", features = ["v4"] }
-winapi =  { version = "*", features = ["namedpipeapi", "tlhelp32"] }
+winapi =  { version = "^0.3.9", features = ["namedpipeapi", "tlhelp32"] }
 
 [dev-dependencies]
 habitat_core = { path = "../core" }


### PR DESCRIPTION
Occasionally whenever we try to update individual dependencies, we'll
come across spurious conflicts around the `winapi` crate, where it
always tries to resolve to version 0.2.8, which at this point is
several years old.

It appears that this is arising from our broad usage of "*" dependency
constraints, along with our use of an old fork of the `ipc-channel`
crate to get support for Windows.

Here, we pin our other usage of `winapi` to modern versions, which in
turn helps keep other dependency updates sane.

(Note that this shouldn't really affect what version of `winapi` we've
actually been using in these crates; it simply codifies our
expectations more clearly.)

Signed-off-by: Christopher Maier <cmaier@chef.io>