### PR TITLE
added utility function required_value_of and refactored

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1258,8 +1258,7 @@ async fn sub_pkg_delete(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 }
 
 fn sub_pkg_verify(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
-    let src = required_value_of(m, "SOURCE");
-    let src = Path::new(src);
+    let src = Path::new(required_value_of(m, "SOURCE"));
     let key_cache = key_cache_from_matches(m)?;
     init()?;
 
@@ -1267,16 +1266,14 @@ fn sub_pkg_verify(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 }
 
 fn sub_pkg_header(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
-    let src = required_value_of(m, "SOURCE");
-    let src = Path::new(src);
+    let src = Path::new(required_value_of(m, "SOURCE"));
     init()?;
 
     command::pkg::header::start(ui, &src)
 }
 
 fn sub_pkg_info(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
-    let src = required_value_of(m, "SOURCE");
-    let src = Path::new(src);
+    let src = Path::new(required_value_of(m, "SOURCE"));
     let to_json = m.is_present("TO_JSON");
     init()?;
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1310,8 +1310,7 @@ async fn sub_pkg_channels(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 async fn sub_svc_set(m: &ArgMatches<'_>) -> Result<()> {
     let remote_sup_addr = remote_sup_from_input(m)?;
     let remote_sup_addr = SrvClient::ctl_addr(remote_sup_addr.as_ref())?;
-    let service_group = required_value_of(m, "SERVICE_GROUP");
-    let service_group = ServiceGroup::from_str(service_group)?;
+    let service_group = required_value_of(m, "SERVICE_GROUP").parse::<ServiceGroup>()?;
     let mut ui = ui::ui();
     let mut validate = sup_proto::ctl::SvcValidateCfg::default();
     validate.service_group = Some(service_group.clone().into());
@@ -1497,14 +1496,12 @@ async fn sub_svc_stop(m: &ArgMatches<'_>) -> Result<()> {
 }
 
 async fn sub_file_put(m: &ArgMatches<'_>) -> Result<()> {
-    let service_group = required_value_of(m, "SERVICE_GROUP");
-    let service_group = ServiceGroup::from_str(service_group)?;
+    let service_group = required_value_of(m, "SERVICE_GROUP").parse::<ServiceGroup>()?;
     let remote_sup_addr = remote_sup_from_input(m)?;
     let remote_sup_addr = SrvClient::ctl_addr(remote_sup_addr.as_ref())?;
     let mut ui = ui::ui();
     let mut msg = sup_proto::ctl::SvcFilePut::default();
-    let file = required_value_of(m, "FILE");
-    let file = Path::new(file);
+    let file = Path::new(required_value_of(m, "FILE"));
     if file.metadata()?.len() > sup_proto::butterfly::MAX_FILE_PUT_SIZE_BYTES as u64 {
         ui.fatal(format!("File too large. Maximum size allowed is {} bytes.",
                          sup_proto::butterfly::MAX_FILE_PUT_SIZE_BYTES))?;
@@ -1669,8 +1666,7 @@ fn sub_ring_key_import(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 
 fn sub_service_key_generate(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let org = org_param_or_env(m)?;
-    let service_group = required_value_of(m, "SERVICE_GROUP");
-    let service_group = ServiceGroup::from_str(service_group)?;
+    let service_group = required_value_of(m, "SERVICE_GROUP").parse::<ServiceGroup>()?;
     let key_cache = key_cache_from_matches(m)?;
     init()?;
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -697,8 +697,7 @@ async fn sub_origin_depart(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 
 async fn sub_accept_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let origin = required_value_of(m, "ORIGIN");
-    let invitation_id = required_value_of(m, "INVITATION_ID");
-    let invitation_id: u64 = invitation_id
+    let invitation_id = required_value_of(m, "INVITATION_ID")
                               .parse()
                               .expect("INVITATION_ID should be valid at this point");
     let url = bldr_url_from_matches(m)?;
@@ -708,8 +707,7 @@ async fn sub_accept_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result
 
 async fn sub_ignore_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let origin = required_value_of(m, "ORIGIN");
-    let invitation_id = required_value_of(m, "INVITATION_ID");
-    let invitation_id: u64 = invitation_id
+    let invitation_id = required_value_of(m, "INVITATION_ID")
                               .parse()
                               .expect("INVITATION_ID should be valid at this point");
     let url = bldr_url_from_matches(m)?;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -607,21 +607,23 @@ async fn sub_origin_key_upload(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 
     init()?;
 
-    if m.is_present("ORIGIN") {
-        let origin = required_value_of(m, "ORIGIN").parse()?;
-        // you can either specify files, or infer the latest key names
-        let with_secret = m.is_present("WITH_SECRET");
-        command::origin::key::upload_latest::start(ui,
-                                                   &url,
-                                                   &token,
-                                                   &origin,
-                                                   with_secret,
-                                                   &key_cache).await
-    } else {
-        let secret_file = required_value_of(m, "PUBLIC_FILE");
-        let keyfile = Path::new(secret_file);
-        let secret_keyfile = m.value_of("SECRET_FILE").map(|f| Path::new(f));
-        command::origin::key::upload::start(ui, &url, &token, &keyfile, secret_keyfile).await
+    match m.value_of("ORIGIN") {
+        Some(origin) => {
+            let origin = origin.parse()?;
+            // you can either specify files, or infer the latest key names
+            let with_secret = m.is_present("WITH_SECRET");
+            command::origin::key::upload_latest::start(ui,
+                                                       &url,
+                                                       &token,
+                                                       &origin,
+                                                       with_secret,
+                                                       &key_cache).await
+        },
+        None => {
+            let keyfile = Path::new(required_value_of(m, "PUBLIC_FILE"));
+            let secret_keyfile = m.value_of("SECRET_FILE").map(|f| Path::new(f));
+            command::origin::key::upload::start(ui, &url, &token, &keyfile, secret_keyfile).await
+        }
     }
 }
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -772,8 +772,7 @@ async fn sub_origin_member_role_set(ui: &mut UI, r: RbacSet) -> Result<()> {
 
 fn sub_pkg_binlink(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let ident = required_pkg_ident_from_input(m)?;
-    let dest_dir = required_value_of(m, "DEST_DIR");
-    let dest_dir = Path::new(dest_dir);
+    let dest_dir = Path::new(required_value_of(m, "DEST_DIR"));
     let force = m.is_present("FORCE");
     match m.value_of("BINARY") {
         Some(binary) => {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -618,7 +618,7 @@ async fn sub_origin_key_upload(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
                                                        &origin,
                                                        with_secret,
                                                        &key_cache).await
-        },
+        }
         None => {
             let keyfile = Path::new(required_value_of(m, "PUBLIC_FILE"));
             let secret_keyfile = m.value_of("SECRET_FILE").map(|f| Path::new(f));

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1173,10 +1173,8 @@ async fn sub_pkg_search(m: &ArgMatches<'_>) -> Result<()> {
 fn sub_pkg_sign(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let origin = origin_param_or_env(m)?;
 
-    let src = required_value_of(m, "SOURCE");
-    let src = Path::new(src);
-    let dst = required_value_of(m, "DEST");
-    let dst = Path::new(dst);
+    let src = Path::new(required_value_of(m, "SOURCE"));
+    let dst = Path::new(required_value_of(m, "DEST"));
 
     let key_cache = key_cache_from_matches(m)?;
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -697,9 +697,9 @@ async fn sub_origin_depart(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 
 async fn sub_accept_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let origin = required_value_of(m, "ORIGIN");
-    let invitation_id = required_value_of(m, "INVITATION_ID")
-                              .parse()
-                              .expect("INVITATION_ID should be valid at this point");
+    let invitation_id =
+        required_value_of(m, "INVITATION_ID").parse()
+                                             .expect("INVITATION_ID should be valid at this point");
     let url = bldr_url_from_matches(m)?;
     let token = auth_token_param_or_env(m)?;
     command::origin::invitations::accept::start(ui, &url, &origin, &token, invitation_id).await
@@ -707,9 +707,9 @@ async fn sub_accept_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result
 
 async fn sub_ignore_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let origin = required_value_of(m, "ORIGIN");
-    let invitation_id = required_value_of(m, "INVITATION_ID")
-                              .parse()
-                              .expect("INVITATION_ID should be valid at this point");
+    let invitation_id =
+        required_value_of(m, "INVITATION_ID").parse()
+                                             .expect("INVITATION_ID should be valid at this point");
     let url = bldr_url_from_matches(m)?;
     let token = auth_token_param_or_env(m)?;
     command::origin::invitations::ignore::start(ui, &url, &origin, &token, invitation_id).await
@@ -730,9 +730,9 @@ async fn sub_list_pending_origin_invitations(ui: &mut UI, m: &ArgMatches<'_>) ->
 
 async fn sub_rescind_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let origin = required_value_of(m, "ORIGIN");
-    let invitation_id = required_value_of(m, "INVITATION_ID")
-                              .parse()
-                              .expect("INVITATION_ID should be valid at this point");
+    let invitation_id =
+        required_value_of(m, "INVITATION_ID").parse()
+                                             .expect("INVITATION_ID should be valid at this point");
     let url = bldr_url_from_matches(m)?;
     let token = auth_token_param_or_env(m)?;
     command::origin::invitations::rescind::start(ui, &url, &origin, &token, invitation_id).await

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1163,8 +1163,7 @@ fn sub_pkg_provides(m: &ArgMatches<'_>) -> Result<()> {
 async fn sub_pkg_search(m: &ArgMatches<'_>) -> Result<()> {
     let url = bldr_url_from_matches(m)?;
     let search_term = required_value_of(m, "SEARCH_TERM");
-    let limit = required_value_of(m, "LIMIT");
-    let limit = limit
+    let limit = required_value_of(m, "LIMIT")
                  .parse()
                  .expect("valid LIMIT");
     let token = maybe_auth_token(m);

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -2032,7 +2032,7 @@ fn user_param_or_env(m: &ArgMatches<'_>) -> Option<String> {
 /// Helper function to get information about the argument given its name
 fn required_value_of<'a>(matches: &'a ArgMatches<'a>, name: &str) -> &'a str {
     matches.value_of(name)
-           .expect(&format!("{} CLAP required arg missing", name))
+           .unwrap_or_else(|| panic!("{} CLAP required arg missing", name))
 }
 
 #[cfg(test)]

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1666,7 +1666,7 @@ fn sub_ring_key_import(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
 
 fn sub_service_key_generate(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let org = org_param_or_env(m)?;
-    let service_group = required_value_of(m, "SERVICE_GROUP").parse::<ServiceGroup>()?;
+    let service_group = required_value_of(m, "SERVICE_GROUP").parse()?;
     let key_cache = key_cache_from_matches(m)?;
     init()?;
 

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -1162,9 +1162,7 @@ fn sub_pkg_provides(m: &ArgMatches<'_>) -> Result<()> {
 async fn sub_pkg_search(m: &ArgMatches<'_>) -> Result<()> {
     let url = bldr_url_from_matches(m)?;
     let search_term = required_value_of(m, "SEARCH_TERM");
-    let limit = required_value_of(m, "LIMIT")
-                 .parse()
-                 .expect("valid LIMIT");
+    let limit = required_value_of(m, "LIMIT").parse().expect("valid LIMIT");
     let token = maybe_auth_token(m);
     command::pkg::search::start(&search_term, &url, limit, token.as_deref()).await
 }

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -730,8 +730,7 @@ async fn sub_list_pending_origin_invitations(ui: &mut UI, m: &ArgMatches<'_>) ->
 
 async fn sub_rescind_origin_invitation(ui: &mut UI, m: &ArgMatches<'_>) -> Result<()> {
     let origin = required_value_of(m, "ORIGIN");
-    let invitation_id = required_value_of(m, "INVITATION_ID");
-    let invitation_id: u64 = invitation_id
+    let invitation_id = required_value_of(m, "INVITATION_ID")
                               .parse()
                               .expect("INVITATION_ID should be valid at this point");
     let url = bldr_url_from_matches(m)?;

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -2032,7 +2032,7 @@ fn user_param_or_env(m: &ArgMatches<'_>) -> Option<String> {
 /// Helper function to get information about the argument given its name
 fn required_value_of<'a>(matches: &'a ArgMatches<'a>, name: &str) -> &'a str {
     matches.value_of(name)
-        .expect(&format!("{} CLAP required arg missing", name))
+           .expect(&format!("{} CLAP required arg missing", name))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Added a utility function required_value_of and refactored the code to use this utility function Clap argument parsing.

The ArgMatches is being passed as a reference, it is unnecessary to pass it as a reference when calling other functions. Removed unnecessary re-referencing the ArgMatches ('&m') when passing the argument.

https://github.com/habitat-sh/habitat/issues/6471