### PR TITLE
Update kernel2 evaluation VM to Centos 6.10

### DIFF
--- a/support/validation/x86_64-linux-kernel2/Vagrantfile
+++ b/support/validation/x86_64-linux-kernel2/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/centos-6.9"
+  config.vm.box = "bento/centos-6.10"
   config.vm.box_check_update = false
 
   config.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
6.9 was EOL'd in November.

Signed-off-by: Christopher Maier <cmaier@chef.io>