### PR TITLE
[CI] Increase service unload timeouts for test_config_files e2e test

### DIFF
--- a/test/end-to-end/test_config_files.ps1
+++ b/test/end-to-end/test_config_files.ps1
@@ -73,7 +73,7 @@ Describe "reading from supervisor and service config files" {
         Wait-SupervisorService $svcName
     }
 
-    Unload-SupervisorService -PackageName $pkgName
+    Unload-SupervisorService -PackageName $pkgName -Timeout 10
     Remove-Item -Force -Recurse -ErrorAction Ignore $svcConfig
 
     It "service starts with bulkload" {
@@ -82,7 +82,7 @@ Describe "reading from supervisor and service config files" {
         Wait-SupervisorService $svcName
     }
 
-    Unload-SupervisorService -PackageName $pkgName
+    Unload-SupervisorService -PackageName $pkgName -Timeout 10
     Stop-Supervisor
 
     It "service starts on Supervisor startup" {
@@ -94,6 +94,6 @@ Describe "reading from supervisor and service config files" {
     Remove-Item -Force -Recurse -ErrorAction Ignore $supConfig
     Remove-Item -Force -Recurse -ErrorAction Ignore $svcConfig
     Remove-Item -Force -Recurse -ErrorAction Ignore $svcDirConfig
-    Unload-SupervisorService -PackageName $pkgName
+    Unload-SupervisorService -PackageName $pkgName -Timeout 10
     Stop-Supervisor
 }


### PR DESCRIPTION
We've seen periodic, spurious test failures with the default 5 second
timeout lately (likely due to environmental issues in our CI
workers). To prevent unnecessary pipeline failures, we'll just bump
the timeout a tad.

Signed-off-by: Christopher Maier <cmaier@chef.io>