### PR TITLE
[CI] Remove `--no-modify-path` from `install_rustup`

### DIFF
--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -41,7 +41,7 @@ install_rustup() {
     echo "--- :rust: rustup is currently installed."
   else
     echo "--- :rust: Installing rustup."
-    curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path -y --profile=minimal
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile=minimal
     # shellcheck disable=SC1090
     source "$HOME"/.cargo/env
   fi


### PR DESCRIPTION
This is a temporary workaround for https://github.com/rust-lang/rustup/issues/2578

Signed-off-by: Christopher Maier <cmaier@chef.io>