### PR TITLE
[CI] Remove old `hab` binaries on Linux containers

### DIFF
--- a/.expeditor/scripts/release_habitat/build_component.sh
+++ b/.expeditor/scripts/release_habitat/build_component.sh
@@ -7,6 +7,10 @@ source .expeditor/scripts/release_habitat/shared.sh
 export HAB_AUTH_TOKEN="${PIPELINE_HAB_AUTH_TOKEN}"
 export HAB_BLDR_URL="${PIPELINE_HAB_BLDR_URL}"
 
+# Before we do *ANYTHING*, we're going to just delete any prior
+# version of Habitat that exists in the container.
+rm -Rf /hab/pkgs/core/hab
+
 ########################################################################
 
 # `component` should be the subdirectory name in `components` where a


### PR DESCRIPTION
This "fixes" a situation where we released a version of Habitat where
the Linux and Linux kernel 2 releases of `core/hab` were identical
down to their release. The packages were built properly, and can be
installed and used properly. However, we run into an issue in our CI
environment because the main build containers contain the Linux
release already, and we install the kernel 2 release alongside it for
building kernel 2 packages. When they have identical releases,
however, they end up going into the same directory, and wackiness can
ensue.

This solution doesn't feel great, but it does appear to work to keep
our CI containers as pristine as possible right now.

(We're only doing this on Linux because it's not a problem on Windows;
there's only one kind of release that can run on that platform.)

Signed-off-by: Christopher Maier <cmaier@chef.io>