### PR TITLE
Lock mio dependency more tightly

### DIFF
--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -78,7 +78,7 @@ habitat-launcher-protocol = { path = "../launcher-protocol" }
 mio-named-pipes = "*"
 # Pinning for now. Since upgrading to 0.7.0 results in conflicts with other crates
 # See https://github.com/habitat-sh/habitat/issues/7522
-mio = "0.6.21"
+mio = "^0.6"
 uuid = { version = "*", features = ["v4"] }
 winapi =  { version = "^0.3.9", features = ["namedpipeapi", "tlhelp32"] }
 


### PR DESCRIPTION
To prevent updating to 0.7.* of mio, we need to use a caret
dependency.

Signed-off-by: Christopher Maier <cmaier@chef.io>