### PR TITLE
Lock Tokio dependencies to 0.2 line

### DIFF
--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -23,6 +23,6 @@ serde = "*"
 serde_derive = "*"
 serde_json = { version = "*", features = [ "preserve_order" ] }
 tee = "*"
-tokio = { version = "*", features = ["full"] }
-tokio-util = "*"
+tokio = { version = "^0.2", features = ["full"] }
+tokio-util = "^0.3"
 url = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -46,7 +46,7 @@ thiserror = "*"
 retry = { git = "https://github.com/habitat-sh/retry", features = ["asynchronous"] }
 rustls = "*"
 termcolor = "*"
-tokio = { version = "*", features = ["full"] }
+tokio = { version = "^0.2", features = ["full"] }
 toml = { version = "*", features = ["preserve_order"] }
 uuid = { version = "*", features = ["v4"] }
 valico = "*"

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -40,8 +40,8 @@ tabwriter = "*"
 tar = "*"
 tempfile = "*"
 thiserror = "*"
-tokio = { version = "*", features = ["full"] }
-tokio-rustls = "*"
+tokio = { version = "^0.2", features = ["full"] }
+tokio-rustls = "^0.14" # Tokio 0.2
 toml = { version = "0.5.6", features = [ "preserve_order" ] }
 typemap = "*"
 url = "*"

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -52,7 +52,7 @@ tabwriter = "*"
 tar = "*"
 termcolor = "*"
 thiserror = "*"
-tokio = { version = "*", features = ["full"] }
+tokio = { version = "^0.2", features = ["full"] }
 toml = { version = "*", features = [ "preserve_order" ] }
 url = { version = "*", features = ["serde"] }
 walkdir = "*"

--- a/components/pkg-export-container/Cargo.toml
+++ b/components/pkg-export-container/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "*", features = ["rc"] }
 serde_json = { version = "*", features = [ "preserve_order" ] }
 tempfile = "*"
 termcolor = "*"
-tokio = { version = "*", features = ["full"] }
+tokio = { version = "^0.2", features = ["full"] }
 url = "*"
 failure = "*"
 failure_derive = "*"

--- a/components/pkg-export-tar/Cargo.toml
+++ b/components/pkg-export-tar/Cargo.toml
@@ -26,7 +26,7 @@ log = "^0.4.11"
 mktemp = "*"
 serde = { version = "*", features = ["rc"] }
 serde_json = { version = "*", features = [ "preserve_order" ] }
-tokio = { version = "*", features = ["full"] }
+tokio = { version = "^0.2", features = ["full"] }
 url = "*"
 failure = "*"
 failure_derive = "*"

--- a/components/sup-client/Cargo.toml
+++ b/components/sup-client/Cargo.toml
@@ -14,5 +14,5 @@ log = "^0.4.11"
 prost = "*"
 rustls = "*"
 termcolor = "*"
-tokio = { version = "*", features = ["full"] }
-tokio-util = { version = "*", features = ["full"] }
+tokio = { version = "^0.2", features = ["full"] }
+tokio-util = { version = "^0.3", features = ["full"] }

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -17,8 +17,8 @@ prost-derive = "*"
 rand = "*"
 serde = "*"
 serde_derive = "*"
-tokio = { version = "*", features = ["full"] }
-tokio-util = { version = "*", features = ["full"] }
+tokio = { version = "^0.2", features = ["full"] }
+tokio-util = { version = "^0.3", features = ["full"] }
 
 [build-dependencies]
 prost-build = "*"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -59,9 +59,9 @@ structopt = { git = "https://github.com/habitat-sh/structopt.git" }
 tempfile = "*"
 termcolor = "*"
 toml = { version = "*", features = ["preserve_order"]}
-tokio = { version = "*", features = ["full"] }
-tokio-rustls = "*"
-tokio-util = { version = "*", features = ["full"] }
+tokio = { version = "^0.2", features = ["full"] }
+tokio-rustls = "^0.14" # Tokio 0.2
+tokio-util = { version = "^0.3", features = ["full"] }
 url = "*"
 valico = "*"
 


### PR DESCRIPTION
0.3 has been released, but has some API incompatibilities. Until we
can address those, we'll declare our dependencies more clearly to
prevent unexpected breakages.

Signed-off-by: Christopher Maier <cmaier@chef.io>