### PR TITLE
remove some unnecessary aliases

### DIFF
--- a/.expeditor/scripts/release_habitat/shared.sh
+++ b/.expeditor/scripts/release_habitat/shared.sh
@@ -111,12 +111,20 @@ ident_has_target() {
 
 get_version_from_hart() {
     local hart="${1}"
-    ${hab_binary} pkg info --json "${hart}" | jq -r '.version'
+    # Note that we redirect stderr to /dev/null to compensate for
+    # a bug that emits deperecated alias warnings from `hab pkg info`
+    # we can stop doing this once the next release after 1.6.235 lands
+    # in stable
+    ${hab_binary} pkg info --json "${hart}" 2>/dev/null | jq -r '.version'
 }
 
 get_release_from_hart() {
     local hart="${1}"
-    ${hab_binary} pkg info --json "${hart}" | jq -r '.release'
+    # Note that we redirect stderr to /dev/null to compensate for
+    # a bug that emits deperecated alias warnings from `hab pkg info`
+    # we can stop doing this once the next release after 1.6.235 lands
+    # in stable
+    ${hab_binary} pkg info --json "${hart}" 2>/dev/null | jq -r '.release'
 }
 
 # This bit of magic strips off the Habitat header (first 6 lines) from

--- a/components/hab/src/cli/hab.rs
+++ b/components/hab/src/cli/hab.rs
@@ -155,7 +155,7 @@ pub enum Channel {
 #[structopt(no_version, aliases = &["j", "jo"], settings = &[AppSettings::ArgRequiredElseHelp, AppSettings::SubcommandRequiredElseHelp])]
 /// Commands relating to Habitat Builder jobs
 pub enum Job {
-    #[structopt(no_version, aliases = &["c", "ca", "can", "cance", "cancel"])]
+    #[structopt(no_version, aliases = &["c", "ca", "can", "cance"])]
     Cancel(JobCancel),
     #[structopt(no_version, aliases = &["d", "de", "dem", "demo", "demot"])]
     Demote(JobDemote),
@@ -311,9 +311,9 @@ pub enum Pkg {
     Channels(PkgChannels),
     #[structopt(no_version, aliases = &["v", "ve", "ver", "veri", "verif"])]
     Verify(PkgVerify),
-    #[structopt(no_version, aliases = &["hea", "head", "heade", "header"])]
+    #[structopt(no_version, aliases = &["hea", "head", "heade"])]
     Header(PkgHeader),
-    #[structopt(no_version, aliases = &["inf", "info"])]
+    #[structopt(no_version, aliases = &["inf"])]
     Info(PkgInfo),
     #[structopt(no_version, aliases = &["dep", "deps"])]
     Dependencies(PkgDependencies),


### PR DESCRIPTION
This fixes the bats tests in CI and removes superfluous and unnecessary alias deprecation warnings.

Signed-off-by: mwrock <matt@mattwrock.com>