### PR TITLE
[CI] Unblock macOS workers again

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -59,6 +59,7 @@ steps:
     env:
       BUILD_PKG_TARGET: "x86_64-darwin"
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
     expeditor:
       executor:
         macos:

--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -65,7 +65,7 @@ steps:
         macos:
           os-version: "10.13"
           inherit-environment-vars: true
-    timeout_in_minutes: 80
+    timeout_in_minutes: 60
     retry:
       automatic:
         limit: 10 # Addressing current Anka system timeouts due to oversubscription

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -970,7 +970,7 @@ steps:
         macos:
           os-version: "10.13"
           inherit-environment-vars: true
-    timeout_in_minutes: 80
+    timeout_in_minutes: 60
     retry:
       automatic:
         limit: 10 # Addressing current Anka system timeouts due to oversubscription

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -964,6 +964,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       BUILD_PKG_TARGET: "x86_64-darwin"
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
     expeditor:
       executor:
         macos:


### PR DESCRIPTION
Recently we've been having problems with the macOS builds in CI. It appears to be a result of our no-longer-supported 10.13 builders trying to update Homebrew formulae to versions that don't work for the platform.

Here, we disable Homebrew's auto-update functionality, which allows things to run again. This also allows us to drop the stage timeouts back down to a more sane level.

The longer-term fix is to update to 10.14, but that will require updating our bootstrapping package. In the meantime, this should get things running again.