### PR TITLE
Improve handling of Supervisor LOCK file

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -1070,6 +1070,37 @@ steps:
             - BUILDKITE_AGENT_ACCESS_TOKEN
             - PIPELINE_HAB_AUTH_TOKEN
 
+  - label: "[:linux: test_supervisor_lock_file_behavior]"
+    command:
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_supervisor_lock_file_behavior
+    artifact_paths:
+      - "*.log"
+    env:
+      BUILD_PKG_TARGET: x86_64-linux
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+            - PIPELINE_HAB_AUTH_TOKEN
+
+  - label: "[:windows: test_supervisor_lock_file_behavior]"
+    command:
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_supervisor_lock_file_behavior
+    artifact_paths:
+      - "*.log"
+    env:
+      BUILD_PKG_TARGET: x86_64-windows
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          environment:
+            - BUILD_PKG_TARGET=x86_64-windows
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+            - PIPELINE_HAB_AUTH_TOKEN
+
   - wait
 
   - label: "[:habicat: Promote to Acceptance]"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1626,7 @@ dependencies = [
  "cpu-time",
  "ctrlc",
  "derivative",
+ "fs2",
  "futures",
  "glob",
  "hab",
@@ -1640,6 +1651,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project 0.4.23",
+ "procfs",
  "prometheus",
  "prost",
  "prost-build",
@@ -1658,6 +1670,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "termcolor",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tokio-util 0.3.1",
@@ -2801,6 +2814,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "procfs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static 1.4.0",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,7 +1651,6 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "pin-project 0.4.23",
- "procfs",
  "prometheus",
  "prost",
  "prost-build",
@@ -2814,21 +2813,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "procfs"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8809e0c18450a2db0f236d2a44ec0b4c1412d0eb936233579f0990faa5d5cd"
-dependencies = [
- "bitflags",
- "byteorder",
- "chrono",
- "flate2",
- "hex",
- "lazy_static 1.4.0",
- "libc",
 ]
 
 [[package]]

--- a/components/launcher-client/src/lib.rs
+++ b/components/launcher-client/src/lib.rs
@@ -5,7 +5,6 @@ mod client;
 pub mod error;
 
 pub use habitat_launcher_protocol::{ERR_NO_RETRY_EXCODE,
-                                    LAUNCHER_LOCK_CLEAN_ENV,
                                     LAUNCHER_PID_ENV,
                                     OK_NO_RETRY_EXCODE};
 

--- a/components/launcher-protocol/src/lib.rs
+++ b/components/launcher-protocol/src/lib.rs
@@ -13,9 +13,6 @@ pub use crate::{error::Error,
 
 pub const LAUNCHER_PIPE_ENV: &str = "HAB_LAUNCHER_PIPE";
 pub const LAUNCHER_PID_ENV: &str = "HAB_LAUNCHER_PID";
-// Set to instruct the Supervisor to clean the Launcher's process LOCK on startup. This is useful
-// when restarting a Supervisor which terminated normally.
-pub const LAUNCHER_LOCK_CLEAN_ENV: &str = "HAB_LAUNCHER_LOCK_CLEAN";
 /// Process exit code from Supervisor which indicates to Launcher that the Supervisor
 /// ran to completion with a successful result. The Launcher should not attempt to restart
 /// the Supervisor and should exit immediately with a successful exit code.

--- a/components/launcher/src/server.rs
+++ b/components/launcher/src/server.rs
@@ -90,7 +90,7 @@ impl Server {
         let mut pid_file = fs::File::create(&pid_file_path)?;
         write!(&mut pid_file, "{}", process::current_pid())?;
 
-        let ((rx, tx), supervisor, pipe) = Self::init(&args, false)?;
+        let ((rx, tx), supervisor, pipe) = Self::init(&args)?;
         Ok(Server { pid_file_path,
                     services: ServiceTable::default(),
                     tx,
@@ -105,9 +105,9 @@ impl Server {
     /// Passing a value of true to the `clean` argument will force the Supervisor to clean the
     /// Launcher's process LOCK before starting. This is useful when restarting a Supervisor
     /// that terminated gracefully.
-    fn init(args: &[String], clean: bool) -> Result<((Receiver, Sender), Child, String)> {
+    fn init(args: &[String]) -> Result<((Receiver, Sender), Child, String)> {
         let (server, pipe) = IpcOneShotServer::new().map_err(Error::OpenPipe)?;
-        let supervisor = spawn_supervisor(&pipe, args, clean)?;
+        let supervisor = spawn_supervisor(&pipe, args)?;
         let ipc_channel = setup_connection(server)?;
         Ok((ipc_channel, supervisor, pipe))
     }
@@ -125,7 +125,7 @@ impl Server {
     fn reload(&mut self) -> Result<()> {
         self.supervisor.kill();
         self.supervisor.wait();
-        let ((rx, tx), supervisor, pipe) = Self::init(&self.args, true)?;
+        let ((rx, tx), supervisor, pipe) = Self::init(&self.args)?;
         self.tx = tx;
         self.rx = rx;
         self.supervisor = supervisor;
@@ -603,7 +603,7 @@ fn is_supported_supervisor_version(version_output: &str) -> bool {
 /// Passing a value of true to the `clean` argument will force the Supervisor to clean the
 /// Launcher's process LOCK before starting. This is useful when restarting a Supervisor
 /// that terminated gracefully.
-fn spawn_supervisor(pipe: &str, args: &[String], clean: bool) -> Result<Child> {
+fn spawn_supervisor(pipe: &str, args: &[String]) -> Result<Child> {
     let binary = supervisor_cmd()?;
 
     if core::env::var(SUP_VERSION_CHECK_DISABLE).is_ok() {
@@ -625,9 +625,7 @@ fn spawn_supervisor(pipe: &str, args: &[String], clean: bool) -> Result<Child> {
     }
 
     let mut command = Command::new(&binary);
-    if clean {
-        command.env(protocol::LAUNCHER_LOCK_CLEAN_ENV, clean.to_string());
-    }
+
     debug!("Starting Supervisor {:?} with args {:?}, {}={}...",
            binary,
            args,

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -69,7 +69,6 @@ valico = "*"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "*"
-procfs = "*"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 jemallocator = "*"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -23,6 +23,7 @@ clap = { git = "https://github.com/habitat-sh/clap.git", branch = "v2-master", f
 configopt = { git = "https://github.com/davidMcneil/configopt.git" }
 cpu-time = "*"
 derivative = "*"
+fs2 = "*"
 futures = { version = "0.3.8" }
 glob = "*"
 hab = { path = "../hab" }
@@ -58,6 +59,7 @@ state = "*"
 structopt = { git = "https://github.com/habitat-sh/structopt.git" }
 tempfile = "*"
 termcolor = "*"
+thiserror = "*"
 toml = { version = "*", features = ["preserve_order"]}
 tokio = { version = "^0.2", features = ["full"] }
 tokio-rustls = "^0.14" # Tokio 0.2
@@ -67,6 +69,7 @@ valico = "*"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "*"
+procfs = "*"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 jemallocator = "*"

--- a/components/sup/src/error.rs
+++ b/components/sup/src/error.rs
@@ -1,7 +1,6 @@
 use crate::event;
 use futures::channel::oneshot;
 use habitat_core::{self,
-                   os::process::Pid,
                    package::{self,
                              Identifiable}};
 use std::{env,
@@ -60,6 +59,7 @@ pub enum Error {
     Io(io::Error),
     TaskJoin(JoinError),
     Launcher(habitat_launcher_client::Error),
+    LockFileError(crate::lock_file::Error),
     MissingRequiredBind(Vec<String>),
     MissingRequiredIdent,
     NameLookup(io::Error),
@@ -75,9 +75,6 @@ pub enum Error {
     PackageNotFound(package::PackageIdent),
     PackageNotRunnable(package::PackageIdent),
     Permissions(String),
-    ProcessLockCorrupt,
-    ProcessLocked(Pid),
-    ProcessLockIO(PathBuf, io::Error),
     RecvError(mpsc::RecvError),
     RecvTimeoutError(mpsc::RecvTimeoutError),
     ServiceDeserializationError(serde_json::Error),
@@ -148,6 +145,13 @@ impl fmt::Display for Error {
             Error::BadStartStyle(ref style) => format!("Unknown service start style '{}'", style),
             Error::BindTimeout(ref err) => format!("Timeout waiting to bind to {}", err),
             Error::LockPoisoned => "A mutex or read/write lock has failed.".to_string(),
+
+            // This '->' formatting is taken from the thiserror crate and how it
+            // presents source error information. Ultimately, it would be good
+            // to standardize on that, as it provides an easy way to generate
+            // informative error messages for users.
+            Error::LockFileError(e) => format!("Lock file error -> {}", e),
+
             Error::TestBootFail => "Simulated boot failure".to_string(),
             Error::ButterflyError(ref err) => format!("Butterfly error: {}", err),
             Error::CtlSecretIo(ref path, ref err) => {
@@ -209,18 +213,6 @@ impl fmt::Display for Error {
                 }
             }
             Error::PackageNotRunnable(ref pkg) => format!("Package is not runnable: {}", pkg),
-            Error::ProcessLockCorrupt => "Unable to decode contents of process lock".to_string(),
-            Error::ProcessLocked(ref pid) => {
-                format!("Unable to start Habitat Supervisor because another instance is already \
-                         running with the pid {}.",
-                        pid)
-            }
-            Error::ProcessLockIO(ref path, ref err) => {
-                format!("Unable to start Habitat Supervisor because we weren't able to write or \
-                         read to a process lock at {}, {}",
-                        path.display(),
-                        err)
-            }
             Error::RecvError(ref err) => err.to_string(),
             Error::RecvTimeoutError(ref err) => err.to_string(),
             Error::ServiceDeserializationError(ref e) => {
@@ -277,6 +269,7 @@ impl error::Error for Error {
         match self {
             // Nothing else implements source yet
             Error::EventError(ref e) => e.source(),
+            Error::LockFileError(ref e) => e.source(),
             _ => None,
         }
     }
@@ -388,4 +381,8 @@ impl From<event::Error> for Error {
 
 impl From<env::VarError> for Error {
     fn from(err: env::VarError) -> Error { Error::EnvVarError(err) }
+}
+
+impl From<crate::lock_file::Error> for Error {
+    fn from(src: crate::lock_file::Error) -> Self { Error::LockFileError(src) }
 }

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -62,6 +62,7 @@ pub mod error;
 pub mod event;
 pub mod http_gateway;
 pub mod logger; // must be pub if used in the `hab-sup` binary
+pub mod lock_file;
 pub mod manager;
 mod sys;
 #[cfg(test)]

--- a/components/sup/src/lib.rs
+++ b/components/sup/src/lib.rs
@@ -61,8 +61,8 @@ pub mod ctl_gateway;
 pub mod error;
 pub mod event;
 pub mod http_gateway;
-pub mod logger; // must be pub if used in the `hab-sup` binary
 pub mod lock_file;
+pub mod logger; // must be pub if used in the `hab-sup` binary
 pub mod manager;
 mod sys;
 #[cfg(test)]

--- a/components/sup/src/lock_file.rs
+++ b/components/sup/src/lock_file.rs
@@ -1,0 +1,544 @@
+//! Pidfile / Lockfile of the Launcher
+//!
+//! When the Supervisor starts, it is given the PID of the Launcher that started
+//! it. It then writes this PID to `/hab/sup/default/LOCK` (see `path()` below)
+//! to serve as a record of the currently-running process. This is used to
+//! discover which process to terminate (when running `hab sup term`), and also
+//! helps ensure that only one Supervisor process is running at a time.
+//!
+//! To maintain this exclusivity, we hold a shared file lock on the file for the
+//! duration of the Supervisor process. As a Supervisor starts, it attempts to
+//! acquire an _exclusive_ lock to that file. It will fail if a Supervisor is
+//! already running, because that process' shared lock will prevent acquisition
+//! of the exclusive lock.
+//!
+//! In an ideal world, this file would probably be written by the Launcher
+//! itself. However, the file currently resides in the `/hab/sup` directory
+//! hierarchy, which the Supervisor is responsible for maintaining.
+use crate::manager::PROC_LOCK_FILE;
+use fs2::FileExt;
+use habitat_core::{env,
+                   os::process::Pid};
+use habitat_launcher_client::LAUNCHER_PID_ENV;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+use std::{fmt,
+          fs::{File,
+               OpenOptions},
+          io::{Read,
+               Write},
+          path::PathBuf,
+          str::FromStr};
+
+type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("I/O error manipulating lock file '{}'", lock_file_path().display())]
+    IOError(#[source] std::io::Error),
+
+    #[error("Could not open lock file '{}'", lock_file_path().display())]
+    CannotOpen(#[source] std::io::Error),
+
+    // File lock-related error conditions
+    #[error("Could not acquire exclusive lock on lock file '{}'. Is another Supervisor process running?", lock_file_path().display())]
+    CannotAcquireExclusiveLock(#[source] std::io::Error),
+
+    /// This could happen on *nix because changing the lock type is actually a
+    /// non-atomic release-followed-by-acquisition. Thus, we call it out
+    /// specifically.
+    #[error("Could not downgrade to shared lock on '{}'. Possible race condidition with another process acquiring an exclusive lock.", lock_file_path().display())]
+    LockDowngrade(#[source] std::io::Error),
+
+    // Windows-only
+    #[error("Could not acquire shared lock on lock file '{}'", lock_file_path().display())]
+    CannotAcquireSharedLock(#[source] std::io::Error),
+
+    // Windows-only
+    #[error("Could not release exclusive lock on lock file '{}'", lock_file_path().display())]
+    CannotReleaseExclusiveLock(#[source] std::io::Error),
+
+    #[error("The lock file '{}' appears to be leftover from a prior Supervisor process", lock_file_path().display())]
+    StaleLockFile,
+
+    #[error("Contents of '{}' are corrupt", lock_file_path().display())]
+    CorruptLockFile(#[source] Box<Self>),
+
+    #[error("The '{}' environment variable must be present!", LAUNCHER_PID_ENV)]
+    InvalidEnvironment(#[source] std::env::VarError),
+
+    #[error("Could not parse '{0}' as a non-zero positive PID")]
+    PidParse(String),
+
+    #[error("PID in file '{}' ({0}) does not hold a lock on the file", lock_file_path().display())]
+    InvalidProcess(Pid),
+
+    #[cfg(target_os = "linux")]
+    #[error("Error encountered interacting with /proc filesystem")]
+    Proc(#[source] procfs::ProcError),
+}
+
+/// Returns the path of the lock file.
+///
+/// Also used directly in error implementations to provide context. Everything
+/// in this module deals with the same file, and manually wiring it through in
+/// `map_err()` calls is tedious.
+fn lock_file_path() -> PathBuf { habitat_sup_protocol::sup_root(None).join(PROC_LOCK_FILE) }
+
+///////////////////////////////////////////////////////////////////////
+
+/// For our purposes, a PID must address a single process (to wit: the
+/// Launcher). On both Linux and Windows, this means that the PID must be
+/// non-zero and positive. (Negative PIDs and PID 0 both have specific meaning
+/// and uses on Linux; while different on Windows, a positive PID is the
+/// important characteristic on both platforms.) As a result, we encapsulate
+/// this logic in one place in this type.
+///
+/// Note: For the purposes of this module, the only way to create a
+/// `PositiveNonZeroPid` is to parse it from a String.
+#[derive(Clone, Copy, Debug)]
+struct PositiveNonZeroPid(Pid);
+
+impl FromStr for PositiveNonZeroPid {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.parse() {
+            Ok(pid) => {
+                if pid <= 0 {
+                    Err(Error::PidParse(s.to_string()))
+                } else {
+                    Ok(PositiveNonZeroPid(pid))
+                }
+            }
+            Err(_e) => Err(Error::PidParse(s.to_string())),
+        }
+    }
+}
+
+impl From<PositiveNonZeroPid> for Pid {
+    fn from(src: PositiveNonZeroPid) -> Self { src.0 }
+}
+
+impl fmt::Display for PositiveNonZeroPid {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", self.0) }
+}
+
+///////////////////////////////////////////////////////////////////////
+
+/// A running Supervisor writes out the PID of its Launcher to a file, and then
+/// holds it open with a shared lock for the duration of the process in order to
+/// ensure only a single Supervisor process is running on a host at a time.
+pub struct LockFile {
+    /// An open file handle to the Launcher's lock file. The file will have a
+    /// shared file lock on it, allowing other processes to read it, but not to
+    /// write to it.
+    ///
+    /// An instance of `LockFile` can only be obtained if no other process has a
+    /// lock on the file. Thus, only one instance of a Supervisor may be running
+    /// on a host at a given time.
+    file: File,
+}
+
+impl LockFile {
+    /// Creates a lockfile, writes the Launcher's PID into it (after obtaining
+    /// an exclusive file lock on it), and holds the filehandle open for the
+    /// lifetime of this type instance. A shared file lock is held on the file,
+    /// preventing another instance from being created. Ultimately, this is used
+    /// to prevent multiple Supervisors from running on a host at the same time.
+    pub fn acquire() -> Result<Self> {
+        let pid: PositiveNonZeroPid =
+            env::var(LAUNCHER_PID_ENV).map_err(Error::InvalidEnvironment)?
+                                      .parse()?;
+
+        let path = lock_file_path();
+        Self::acquire_impl(path, pid)
+    }
+
+    /// Implementation of lock file creation / acquisition logic, separating it
+    /// from the logic of determining the file path and the PID to write to that
+    /// file.
+    fn acquire_impl(path: PathBuf, pid: PositiveNonZeroPid) -> Result<Self> {
+        // Create the file in a block simply to contain the mutability.
+        let file = {
+            // We use `create`, rather than `create_new`, because the lock file may
+            // exist already if it were not cleaned up properly. Whether or not we
+            // can get an exclusive lock on the file is the real test.
+            //
+            // We explicitly DO NOT truncate at first, because this open operation
+            // is not limited by file locks on Linux, which are advisory*. If we
+            // were to truncate, a second Supervisor could try to start up and
+            // obliterate the PID of the running Supervisor. As a result, we'll
+            // manually truncate later on, once we have obtained an exclusive lock.
+            //
+            // * Well, Linux file locks _can_ be mandatory, but it requries mounting
+            // filesystems in a particular way, setting specific permission bits
+            // on files, and comes with a lot of other caveats. To quote the Linux
+            // Programming Interface, Section 55.4, "the use of mandatory locks is
+            // best avoided".
+            let mut file = OpenOptions::new().write(true)
+                                              .create(true)
+                                              .truncate(false) // NEVER TRUE!
+                                              .open(&path)
+                                              .map_err(Error::CannotOpen)?;
+
+            // If we can't get an exclusive lock, then something else has locked the
+            // file. Assume it's another Supervisor and bail.
+            file.try_lock_exclusive()
+                .map_err(Error::CannotAcquireExclusiveLock)?;
+
+            // Now that we know we have an exclusive lock, we can truncate the file
+            // (in case it existed before!) and write the value of the new PID to
+            // it.
+            file.set_len(0).map_err(Error::IOError)?;
+            write!(&mut file, "{}", pid).map_err(Error::IOError)?;
+            file
+        };
+
+        // Now that we have written the PID to the file, we need to downgrade
+        // our exclusive lock to a shared one. This will ensure that other
+        // processes can read the file to find out the PID, but that no one else
+        // will be able to write the file. This also means that no other process
+        // (like another Supervisor) can create another instance of `LockFile`,
+        // because doing so requires an exclusive file lock.
+        //
+        // On Linux, only one lock can be held on a file by a process, so by
+        // taking out a shared lock, we effectively downgrade the lock, as
+        // desired.
+        //
+        // The relevant documentation from
+        // [flock(2)](https://linux.die.net/man/2/flock):
+        //
+        // > A process may only hold one type of lock (shared or exclusive) on a
+        // > file. Subsequent flock() calls on an already locked file will
+        // > convert an existing lock to the new lock mode.
+        //
+        // Note, however, that on Linux, this "downgrading" operation is
+        // unfortunately *NOT* atomic, so there is a small chance that another
+        // process attempting to acquire an exclusive lock on the file could
+        // succeed in this window (See `read_lock_file` below).
+        //
+        // On Windows, however, we can hold multiple locks; since we're using
+        // the same file handle, we're allowed to take out a shared lock _while
+        // still holding our exclusive lock_. To release the locks requires two
+        // `unlock` operations, the first of which releases the _exclusive_
+        // lock. Thus, we can downgrade to a shared lock by acquiring a shared
+        // lock and then unlocking once.
+        //
+        // See
+        // [LockFileEx](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex)
+        // for more.
+        file.try_lock_shared().map_err(|e| {
+                                   if cfg!(windows) {
+                                       Error::CannotAcquireSharedLock(e)
+                                   } else {
+                                       // Unix, Linux, et al.
+                                       Error::LockDowngrade(e)
+                                   }
+                               })?;
+        if cfg!(windows) {
+            file.unlock().map_err(Error::CannotReleaseExclusiveLock)?;
+        }
+
+        // Now, anyone should be able to read the file, but another Supervisor
+        // can't start up as long as we hold onto this file.
+        Ok(Self { file })
+    }
+}
+
+impl Drop for LockFile {
+    /// Though the operating system will drop file locks when the file handle is
+    /// closed, it is good to explicitly drop them when we can.
+    ///
+    /// In particular, this is [recommended][1] on Windows, where such automatic
+    /// lock dropping is dependent on currently available system resources.
+    ///
+    /// **WE DO NOT DELETE THE LOCK FILE!** Because opening a file and acquiring
+    /// a lock do not atomically occur together, there are sequences of events
+    /// that could play out that would lead to multiple Supervisors being able
+    /// to run simultaneously, thus defeating the entire purpose of the
+    /// `LockFile`, _but only if we delete the file_. (This arises because both
+    /// processes would acquire exclusive locks on filehandles that point to
+    /// different instances of the file in question. [See further
+    /// discussion.][2])
+    ///
+    /// (This shouldn't be taken to mean that users can't clean up the file on
+    /// their own, if they choose; it just means that we're not going to
+    /// intentionally undermine the exclusivity that the lock file is supposed
+    /// to provide. The rest of this implementation is robust against the
+    /// presence of stale lock files, so leaving them on disk poses no harm.)
+    ///
+    /// [1]:
+    /// https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-unlockfile#remarks
+    /// [2]: http://www.guido-flohr.net/never-delete-your-pid-file/
+    fn drop(&mut self) {
+        if let Err(e) = self.file.unlock() {
+            error!("Error unlocking '{}'; proceeding anyway: {:?}",
+                   lock_file_path().display(),
+                   e);
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////
+
+/// Reads the contents of the Supervisor / Launcher lock file to obtain the PID
+/// inside.
+///
+/// This is intended to support the `hab sup term` use case, where we use this
+/// function to determine which process to terminate.
+///
+/// If the following are true:
+///
+/// - the file is already locked by a process, and
+/// - the file contains a valid PID
+/// - the process identified by that PID holds the lock*
+///
+/// then it is assumed that the process identified by the PID is the Launcher.
+///
+/// * Currently, we only verify that the PID in the file holds the lock on the
+/// file on Linux, due to the advisory nature of locks on that platform. This
+/// is mainly done as a general sanity-preserving measure. While unlikely,
+/// this would prevent some misbehaving process from writing an arbitrary PID
+/// into the lockfile, thus targeting that process for termination on the next
+/// invocation of `hab sup term`.
+pub fn read_lock_file() -> Result<Pid> { read_lock_file_impl(lock_file_path()) }
+
+/// Implementation of main lockfile reading logic, separate from the specific
+/// file being read. Done to facilitate testing.
+fn read_lock_file_impl(path: PathBuf) -> Result<Pid> {
+    let mut file = OpenOptions::new().read(true)
+                                     .open(&path)
+                                     .map_err(Error::IOError)?;
+
+    // This function is expected to be called in a context where a Supervisor is
+    // already running. As a result, we should *NOT* be able to acquire an
+    // exclusive lock on the lock file. If we _can_, it means that whatever
+    // Supervisor process that originally had the lock has released it, so we
+    // should consider any contents of the file to be garbage.
+    if file.try_lock_exclusive().is_ok() {
+        return Err(Error::StaleLockFile);
+    }
+
+    let pid = {
+        let mut buffer = String::new();
+        file.read_to_string(&mut buffer).map_err(Error::IOError)?;
+        buffer.trim()
+              .parse()
+              .map_err(|e| Error::CorruptLockFile(Box::new(e)))?
+    };
+
+    if pid_holds_lock(pid, file)? {
+        Ok(pid.into())
+    } else {
+        Err(Error::InvalidProcess(pid.into()))
+    }
+}
+
+#[cfg(target_os = "linux")] // This implementation depends on /proc
+/// Returns `true` if the given PID holds a file lock on `file`.
+fn pid_holds_lock(pid: PositiveNonZeroPid, file: File) -> Result<bool> {
+    let file_inode = file.metadata().map_err(Error::IOError)?.ino();
+    let pid = pid.into();
+
+    // If we find an advisory read lock where the PID is the process
+    // that holds the lock on the file, then we're good!
+    Ok(procfs::locks().map_err(Error::Proc)?
+                      .into_iter()
+                      .find(|lock| {
+                          // LockMode and LockKind don't implement PartialEq :(
+                          lock.mode.as_str() == "ADVISORY"
+                          && lock.kind.as_str() == "READ"
+                          && lock.inode == file_inode
+                          && lock.pid == Some(pid)
+                      })
+                      .is_some())
+}
+
+#[cfg(windows)]
+/// Always returns `true` on Windows; the mandatory nature of file locking on
+/// Windows seems to remove the possibility of the file holding a non-Launcher
+/// PID
+fn pid_holds_lock(_pid: PositiveNonZeroPid, _file: File) -> Result<bool> { Ok(true) }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path,
+                    PathBuf};
+    use tempfile::{tempdir,
+                   TempDir};
+
+    /// Create a directory to put lock files in, and create a `PathBuf` that
+    /// points to a location in that directory.
+    ///
+    /// The dirctory is temporary, so hang on to it as long as you need it!
+    fn setup() -> (PathBuf, TempDir) {
+        let dir = tempdir().unwrap();
+        let lock_path = dir.path().join("LOCK");
+        (lock_path, dir)
+    }
+
+    /// Given a path and a string, write the string to the path and return an
+    /// open file handle.
+    fn write_to_file<P, C>(path: P, content: C) -> File
+        where P: AsRef<Path>,
+              C: AsRef<str>
+    {
+        let mut file = std::fs::OpenOptions::new().write(true)
+                                                  .create(true)
+                                                  .open(path.as_ref())
+                                                  .unwrap();
+        write!(file, "{}", content.as_ref()).unwrap();
+        file
+    }
+
+    fn assert_file_contents<P>(path: P, expected_content: &str)
+        where P: AsRef<Path>
+    {
+        assert!(path.as_ref().exists());
+        let actual_content = std::fs::read_to_string(path.as_ref()).unwrap();
+        assert_eq!(actual_content, expected_content);
+    }
+
+    #[test]
+    fn lock_acquisition_creates_file_if_necessary() {
+        let (lock_path, _dir) = setup();
+
+        assert!(!lock_path.exists());
+
+        let _lock_file =
+            LockFile::acquire_impl(lock_path.clone(), PositiveNonZeroPid(2112)).unwrap();
+
+        assert_file_contents(lock_path, "2112");
+    }
+
+    #[test]
+    fn lock_acquisition_overwrites_existing_file() {
+        let (lock_path, _dir) = setup();
+
+        // This is obviously some bogus content; it's just going to act as a
+        // sentinel, since a successful lock acquisition should overwrite it
+        // with correct information.
+        write_to_file(&lock_path, "Rusty McRustface");
+        assert_file_contents(&lock_path, "Rusty McRustface");
+
+        let _lock_file =
+            LockFile::acquire_impl(lock_path.clone(), PositiveNonZeroPid(2112)).unwrap();
+
+        assert_file_contents(&lock_path, "2112");
+    }
+
+    #[test]
+    #[should_panic(expected = "CannotAcquireExclusiveLock")]
+    fn cannot_have_more_than_one_instance() {
+        let (lock_path, _dir) = setup();
+
+        let lock_file_1 = LockFile::acquire_impl(lock_path.clone(), PositiveNonZeroPid(2112));
+        assert!(lock_file_1.is_ok());
+
+        // Acquiring a second lock will fail because the first one is still in
+        // effect.
+        LockFile::acquire_impl(lock_path, PositiveNonZeroPid(2113)).unwrap();
+    }
+
+    #[test]
+    fn dropping_releases_lock() {
+        let (lock_path, _dir) = setup();
+
+        let lock_file_1 =
+            LockFile::acquire_impl(lock_path.clone(), PositiveNonZeroPid(2112)).unwrap();
+
+        // We can't acquire the lock a second time, as tested above.
+        let lock_file_2 = LockFile::acquire_impl(lock_path.clone(), PositiveNonZeroPid(2112));
+        assert!(lock_file_2.is_err());
+
+        // However, once we get rid of the old lock, though, we can reacquire it.
+        drop(lock_file_1);
+        let lock_file_2 = LockFile::acquire_impl(lock_path.clone(), PositiveNonZeroPid(2112));
+        assert!(lock_file_2.is_ok());
+    }
+
+    #[test]
+    fn dropping_a_lock_does_not_delete_the_backing_file() {
+        let (lock_path, _dir) = setup();
+
+        assert!(!lock_path.exists());
+
+        let lock_file =
+            LockFile::acquire_impl(lock_path.clone(), PositiveNonZeroPid(2112)).unwrap();
+
+        // Just asserting that the file really gets created
+        assert_file_contents(&lock_path, "2112");
+
+        drop(lock_file);
+
+        // Dropping the lock MUST LEAVE THE FILE BEHIND (see the `Drop`
+        // implementation for more).
+        assert_file_contents(&lock_path, "2112");
+    }
+
+    #[test]
+    #[should_panic(expected = "StaleLockFile")]
+    fn cannot_read_a_stale_lockfile() {
+        let (lock_path, _dir) = setup();
+        write_to_file(&lock_path, "1234");
+
+        // There's no lock on the file, thus it is stale.
+        read_lock_file_impl(lock_path).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "CorruptLockFile")]
+    fn corrupt_lock_files_cannot_be_read() {
+        let (lock_path, _dir) = setup();
+
+        // Write some corrupt data to the file
+        let file = write_to_file(&lock_path, "LOLWUT");
+
+        // Lock the file so we can get past that check.
+        file.lock_shared().unwrap();
+
+        // Trying to get the PID out will fail now.
+        read_lock_file_impl(lock_path).unwrap();
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    #[should_panic(expected = "InvalidProcess")]
+    fn does_not_return_pid_if_it_does_not_lock_the_file() {
+        let (lock_path, _dir) = setup();
+
+        // We're going to put a PID that is NOT the PID of this testing process
+        // into the lock file, and then have this testing process take a lock to
+        // the file.
+        let this_pid = std::process::id() as Pid;
+        let pid_to_write = this_pid - 1; // just make it different
+
+        let file = write_to_file(&lock_path, pid_to_write.to_string());
+        file.lock_shared().unwrap();
+
+        // Because this testing process' PID isn't in the file, this check will
+        // fail.
+        read_lock_file_impl(lock_path).unwrap();
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn only_return_pid_if_lock_held_by_that_pid() {
+        let (lock_path, _dir) = setup();
+
+        // Put the PID of this testing process into the file, and then have this
+        // testing process take a lock on the file.
+        let this_pid = std::process::id() as Pid;
+        let file = write_to_file(&lock_path, this_pid.to_string());
+        file.lock_shared().unwrap();
+
+        // We should thus get our PID back because it's in the file, and this
+        // process holds the lock.
+        let result = read_lock_file_impl(lock_path);
+        assert!(result.is_ok());
+        let actual_pid = result.unwrap();
+        assert_eq!(this_pid, actual_pid);
+    }
+}

--- a/components/sup/src/lock_file.rs
+++ b/components/sup/src/lock_file.rs
@@ -106,10 +106,10 @@ impl FromStr for PositiveNonZeroPid {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s.parse() {
             Ok(pid) => {
-                if pid <= 0 {
-                    Err(Error::PidParse(s.to_string()))
-                } else {
+                if pid > 0 {
                     Ok(PositiveNonZeroPid(pid))
+                } else {
+                    Err(Error::PidParse(s.to_string()))
                 }
             }
             Err(_e) => Err(Error::PidParse(s.to_string())),

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -20,8 +20,7 @@ use crate::sup::{cli::cli,
                  logger,
                  manager::{Manager,
                            ManagerConfig,
-                           TLSConfig,
-                           PROC_LOCK_FILE},
+                           TLSConfig},
                  util};
 use configopt::ConfigOpt;
 use hab::cli::hab::{sup::SupRun,
@@ -226,13 +225,9 @@ async fn sub_run_rsr_imlw_mlw_gsw_smw_rhw_msw(sup_run: SupRun,
 async fn sub_sh() -> Result<()> { command::shell::sh().await }
 
 fn sub_term() -> Result<()> {
-    // We were generating a ManagerConfig from matches here, but 'hab sup term' takes no options.
-    // This means that we were implicitly getting the default ManagerConfig here. Instead of calling
-    // a function to generate said config, we can just explicitly pass the default.
-    let proc_lock_file = habitat_sup_protocol::sup_root(None).join(PROC_LOCK_FILE);
-    match Manager::term(&proc_lock_file) {
-        Err(Error::ProcessLockIO(..)) => {
-            println!("Supervisor not started.");
+    match Manager::term() {
+        Err(e @ Error::LockFileError(..)) => {
+            println!("Supervisor not terminated: {}", e);
             Ok(())
         }
         result => result,

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -620,16 +620,12 @@ impl Manager {
     /// implicitly assumed to be that of a running Launcher process. That
     /// PID is then told to terminate.
     pub fn term() -> Result<()> {
-        match crate::lock_file::read_lock_file() {
-            Ok(pid) => {
-                #[cfg(unix)]
-                process::signal(pid, Signal::TERM).map_err(|_| Error::SignalFailed)?;
-                #[cfg(windows)]
-                process::terminate(pid)?;
-                Ok(())
-            }
-            Err(err) => Err(err)?,
-        }
+        let pid = crate::lock_file::read_lock_file()?;
+        #[cfg(unix)]
+        process::signal(pid, Signal::TERM).map_err(|_| Error::SignalFailed)?;
+        #[cfg(windows)]
+        process::terminate(pid)?;
+        Ok(())
     }
 
     /// # Locking (see locking.md)

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -42,6 +42,7 @@ use crate::{census::{CensusRing,
             event::{self,
                     EventStreamConfig},
             http_gateway,
+            lock_file::LockFile,
             util::pkg,
             VERSION};
 use cpu_time::ProcessTime;
@@ -71,7 +72,6 @@ use habitat_core::{crypto::keys::{KeyCache,
                    env::Config,
                    fs::FS_ROOT_PATH,
                    os::process::{self,
-                                 Pid,
                                  ShutdownTimeout},
                    package::{Identifiable,
                              PackageIdent,
@@ -79,9 +79,7 @@ use habitat_core::{crypto::keys::{KeyCache,
                    service::ServiceGroup,
                    util::ToI64,
                    ChannelIdent};
-use habitat_launcher_client::{LauncherCli,
-                              LAUNCHER_LOCK_CLEAN_ENV,
-                              LAUNCHER_PID_ENV};
+use habitat_launcher_client::LauncherCli;
 use habitat_sup_protocol::{self};
 use parking_lot::{Mutex,
                   RwLock};
@@ -99,10 +97,8 @@ use std::{collections::{HashMap,
                         HashSet},
           ffi::OsStr,
           fs::{self,
-               File,
-               OpenOptions},
-          io::{BufRead,
-               BufReader,
+               File},
+          io::{BufReader,
                Read,
                Write},
           iter::{FromIterator,
@@ -592,6 +588,11 @@ pub struct Manager {
 
     feature_flags: FeatureFlag,
     pid_source:    ServicePidSource,
+
+    /// Open file handle to the Launcher's lock file. As long as we hold this,
+    /// we are the only Supervisor process that may run on this host. We don't
+    /// actually use this; we just keep it open.
+    _lock_file: LockFile,
 }
 
 impl Manager {
@@ -603,20 +604,23 @@ impl Manager {
     /// # Locking (see locking.md)
     /// * `MemberList::initial_members` (write)
     pub async fn load_imlw(cfg: ManagerConfig, launcher: LauncherCli) -> Result<Manager> {
+        let lock_file = LockFile::acquire()?;
+
         let state_path = cfg.sup_root();
         let fs_cfg = FsCfg::new(state_path);
         Self::create_state_path_dirs(&fs_cfg)?;
         Self::clean_dirty_state(&fs_cfg)?;
-        if env::var(LAUNCHER_LOCK_CLEAN_ENV).is_ok() {
-            release_process_lock(&fs_cfg);
-        }
-        obtain_process_lock(&fs_cfg)?;
-
-        Self::new_imlw(cfg, fs_cfg, launcher).await
+        Self::new_imlw(cfg, fs_cfg, lock_file, launcher).await
     }
 
-    pub fn term(proc_lock_file: &Path) -> Result<()> {
-        match read_process_lock(proc_lock_file) {
+    /// Terminate the locally-running Supervisor/Launcher (assuming it is
+    /// running, of course).
+    ///
+    /// If the lock file can be read successfully, the PID being returned is
+    /// implicitly assumed to be that of a running Launcher process. That
+    /// PID is then told to terminate.
+    pub fn term() -> Result<()> {
+        match crate::lock_file::read_lock_file() {
             Ok(pid) => {
                 #[cfg(unix)]
                 process::signal(pid, Signal::TERM).map_err(|_| Error::SignalFailed)?;
@@ -624,13 +628,17 @@ impl Manager {
                 process::terminate(pid)?;
                 Ok(())
             }
-            Err(err) => Err(err),
+            Err(err) => Err(err)?,
         }
     }
 
     /// # Locking (see locking.md)
     /// * `MemberList::initial_members` (write)
-    async fn new_imlw(cfg: ManagerConfig, fs_cfg: FsCfg, launcher: LauncherCli) -> Result<Manager> {
+    async fn new_imlw(cfg: ManagerConfig,
+                      fs_cfg: FsCfg,
+                      lock_file: LockFile,
+                      launcher: LauncherCli)
+                      -> Result<Manager> {
         debug!("new(cfg: {:?}, fs_cfg: {:?}", cfg, fs_cfg);
         outputln!("{} ({})", SUP_PKG_IDENT, *THIS_SUPERVISOR_IDENT);
         let cfg_static = cfg.clone();
@@ -718,7 +726,8 @@ impl Manager {
                      busy_services: Arc::default(),
                      services_need_reconciliation: ReconciliationFlag::new(false),
                      feature_flags: cfg.feature_flags,
-                     pid_source })
+                     pid_source,
+                     _lock_file: lock_file })
     }
 
     /// Load the initial Butterly Member which is used in initializing the Butterfly server. This
@@ -1253,7 +1262,6 @@ impl Manager {
             }
         }
 
-        release_process_lock(&self.fs_cfg);
         self.butterfly.persist_data_rsr_mlr();
 
         match shutdown_mode {
@@ -1818,85 +1826,6 @@ fn tls_config(config: &TLSConfig) -> Result<rustls::ServerConfig> {
     server_config.set_single_cert(cert_chain, key)?;
     server_config.ignore_client_order = true;
     Ok(server_config)
-}
-
-fn obtain_process_lock(fs_cfg: &FsCfg) -> Result<()> {
-    match write_process_lock(&fs_cfg.proc_lock_file) {
-        Ok(()) => Ok(()),
-        Err(_) => {
-            match read_process_lock(&fs_cfg.proc_lock_file) {
-                Ok(pid) => {
-                    if process::is_alive(pid) {
-                        return Err(Error::ProcessLocked(pid));
-                    }
-                    release_process_lock(&fs_cfg);
-                    write_process_lock(&fs_cfg.proc_lock_file)
-                }
-                Err(Error::ProcessLockCorrupt) => {
-                    release_process_lock(&fs_cfg);
-                    write_process_lock(&fs_cfg.proc_lock_file)
-                }
-                Err(err) => Err(err),
-            }
-        }
-    }
-}
-
-fn read_process_lock<T>(lock_path: T) -> Result<Pid>
-    where T: AsRef<Path>
-{
-    match File::open(lock_path.as_ref()) {
-        Ok(file) => {
-            let reader = BufReader::new(file);
-            match reader.lines().next() {
-                Some(Ok(line)) => {
-                    match line.parse::<Pid>() {
-                        Ok(pid) if pid == 0 => {
-                            error!(target: "pidfile_tracing", "Read PID of 0 from process lock file {}!",
-                                   lock_path.as_ref().display());
-                            // Treat this the same as a corrupt pid
-                            // file, because that's basically what it
-                            // is.
-                            //
-                            // This *should* be an impossible situation.
-                            Err(Error::ProcessLockCorrupt)
-                        }
-                        Ok(pid) => Ok(pid),
-                        Err(_) => Err(Error::ProcessLockCorrupt),
-                    }
-                }
-                _ => Err(Error::ProcessLockCorrupt),
-            }
-        }
-        Err(err) => Err(Error::ProcessLockIO(lock_path.as_ref().to_path_buf(), err)),
-    }
-}
-
-fn release_process_lock(fs_cfg: &FsCfg) {
-    if let Err(err) = fs::remove_file(&fs_cfg.proc_lock_file) {
-        debug!("Couldn't cleanup Supervisor process lock, {}", err);
-    }
-}
-
-fn write_process_lock<T>(lock_path: T) -> Result<()>
-    where T: AsRef<Path>
-{
-    match OpenOptions::new().write(true)
-                            .create_new(true)
-                            .open(lock_path.as_ref())
-    {
-        Ok(mut file) => {
-            let pid = match env::var(LAUNCHER_PID_ENV) {
-                Ok(pid) => pid.parse::<Pid>().expect("Unable to parse launcher pid"),
-                Err(_) => process::current_pid(),
-            };
-            match write!(&mut file, "{}", pid) {
-                Ok(()) => Ok(()),
-                Err(err) => Err(Error::ProcessLockIO(lock_path.as_ref().to_path_buf(), err)),
-            }
-        }
-        Err(err) => Err(Error::ProcessLockIO(lock_path.as_ref().to_path_buf(), err)),
-    }
 }
 
 #[cfg(windows)]

--- a/test/end-to-end/test_supervisor_lock_file_behavior.ps1
+++ b/test/end-to-end/test_supervisor_lock_file_behavior.ps1
@@ -1,0 +1,90 @@
+Add-Type -TypeDefinition (Get-Content "$PSScriptroot/../../.expeditor/scripts/end_to_end/SupervisorRunner.cs" | Out-String)
+
+# Download the dependencies first to prevent timing issues, long timeouts, etc.
+hab pkg install core/hab-sup --channel="${env:HAB_BLDR_CHANNEL}"
+hab pkg install core/hab-launcher --channel="${env:HAB_BLDR_CHANNEL}"
+
+# Write the given content to `/hab/sup/default/LOCK`
+function Write-Lockfile($content) {
+    # Ensure the directory path is present first
+    New-Item -ItemType Directory -Path "/hab/sup/default" -ErrorAction SilentlyContinue
+    # Write the contents to the lock file path
+    $content | Out-File "/hab/sup/default/LOCK"
+}
+
+# Find a PID that doesn't correspond to an actual process; if things go wrong,
+# we don't want to accidentally kill something important!
+function Select-BogusPID() {
+    $test_pid = 2112
+     while (Get-Process -Id $test_pid -ErrorAction SilentlyContinue) {
+        $test_pid += 1
+    }
+    $test_pid
+}
+
+# Spawn a separate process that sleeps for 100 seconds. We do this to simply
+# have a running process that we control.
+#
+# Returns the process information.
+function Start-SleeperProcess() {
+    Start-Process $PSHOME\pwsh -PassThru -ArgumentList "-Command  `"&{ Start-Sleep -Seconds 100 }`""
+}
+
+Describe "Supervisor LOCK file" {
+    Context "with stale LOCK file containing non-running PID" {
+        Write-Lockfile(Select-BogusPID)
+
+        It "Starts the Supervisor anyway" {
+            $supLog = New-SupervisorLogFile("with_stale_lock_file_containing_non_running_pid")
+            Start-Supervisor -Timeout 45 -LogFile $supLog
+        }
+
+        AfterEach {
+            Stop-Supervisor
+        }
+    }
+
+    Context "with stale LOCK file containing a running, non-Launcher PID" {
+        $sleeper = Start-SleeperProcess
+        Write-Lockfile($sleeper.Id)
+        AfterEach {
+            $sleeper | Stop-Process -ErrorAction SilentlyContinue
+            Stop-Supervisor
+        }
+
+        It "Starts the Supervisor anyway" {
+            $supLog = New-SupervisorLogFile("with_stale_lock_file_containing_a_running_non_launcher_pid")
+            Start-Supervisor -Timeout 45 -LogFile $supLog
+        }
+    }
+
+    Context "with a real, legitimate LOCK file" {
+        $legitimateLog = New-SupervisorLogFile("legitimate_supervisor")
+        Start-Supervisor -Timeout 45 -LogFile $legitimateLog
+
+        AfterEach {
+            Stop-Supervisor
+        }
+
+        It "Fails to start another Supervisor" {
+            $sup = New-Object SupervisorRunner
+            $supLog = New-SupervisorLogFile("with_a_real_legitimate_lock_file")
+            $supPid = $sup.Run($supLog)
+
+            $retries=0
+            $max_retries=5
+            $exitFailure = $false
+            while(!$supPid.HasExited) {
+                if($retries++ -gt $max_retries) {
+                    $exitFailure = $true
+                } else {
+                    Start-Sleep 1
+                }
+            }
+
+            $exitFailure | Should -Be $false
+            $supPid.ExitCode | Should -Not -Be 0
+            $supLog | Should -FileContentMatch "Is another Supervisor process running?"
+        }
+    }
+}

--- a/test/end-to-end/test_supervisor_lock_file_behavior.ps1
+++ b/test/end-to-end/test_supervisor_lock_file_behavior.ps1
@@ -16,7 +16,7 @@ function Write-Lockfile($content) {
 # we don't want to accidentally kill something important!
 function Select-BogusPID() {
     $test_pid = 2112
-     while (Get-Process -Id $test_pid -ErrorAction SilentlyContinue) {
+    while (Get-Process -Id $test_pid -ErrorAction SilentlyContinue) {
         $test_pid += 1
     }
     $test_pid


### PR DESCRIPTION
The Supervisor uses a `LOCK` file (`/hab/sup/default/LOCK`, to be
specific) to ensure that at most only one Supervisor process may run
on a host at a time. Most of the time, this works fine, but on
occasion it can backfire. In particular, if the Supervisor exits
without deleting the `LOCK` file (as with a sudden machine shutdown),
the Supervisor can sometimes refuse to come back up again, if the PID
contained in the `LOCK` file is an already-running process (which can
very plausibly happen in such a shutdown scenario).

Here, we refactor the behavior around the `LOCK` file to fix this
loophole. Now, rather than simply relying on the presence or absence
of the file, and whether or not the PID in the file refers to a
running process, we take advantage of file locking primitives. Now, a
running Supervisor holds a file handle to the `LOCK` file open for the
life of the Supervisor, as well as a shared file lock on the file. For
a Supervisor to start, however, it must be able to obtain an
_exclusive_ lock to the `LOCK` file. In this way, a running Supervisor
will prevent any other Supervisor from running. A "stale" `LOCK` file
won't be locked by any process, allowing a new Supervisor process to
start without a problem.

We hold a shared lock in order to allow other processses to read the
`LOCK` file, which is required for the current implementation of `hab
sup term`. Part of this change modifies the behavior of `hab sup term`
in order to be more robust. In particular, it will only terminate the
process whose PID is in the `LOCK` file if the file is currently locked.

The big behavioral change here that users may notice, however, is that
we no longer delete the `LOCK` file at all when the Supervisor shuts
down. Since file lock release and file deletion cannot together be an
atomic operation, attempting to do both operations (in either order)
allows race conditions that can lead to two Supervisors running at
once (which rather defeats the purpose of the file in the first
place!). Since stale `LOCK` files will no longer block a Supervisor
from coming up, though, we can eliminate these races by just not
deleting the file.

Fixes #7501

Signed-off-by: Christopher Maier <cmaier@chef.io>