### PR TITLE
[CI] Unload test-probe service after test

### DIFF
--- a/test/end-to-end/test_health_check_output_of_http_gateway.ps1
+++ b/test/end-to-end/test_health_check_output_of_http_gateway.ps1
@@ -6,6 +6,7 @@ if ($IsWindows) {
 
 Describe "HTTP gateway" {
     AfterAll {
+        Unload-SupervisorService -PackageName habitat-testing/test-probe -Timeout 30
         Stop-Supervisor
     }
 


### PR DESCRIPTION
The `habitat-testing/test-probe` service has a long shutdown sequence
that causes the test (as originally written) to fail with a timeout.

To fix this, we'll unload the service first (with a suitable timeout),
and _then_ stop the Supervisor.

Signed-off-by: Christopher Maier <cmaier@chef.io>