### PR TITLE
Bump os_info from 2.0.8 to 3.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2460,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "2.0.8"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc1b4330bb29087e791ae2a5cf56be64fb8946a4ff5aec2ba11c6ca51f5d60"
+checksum = "a2127a5da3c69035537febc04cd07008bb643653303b213a49b036d944531207"
 dependencies = [
  "log 0.4.11",
  "serde",

--- a/components/core/src/util/docker.rs
+++ b/components/core/src/util/docker.rs
@@ -15,23 +15,28 @@ pub fn command_path() -> Result<PathBuf> {
 /// Note that changes here should be mirrored in .buildkite/scripts/build_docker_image.ps1
 pub fn default_base_tag_for_host() -> Result<&'static str> {
     if cfg!(windows) {
+        use os_info::Version::*; // for Semantic variant
+
         let mut cmd = Command::new(command_path()?);
         cmd.arg("info").arg("--format='{{.Isolation}}'");
         let result = cmd.output().expect("Docker command failed to spawn");
+
+        let info = os_info::get();
+
         if String::from_utf8(result.stdout)?.trim() == "'hyperv'" {
             // hyperv isolation can build any version so we will default to 2019
             // if the host supports it, otherwise 2016
-            if os_info::get().version().version() >= &os_info::VersionType::Semantic(10, 0, 17763) {
+            if *info.version() >= Semantic(10, 0, 17763) {
                 Ok("ltsc2019")
             } else {
                 Ok("ltsc2016")
             }
         } else {
-            match os_info::get().version().version() {
-                os_info::VersionType::Semantic(10, 0, 14393) => Ok("ltsc2016"),
-                os_info::VersionType::Semantic(10, 0, 17134) => Ok("1803"),
-                os_info::VersionType::Semantic(10, 0, 17763) => Ok("ltsc2019"),
-                os_info::VersionType::Semantic(10, 0, 18362) => Ok("1903"),
+            match info.version() {
+                Semantic(10, 0, 14393) => Ok("ltsc2016"),
+                Semantic(10, 0, 17134) => Ok("1803"),
+                Semantic(10, 0, 17763) => Ok("ltsc2019"),
+                Semantic(10, 0, 18362) => Ok("1903"),
                 unsupported_version => {
                     Err(Error::UnsupportedDockerHostKernel(unsupported_version.to_string()))
                 }


### PR DESCRIPTION
There were some breaking API [changes][1] when os_info went to version 3;
this addresses them in our codebase.

[1]: https://github.com/stanislav-tkach/os_info/blob/master/CHANGELOG.md#300-2020-09-28

Signed-off-by: Christopher Maier <cmaier@chef.io>