### PR TITLE
Update release announcement instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -283,7 +283,7 @@ for additional details.
 
 # Release Notification
 
-1. Create new posts in [Chef Release Announcements](https://discourse.chef.io) on the Chef Discourse.
+1. Create new posts in the [Chef Release Announcements](https://discourse.chef.io/c/chef-release) category on the [Chef Discourse server](https://discourse.chef.io).
 1. Tweet a release announcement from `@habitatsh`.
 
 # Release postmortem


### PR DESCRIPTION
Announcements should be posted to the "Chef Release Announcements"
category, with all the other products, rather than the "Chef Habitat"
category, which we have been doing (that is where all the content from
Habitat's old stand-alone Discourse instance ended up when it was
merged into the main Chef instance).

Signed-off-by: Christopher Maier <cmaier@chef.io>