### PR TITLE
Lock lazy_static dependency

### DIFF
--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -18,7 +18,7 @@ env_logger = "*"
 habitat_core = { path = "../core" }
 habitat_common = { path = "../common" }
 log = "^0.4.11"
-lazy_static = "*"
+lazy_static = "^1.4.0"
 prometheus = "*"
 parking_lot = "*"
 prost = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -26,7 +26,7 @@ habitat_core = { path = "../core" }
 #   See https://github.com/sunng87/handlebars-rust/commit/707f05442ef6f441a1cfc6b13ac180b78cb296db
 handlebars = { version = "= 0.28.3", default-features = false }
 json = "*"
-lazy_static = "*"
+lazy_static = "^1.4.0"
 libc = "*"
 log = "^0.4.11"
 native-tls = { version = "*", features = ["vendored"] }

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -19,7 +19,7 @@ dns-lookup = "*"
 errno = "*"
 glob = "*"
 hex = "*"
-lazy_static = "*"
+lazy_static = "^1.4.0"
 libc = "0.2.76"
 log = "^0.4.11"
 native-tls = { version = "*", features = ["vendored"] }

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -31,7 +31,7 @@ habitat-sup-client = { path = "../sup-client" }
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 # We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
 handlebars = { version = "0.29.1", default-features = false }
-lazy_static = "*"
+lazy_static = "^1.4.0"
 libc = "*"
 log = "^0.4.11"
 pbr = "*"

--- a/components/pkg-export-container/Cargo.toml
+++ b/components/pkg-export-container/Cargo.toml
@@ -23,7 +23,7 @@ habitat_common = { path = "../common" }
 habitat_core = { path = "../core" }
 # We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
 handlebars = { version = "0.29.1", default-features = false }
-lazy_static = "*"
+lazy_static = "^1.4.0"
 linked-hash-map = "*"
 log = "^0.4.11"
 rusoto_core = "*"

--- a/components/pkg-export-tar/Cargo.toml
+++ b/components/pkg-export-tar/Cargo.toml
@@ -21,7 +21,7 @@ habitat_common = { path = "../common" }
 habitat_core = { path = "../core" }
 # We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
 handlebars = { version = "0.29.1", default-features = false }
-lazy_static = "*"
+lazy_static = "^1.4.0"
 log = "^0.4.11"
 mktemp = "*"
 serde = { version = "*", features = ["rc"] }

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -10,7 +10,7 @@ workspace = "../../"
 base64 = "*"
 bytes = "*"
 habitat_core = { path = "../core" }
-lazy_static = "*"
+lazy_static = "^1.4.0"
 log = "^0.4.11"
 prost = "*"
 prost-derive = "*"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -33,7 +33,7 @@ habitat_api_client = { path = "../builder-api-client" }
 habitat_http_client = { path = "../http-client" }
 habitat-launcher-client = { path = "../launcher-client" }
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
-lazy_static = "*"
+lazy_static = "^1.4.0"
 libc = "*"
 log = "^0.4.11"
 log4rs = "*"


### PR DESCRIPTION
Similar to what happened in #7976, but with the `lazy_static`
crate. Sometimes when we update other dependencies, we can fall back
to older `lazy_static` versions because we rely on "*" versioning a
bit too liberally.

(Again, this doesn't materially change anything in the code; it merely
expresses our constraints clearly.)

Signed-off-by: Christopher Maier <cmaier@chef.io>