### PR TITLE
Edit plan_variable docs for clarity

### DIFF
--- a/.expeditor/scripts/verify/shellcheck.sh
+++ b/.expeditor/scripts/verify/shellcheck.sh
@@ -16,6 +16,8 @@ shellcheck --version
 #
 # Exclude the bats submodules since we don't own that code.
 #
+# Exclude the chef-web-docs submodule since we don't own that code either.
+#
 # Exclude the following shellcheck issues since they're pervasive and innocuous:
 # https://github.com/koalaman/shellcheck/wiki/SC1090
 # https://github.com/koalaman/shellcheck/wiki/SC1091
@@ -35,6 +37,7 @@ find . -type f \
   -and \! -path "./test/integration/test_helper/bats-support/*" \
   -and \! -path "./test/fixtures/render/consul/hooks/run" \
   -and \! -path "./test/fixtures/render/error/*" \
+  -and \! -path "./components/docs-chef-io/chef-web-docs/*" \
   -print \
   | xargs shellcheck --external-sources --exclude=1090,1091,1117,2148,2034
 

--- a/components/docs-chef-io/content/habitat/plan_variables.md
+++ b/components/docs-chef-io/content/habitat/plan_variables.md
@@ -21,37 +21,37 @@ pkg_dirname
 
   If a .tar file extracts to a directory that's different from the filename, then you would need to override this value to match the directory name created during extraction.
 
-  Default value: `{pkg_name}-{pkg_version}`
+  Default value: `${pkg_name}-${pkg_version}`
 
 pkg_svc_path
 : Where the running service is located.
 
-  Default value: `HAB_ROOT_PATH/svc/pkg_name`
+  Read-only value: `${HAB_ROOT_PATH}/svc/${pkg_name}`
 
 pkg_svc_data_path
 : Where the running service data is located.
 
-  Default value: `pkg_svc_path/data`
+  Read-only value: `${pkg_svc_path}/data`
 
 pkg_svc_files_path
 : Where the gossiped configuration files are located.
 
-  Default value: `pkg_svc_path/files`
+  Read-only value: `${pkg_svc_path}/files`
 
 pkg_svc_var_path
 : Where the running service variable data is located.
 
-  Default value: `pkg_svc_path/var`
+  Read-only value: `${pkg_svc_path}/var`
 
 pkg_svc_config_path
 : Where the running service configuration is located.
 
-  Read-only value: `pkg_svc_path/config`
+  Read-only value: `${pkg_svc_path}/config`
 
 pkg_svc_static_path
 : Where the running service static data is located.
 
-  Default value: `pkg_svc_path/static`
+  Read-only value: `${pkg_svc_path}/static`
 
 CACHE_PATH
 : A temporary directory that will be clean on every build.

--- a/components/docs-chef-io/content/habitat/plan_variables.md
+++ b/components/docs-chef-io/content/habitat/plan_variables.md
@@ -17,31 +17,47 @@ pkg_prefix
 : The absolute path for your package.
 
 pkg_dirname
-: Set to `{pkg_name}-{pkg_version}` by default. If a .tar file extracts to a directory that's different from the filename, then you would need to override this value to match the directory name created during extraction.
+: The directory created when Habitat extracts an archive.
+
+  If a .tar file extracts to a directory that's different from the filename, then you would need to override this value to match the directory name created during extraction.
+
+  Default value: `{pkg_name}-{pkg_version}`
 
 pkg_svc_path
-: Where the running service is located. Location: `HAB_ROOT_PATH/svc/pkg_name`
+: Where the running service is located.
+
+  Default value: `HAB_ROOT_PATH/svc/pkg_name`
 
 pkg_svc_data_path
-: Where the running service data is located. Location: `pkg_svc_path/data`
+: Where the running service data is located.
+
+  Default value: `pkg_svc_path/data`
 
 pkg_svc_files_path
-: Where the gossiped configuration files are located. Location: `pkg_svc_path/files`
+: Where the gossiped configuration files are located.
+
+  Default value: `pkg_svc_path/files`
 
 pkg_svc_var_path
-: Where the running service variable data is located. Location: `pkg_svc_path/var`
+: Where the running service variable data is located.
+
+  Default value: `pkg_svc_path/var`
 
 pkg_svc_config_path
-: Where the running service configuration is located. Location: `pkg_svc_path/config`
+: Where the running service configuration is located.
+
+  Read-only value: `pkg_svc_path/config`
 
 pkg_svc_static_path
-: Where the running service static data is located. Location: `pkg_svc_path/static`
+: Where the running service static data is located.
+
+  Default value: `pkg_svc_path/static`
 
 CACHE_PATH
 : A temporary directory that will be clean on every build.
 
 HAB_CACHE_SRC_PATH
-: The default path where source archives are downloaded, extracted, & compiled.
+: The default path where source archives are downloaded, extracted, and compiled.
 
 HAB_CACHE_ARTIFACT_PATH
 : The default download root path for packages.

--- a/components/docs-chef-io/content/habitat/plan_variables.md
+++ b/components/docs-chef-io/content/habitat/plan_variables.md
@@ -11,7 +11,9 @@ description = "Set package, service, and cache paths, compiler options, install 
 +++
 [\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/plan_variables.md)
 
-The following variables can be used in your plans to help get binaries and libraries to build and install in the correct locations in your package.
+The following variables can be used in your plans to help get binaries and libraries
+to build and install in the correct locations in your package. The values for the
+variables listed below are default values or read-only values.
 
 pkg_prefix
 : The absolute path for your package.
@@ -56,14 +58,22 @@ pkg_svc_static_path
 CACHE_PATH
 : A temporary directory that will be clean on every build.
 
+  Read-only value: `${HAB_CACHE_SRC_PATH}/${pkg_dirname}`
+
 HAB_CACHE_SRC_PATH
 : The default path where source archives are downloaded, extracted, and compiled.
+
+  Read-only value: `${HAB_ROOT_PATH}/cache/src`
 
 HAB_CACHE_ARTIFACT_PATH
 : The default download root path for packages.
 
+  Read-only value: `${HAB_ROOT_PATH}/cache/artifacts`
+
 HAB_PKG_PATH
 : The root path containing all locally installed packages.
+
+  Read-only value: `${HAB_ROOT_PATH}/pkgs`
 
 PLAN_CONTEXT
 : The location on your local dev machine for the files in your plan directory.


### PR DESCRIPTION
Signed-off-by: IanMadd <imaddaus@chef.io>

Edit the Plan Variable docs to make the values of the variables more clear.

I set the value of `pkg_svc_config_path` to "Read-only value", the others are "Default value". We can change that if those aren't correct.

https://deploy-preview-7992--chef-habitat.netlify.app/habitat/plan_variables/