### PR TITLE
[CI] Bump macOS builder timeouts

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -64,7 +64,7 @@ steps:
         macos:
           os-version: "10.13"
           inherit-environment-vars: true
-    timeout_in_minutes: 60
+    timeout_in_minutes: 80
     retry:
       automatic:
         limit: 10 # Addressing current Anka system timeouts due to oversubscription

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -969,7 +969,7 @@ steps:
         macos:
           os-version: "10.13"
           inherit-environment-vars: true
-    timeout_in_minutes: 60
+    timeout_in_minutes: 80
     retry:
       automatic:
         limit: 10 # Addressing current Anka system timeouts due to oversubscription


### PR DESCRIPTION
We seem to be having some (hopefully temporary) build timeouts in
CI. This increases our timeout by 20 minutes to try and deal with it.

Signed-off-by: Christopher Maier <cmaier@chef.io>