### PR TITLE
Lock down log dependencies

### DIFF
--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -13,7 +13,7 @@ env = "*"
 futures = "*"
 habitat_core = { path = "../core" }
 habitat_http_client = { path = "../http-client" }
-log = "*"
+log = "^0.4.11"
 pbr = "*"
 percent-encoding = "*"
 rand = "*"

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "*"
 env_logger = "*"
 habitat_core = { path = "../core" }
 habitat_common = { path = "../common" }
-log = "*"
+log = "^0.4.11"
 lazy_static = "*"
 prometheus = "*"
 parking_lot = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -28,7 +28,7 @@ handlebars = { version = "= 0.28.3", default-features = false }
 json = "*"
 lazy_static = "*"
 libc = "*"
-log = "*"
+log = "^0.4.11"
 native-tls = { version = "*", features = ["vendored"] }
 owning_ref = "*"
 parking_lot = "*"

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -21,7 +21,7 @@ glob = "*"
 hex = "*"
 lazy_static = "*"
 libc = "0.2.76"
-log = "*"
+log = "^0.4.11"
 native-tls = { version = "*", features = ["vendored"] }
 os_info = "*"
 paste = "1.0"

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -33,7 +33,7 @@ habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 handlebars = { version = "0.29.1", default-features = false }
 lazy_static = "*"
 libc = "*"
-log = "*"
+log = "^0.4.11"
 pbr = "*"
 rants = { version = "*", features = ["native-tls"] }
 # reqwest 0.10.4 significantly increased compile times. The increase was about a 5.5

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -7,7 +7,7 @@ workspace = "../../"
 
 [dependencies]
 base64 = "*"
-log = "*"
+log = "^0.4.11"
 native-tls = { version = "*", features = ["vendored"] }
 pem = "*"
 httparse = "*"

--- a/components/launcher-client/Cargo.toml
+++ b/components/launcher-client/Cargo.toml
@@ -13,6 +13,6 @@ habitat-launcher-protocol = { path = "../launcher-protocol" }
 habitat_common = { path = "../common" }
 ipc-channel = { git = "https://github.com/habitat-sh/ipc-channel", branch = "hbt-windows" }
 libc = "*"
-log = "*"
+log = "^0.4.11"
 prost = "*"
 serde = "*"

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -17,7 +17,7 @@ habitat_core = { path = "../core" }
 habitat-launcher-protocol = { path = "../launcher-protocol" }
 ipc-channel = { git = "https://github.com/habitat-sh/ipc-channel", branch = "hbt-windows" }
 libc = "*"
-log = "*"
+log = "^0.4.11"
 prost = "*"
 semver = "*"
 

--- a/components/pkg-export-container/Cargo.toml
+++ b/components/pkg-export-container/Cargo.toml
@@ -25,7 +25,7 @@ habitat_core = { path = "../core" }
 handlebars = { version = "0.29.1", default-features = false }
 lazy_static = "*"
 linked-hash-map = "*"
-log = "*"
+log = "^0.4.11"
 rusoto_core = "*"
 rusoto_credential = "*"
 rusoto_ecr = "*"

--- a/components/pkg-export-tar/Cargo.toml
+++ b/components/pkg-export-tar/Cargo.toml
@@ -22,7 +22,7 @@ habitat_core = { path = "../core" }
 # We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
 handlebars = { version = "0.29.1", default-features = false }
 lazy_static = "*"
-log = "*"
+log = "^0.4.11"
 mktemp = "*"
 serde = { version = "*", features = ["rc"] }
 serde_json = { version = "*", features = [ "preserve_order" ] }

--- a/components/rst-reader/Cargo.toml
+++ b/components/rst-reader/Cargo.toml
@@ -14,4 +14,4 @@ doc = false
 clap = { git = "https://github.com/habitat-sh/clap.git", branch = "v2-master", features = [ "suggestions", "color", "unstable" ] }
 env_logger = "*"
 habitat_butterfly = { path = "../butterfly", default-features = false }
-log = "*"
+log = "^0.4.11"

--- a/components/sup-client/Cargo.toml
+++ b/components/sup-client/Cargo.toml
@@ -10,7 +10,7 @@ futures = { version = "*" }
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 habitat_common = { path = "../common" }
 habitat_core = { path = "../core" }
-log = "*"
+log = "^0.4.11"
 prost = "*"
 rustls = "*"
 termcolor = "*"

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "*"
 bytes = "*"
 habitat_core = { path = "../core" }
 lazy_static = "*"
-log = "*"
+log = "^0.4.11"
 prost = "*"
 prost-derive = "*"
 rand = "*"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -35,7 +35,7 @@ habitat-launcher-client = { path = "../launcher-client" }
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 lazy_static = "*"
 libc = "*"
-log = "*"
+log = "^0.4.11"
 log4rs = "*"
 notify = "*"
 num_cpus = "*"

--- a/components/win-users/Cargo.toml
+++ b/components/win-users/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 cc = "*"
 
 [dependencies]
-log = "*"
+log = "^0.4.11"
 
 [target.'cfg(windows)'.dependencies]
 widestring = "*"


### PR DESCRIPTION
Similar to what happened in #7976, but with the `log` crate. Sometimes
when we update other dependencies, we can fall back to older `log`
versions because we rely on "*" versioning a bit too liberally.

(Again, this doesn't materially change anything in the code; it merely
expresses our constraints clearly.)

Signed-off-by: Christopher Maier <cmaier@chef.io>