### PR TITLE
Page metadata

### DIFF
--- a/components/docs-chef-io/Makefile
+++ b/components/docs-chef-io/Makefile
@@ -5,6 +5,7 @@ SHELL=bash
 preview_netlify: chef_web_docs
 	cp -R content/* chef-web-docs/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/content
 	cp -R static/* chef-web-docs/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/static
+	cp -R config.toml chef-web-docs/_vendor/github.com/habitat-sh/habitat/components/docs-chef-io/
 	pushd chef-web-docs && make assets; hugo --gc --minify --buildFuture && popd
 
 serve: chef_web_docs

--- a/components/docs-chef-io/archetypes/default.md
+++ b/components/docs-chef-io/archetypes/default.md
@@ -1,8 +1,8 @@
 +++
 title = "{{ .Name | humanize | title }}"
-
 date = {{ .Date }}
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -11,5 +11,3 @@ draft = false
     parent = "habitat"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/{{ .Name }}.md)

--- a/components/docs-chef-io/config.toml
+++ b/components/docs-chef-io/config.toml
@@ -1,0 +1,2 @@
+[params.habitat]
+gh_path = "https://github.com/habitat-sh/habitat/tree/master/components/docs-chef-io/content/"

--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -1,7 +1,9 @@
 +++
 title = "About Chef Habitat"
-
 aliases = ["/habitat/reference/", "/habitat/glossary/", "/habitat/diagrams/"]
+
+[cascade]
+  product = ["habitat"]
 
 [menu]
   [menu.habitat]

--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -1,6 +1,7 @@
 +++
 title = "About Chef Habitat"
 aliases = ["/habitat/reference/", "/habitat/glossary/", "/habitat/diagrams/"]
+gh_repo = "habitat"
 
 [cascade]
   product = ["habitat"]

--- a/components/docs-chef-io/content/habitat/about_services.md
+++ b/components/docs-chef-io/content/habitat/about_services.md
@@ -1,9 +1,9 @@
 +++
 title = "About Services"
 aliases = ["/habitat/using-habitat/"]
-
 date = 2020-10-26T18:37:38-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -12,8 +12,6 @@ draft = false
     parent = "habitat/services"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/about_services.md)
 
 A service is a Chef Habitat package running under a Chef Habitat Supervisor.
 

--- a/components/docs-chef-io/content/habitat/aks.md
+++ b/components/docs-chef-io/content/habitat/aks.md
@@ -1,6 +1,7 @@
 +++
 title = "Azure Container Services (AKS)"
 description = "Azure and Kubernetes K8"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Azure and Kubernetes K8"
     identifier = "habitat/containers/aks Chef Habitat Azure Kubernetes"
     parent = "habitat/containers"
     weight = 40
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/aks.md)
 
 [Azure Container Services (AKS)](https://azure.microsoft.com/services/container-service/)
 is a fully managed Kubernetes service running on the Azure platform.

--- a/components/docs-chef-io/content/habitat/application_lifecycle_hooks.md
+++ b/components/docs-chef-io/content/habitat/application_lifecycle_hooks.md
@@ -1,6 +1,7 @@
 +++
 title = "Application Lifecycle Hooks"
 description = "Control service runtime actions with application lifecycle hooks"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Control service runtime actions with application lifecycle hooks"
     parent = "habitat/reference"
 
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/application_lifecycle_hooks.md)
 
 Each plan can specify lifecycle event handlers, or hooks, to perform certain actions during a service's runtime. Each hook is a script with a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) defined at the top to specify the interpreter to be used. On Windows, Powershell Core is the only interpreter ever used.
 

--- a/components/docs-chef-io/content/habitat/application_rebuild_flow.md
+++ b/components/docs-chef-io/content/habitat/application_rebuild_flow.md
@@ -1,6 +1,7 @@
 +++
 title = "Application Rebuild Flow"
 description = "Application Rebuild Flow"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,7 +11,5 @@ description = "Application Rebuild Flow"
     weight = 40
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/application_rebuild_flow.md)
-
 ![Chef Habitat Application Rebuild Flow Diagram](/images/habitat/habitat-application-rebuild-flow.png)
 

--- a/components/docs-chef-io/content/habitat/architecture_overview.md
+++ b/components/docs-chef-io/content/habitat/architecture_overview.md
@@ -1,6 +1,7 @@
 +++
 title = "Chef Habitat Architecture Overview"
 description = "Chef Habitat Architecture Overview"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,7 +11,5 @@ description = "Chef Habitat Architecture Overview"
     weight = 10
 
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/architecture_overview.md)
 
 ![Chef Habitat Architecture Overview Diagram](/images/habitat/habitat-architecture-overview.png)

--- a/components/docs-chef-io/content/habitat/binary_wrapper.md
+++ b/components/docs-chef-io/content/habitat/binary_wrapper.md
@@ -1,6 +1,7 @@
 +++
 title = "Binary Wrapper Packages"
 description = "Tips and tricks for managing hardcoded library dependencies in binaries"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Tips and tricks for managing hardcoded library dependencies in bi
     parent = "habitat/plans"
 
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/binary_wrapper.md)
 
 While Chef Habitat provides the best behavior for applications that can be compiled from source into the Chef Habitat ecosystem, it can also bring the same management benefits to applications distributed in binary-only form.
 

--- a/components/docs-chef-io/content/habitat/build_helpers.md
+++ b/components/docs-chef-io/content/habitat/build_helpers.md
@@ -1,6 +1,7 @@
 +++
 title = "Build Helpers"
 description = "Define package buildtime actions with helper functions."
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Define package buildtime actions with helper functions."
     parent = "habitat/reference"
 
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/build_helpers.md)
 
 The following helper functions can be useful in your plan to help you build your package correctly. `Attach()` specifically is to help with debugging - the other helper functions are to help you in building your package.
 

--- a/components/docs-chef-io/content/habitat/build_phase_callbacks.md
+++ b/components/docs-chef-io/content/habitat/build_phase_callbacks.md
@@ -1,16 +1,14 @@
 +++
 title = "Build Phase Callbacks"
 description = "Override default buildtime behavior with build phase callbacks"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
     title = "Build Phase Callbacks"
     identifier = "habitat/reference/build-phase-callbacks"
     parent = "habitat/reference"
-
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/build_phase_callbacks.md)
 
 When defining your plan, you can override the default behavior of Chef Habitat in each build phase through a callback. To define a callback, simply create a shell function of the same name in your plan file and then write your script. If you do not want to use the default callback behavior, you must override the callback and `return 0` in the function definition or simply provide no implementation in a `plan.ps1`.
 

--- a/components/docs-chef-io/content/habitat/builder_account.md
+++ b/components/docs-chef-io/content/habitat/builder_account.md
@@ -1,6 +1,7 @@
 +++
 title = "Create an Account"
 description = "Setting up Chef Habitat Builder in the Cloud and on your workstation"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,8 +11,6 @@ description = "Setting up Chef Habitat Builder in the Cloud and on your workstat
     weight = 20
 
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/builder_account.md)
 
 Whether you are looking to leverage the SaaS or on-prem version of Chef Habitat Builder, you will need to create an account on the SaaS version of Chef Habitat Builder. After you have then downloaded the version, you will then sync the two accounts.
 

--- a/components/docs-chef-io/content/habitat/builder_api.md
+++ b/components/docs-chef-io/content/habitat/builder_api.md
@@ -1,8 +1,6 @@
 +++
 title = "Chef Habitat Builder API"
-
 aliases = ["/habitat/api/builder-api/"]
-
 date = 2019-03-06T17:25:30-07:00
 draft = false
 layout = "data-api"
@@ -16,5 +14,3 @@ return_page = "/habitat/"
     parent = "habitat/reference/api"
     identifier = "habitat/reference/api Builder API"
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/builder_api.md)

--- a/components/docs-chef-io/content/habitat/builder_architecture.md
+++ b/components/docs-chef-io/content/habitat/builder_architecture.md
@@ -1,6 +1,7 @@
 +++
 title = "Chef Habitat Builder Architecture"
 description = "Chef Habitat Builder Architecture"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,6 +11,4 @@ description = "Chef Habitat Builder Architecture"
     weight = 90
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/builder_architecture.md)
-
 ![Chef Habitat Builder Architecture Diagram](/images/habitat/habitat-builder-architecture.png)

--- a/components/docs-chef-io/content/habitat/builder_origin_packages.md
+++ b/components/docs-chef-io/content/habitat/builder_origin_packages.md
@@ -1,6 +1,7 @@
 +++
 title = "Upload and Promote Packages"
 description = "Upload and Promote packages on Chef Habitat Builder enables automated package rebuilds and increases collaboration"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,10 +9,7 @@ description = "Upload and Promote packages on Chef Habitat Builder enables autom
     identifier = "habitat/builder/origin-packages"
     parent = "habitat/builder"
     weight = 40
-
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/builder_origin_packages.md)
 
 While you can build and run Chef Habitat packages without sharing them on [Chef Habitat Builder](https://bldr.habitat.sh), uploading them there enables greater collaboration and automated package rebuilds as underlying dependencies or your connected GitHub repository are updated.
 

--- a/components/docs-chef-io/content/habitat/builder_origins.md
+++ b/components/docs-chef-io/content/habitat/builder_origins.md
@@ -1,6 +1,7 @@
 +++
 title = "Create an Origin on Builder"
 description = "Create an Origin on Builder"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,10 +9,7 @@ description = "Create an Origin on Builder"
     identifier = "habitat/builder/origins"
     parent = "habitat/builder"
     weight = 30
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/builder_origins.md)
-
 An origin is a place on Chef Habitat Builder where you can store, share, and build packages. It is a unique namespace within Chef Habitat Builder, and while you can delete or transfer an origin, you can't rename an origin after it is created. One example of an origin is the "core" origin, which is the set of foundational packages managed and versioned by the core Chef Habitat maintainers.
 
 You can join existing origins by invitation and you can create your own origins.

--- a/components/docs-chef-io/content/habitat/builder_overview.md
+++ b/components/docs-chef-io/content/habitat/builder_overview.md
@@ -1,7 +1,7 @@
 +++
 title = "About Chef Habitat Builder"
 description = "Chef Habitat Builder is Chef's Application Delivery Enterprise hub"
-
+gh_repo = "habitat"
 aliases = ["/habitat/using-builder/"]
 
 [menu]
@@ -12,7 +12,6 @@ aliases = ["/habitat/using-builder/"]
     weight = 10
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/builder_overview.md)
 
 Chef Habitat Builder acts as the core of Chef's Application Delivery Enterprise hub. Chef Habitat Builder was first launched as a cloud service and as the repository of all available plan templates built by Chef and the supporting community. Due to the fact that the application source code is stored alongside the build package, many users expressed a preference for storing packages and running Chef Habitat Builder on-prem. As a result, Chef Habitat Builder can be consumed either as a cloud based or on-premises solution. Plan files are stored in the Chef Habitat Builder SaaS, where they can be viewed and accessed by the Chef Habitat community and then shared with the on-premises version of the builder where they can then be copied and maintained locally.
 

--- a/components/docs-chef-io/content/habitat/builder_profile.md
+++ b/components/docs-chef-io/content/habitat/builder_profile.md
@@ -3,6 +3,7 @@ title = "Builder Profile"
 
 date = 2020-10-12T16:08:26-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -11,7 +12,6 @@ draft = false
     parent = "habitat/builder"
     weight = 30
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/builder_profile.md)
 
 Whether you are looking to leverage the SaaS or on-prem version of Chef Habitat Builder, you will need to create an account on the SaaS version of Chef Habitat Builder. After you have then downloaded the version, you will then sync the two accounts.
 

--- a/components/docs-chef-io/content/habitat/certs_custom.md
+++ b/components/docs-chef-io/content/habitat/certs_custom.md
@@ -1,15 +1,14 @@
 +++
 title = "Custom Certificates"
 description = "Handling custom (CA) certificates"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
     title = "Custom Certificates"
     identifier = "habitat/reference/certs-custom Custom Certs"
     parent = "habitat/reference"
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/certs_custom.md)
 
 Many enterprise environments use custom certificates (for example, self-signed). For example, an on-premises Chef Habitat Builder Depot might have a self-signed SSL certificate.
 

--- a/components/docs-chef-io/content/habitat/config_templates.md
+++ b/components/docs-chef-io/content/habitat/config_templates.md
@@ -1,6 +1,7 @@
 +++
 title = "Configuration Templates"
 description = "Using templates and tags to tune your application configuration files"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,7 +10,6 @@ description = "Using templates and tags to tune your application configuration f
     parent = "habitat/reference"
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/config_templates.md)
 
 Chef Habitat allows you to templatize your application's native configuration files using [Handlebars](https://handlebarsjs.com/) syntax. The following sections describe how to create tunable configuration elements for your application or service.
 

--- a/components/docs-chef-io/content/habitat/configuration_management.md
+++ b/components/docs-chef-io/content/habitat/configuration_management.md
@@ -2,6 +2,7 @@
 title = "Configuration Management"
 description = "Configuration Management"
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,8 +11,6 @@ draft = false
     parent = "habitat/reference"
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/configuration_management.md)
-
 **Examples: [Ansible](https://www.ansible.com/), [Chef](https://www.chef.io/chef/), [Puppet](https://puppet.com/), and [Salt](https://saltstack.com/)**
 
 Configuration management tools allow you write configuration files, using a declarative language to manage a server. These tools focus on building working servers by installing and configuring system settings, system libraries, and application libraries before an application is installed on the server. Chef Habitat focuses on the application first instead of the server. Chef Habitat builds and packages your application's entire binary toolchain, including the system libraries, application libraries, and runtime dependencies necessary for your application to function. As a result, Chef Habitat can replace many use-cases that configuration management tools perform related to installing system binaries, application dependent libraries, or templating configuration files.

--- a/components/docs-chef-io/content/habitat/container_orchestration.md
+++ b/components/docs-chef-io/content/habitat/container_orchestration.md
@@ -1,6 +1,7 @@
 +++
 title = "Container Orchestration"
 description = "Container Orchestration with Chef Habitat"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,6 +11,5 @@ description = "Container Orchestration with Chef Habitat"
     weight = 20
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/container_orchestration.md)
 
 Chef Habitat packages may be exported with the Supervisor directly into a [variety of container formats]({{< relref "pkg_exports" >}}), but frequently the container is running in a container orchestrator such as Kubernetes or Mesos. Container orchestrators provide scheduling and resource allocation, ensuring workloads are running and available. Containerized Chef Habitat packages can run within these runtimes, managing the applications while the runtimes handle the environment surrounding the application (ie. compute, networking, security).

--- a/components/docs-chef-io/content/habitat/containers.md
+++ b/components/docs-chef-io/content/habitat/containers.md
@@ -1,6 +1,7 @@
 +++
 title = "Chef Habitat and Containers"
 description = "Chef Habitat and Containers"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,8 +11,6 @@ description = "Chef Habitat and Containers"
     weight = 10
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/containers.md)
-
 **Examples: [Docker](https://www.docker.com/) and [CoreOS](https://coreos.com/)**
 
 Containers enable you to build an immutable snapshot of your runtime environment, including your operating system, system libraries, application libraries, and application. The container is built with a CLI tool, and then pushed to a container-specific artifact repository, known as a container registry. Chef Habitat is not a container format and exports your application to the container format of your choice.

--- a/components/docs-chef-io/content/habitat/continuous_integration.md
+++ b/components/docs-chef-io/content/habitat/continuous_integration.md
@@ -1,6 +1,7 @@
 +++
 title = "Chef Habitat and Continuous Integration"
 description = "Chef Habitat and Continuous Integration"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,8 +11,6 @@ description = "Chef Habitat and Continuous Integration"
     weight = 200
 
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/continuous_integration.md)
 
 **Examples: [Jenkins](https://jenkins.io/), [TravisCI](https://travis-ci.org/), and [Drone](https://drone.io/)**
 

--- a/components/docs-chef-io/content/habitat/dependency_update_flow.md
+++ b/components/docs-chef-io/content/habitat/dependency_update_flow.md
@@ -1,6 +1,7 @@
 +++
 title = "Dependency Update Flow"
 description = "Dependency Update Flow"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,7 +11,5 @@ description = "Dependency Update Flow"
     weight = 30
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/dependency_update_flow.md)
-
 ![Chef Habitat Dependency Update Flow Diagram](/images/habitat/habitat-dependency-update-flow.png)
 

--- a/components/docs-chef-io/content/habitat/docker_automated_flow.md
+++ b/components/docs-chef-io/content/habitat/docker_automated_flow.md
@@ -1,6 +1,7 @@
 +++
 title = "Automate Docker Container Publishing Flow"
 description = "Automate Docker Container Publishing Flow"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,7 +11,5 @@ description = "Automate Docker Container Publishing Flow"
     weight = 60
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/docker_automated_flow.md)
-
 ![Chef Habitat Automated Docker Container Publishing Flow Diagram](/images/habitat/habitat-automated-docker-container-publishing-flow.png)
 

--- a/components/docs-chef-io/content/habitat/docker_flow.md
+++ b/components/docs-chef-io/content/habitat/docker_flow.md
@@ -1,6 +1,7 @@
 +++
 title = "Docker Container Publishing Flow"
 description = "Docker Container Publishing Flow"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,6 +11,4 @@ description = "Docker Container Publishing Flow"
     weight = 50
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/docker_flow.md)
-
 ![Chef Habitat Initial Docker Container Publishing Flow Diagram](/images/habitat/habitat-initial-docker-container-publishing-flow.png)

--- a/components/docs-chef-io/content/habitat/ecs.md
+++ b/components/docs-chef-io/content/habitat/ecs.md
@@ -1,6 +1,7 @@
 +++
 title = "Amazon ECS"
 description = "Amazon ECS registry service and Chef Habitat"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,7 +11,6 @@ description = "Amazon ECS registry service and Chef Habitat"
     weight = 50
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/ecs.md)
 
 Amazon Web Services provides a container management service called [EC2 Container Service (ECS)](https://aws.amazon.com/ecs/). ECS provides a Docker registry, container hosting and tooling to make deploying Docker-based containers fairly straightforward. ECS will schedule and deploy  your Docker containers within a Task while Chef Habitat manages the applications.
 

--- a/components/docs-chef-io/content/habitat/environment_variables.md
+++ b/components/docs-chef-io/content/habitat/environment_variables.md
@@ -1,6 +1,7 @@
 +++
 title = "Environment Variables"
 description = "Customize and configure your Chef Habitat Studio and Supervisor environments"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,7 +10,6 @@ description = "Customize and configure your Chef Habitat Studio and Supervisor e
     parent = "habitat/reference"
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/environment_variables.md)
 
 This is a list of all environment variables that can be used to modify the operation of the Chef Habitat Studio and Supervisor.
 

--- a/components/docs-chef-io/content/habitat/gcr.md
+++ b/components/docs-chef-io/content/habitat/gcr.md
@@ -1,6 +1,7 @@
 +++
 title = "Google Container Registry (GCR)"
 description = "Google Container Registry"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,8 +11,6 @@ description = "Google Container Registry"
     weight = 60
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/gcr.md)
-
 [Google Container Registry](https://cloud.google.com/container-registry/) is a private Docker repository that
 works with popular continuous delivery systems. It runs on GCP to provide consistent uptime on an infrastructure
 protected by Google's security. The registry service hosts your private images in Cloud Storage under your GCP project.

--- a/components/docs-chef-io/content/habitat/hab_setup.md
+++ b/components/docs-chef-io/content/habitat/hab_setup.md
@@ -1,6 +1,7 @@
 +++
 title = "Configure the Chef Habitat CLI"
 description = "Set up the Chef Habitat CLI"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Set up the Chef Habitat CLI"
     identifier = "habitat/get_started/hab-setup Install Chef Habitat"
     parent = "habitat/get_started"
     weight = 20
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/hab_setup.md)
 
 Once Chef Habitat has been installed, the `hab` CLI makes it easy to get your workstation configured by guiding through the setup process. To set up your workstation, run `hab cli setup` and follow the instructions.
 

--- a/components/docs-chef-io/content/habitat/install_faq.md
+++ b/components/docs-chef-io/content/habitat/install_faq.md
@@ -2,6 +2,7 @@
 title = "Download and Install FAQ"
 description = "Download and Install FAQ"
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,9 +10,7 @@ draft = false
     identifier = "habitat/get_started/install-faq Install Frequently Asked Questions FAQ"
     parent = "habitat/get_started"
     weight = 30
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/install_faq.md)
 
 This section tracks some questions that are frequently encountered when downloading and installing the `hab` binary.
 

--- a/components/docs-chef-io/content/habitat/install_habitat.md
+++ b/components/docs-chef-io/content/habitat/install_habitat.md
@@ -1,8 +1,8 @@
 +++
 title = "Get Chef Habitat"
 description = "Install the Chef Habitat CLI and configure your workstation for Chef Habitat development"
-
 aliases = ["/habitat/install-habitat/"]
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,9 +10,7 @@ aliases = ["/habitat/install-habitat/"]
     identifier = "habitat/get_started/installing-packages"
     parent = "habitat/get_started"
     weight = 10
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/install_habitat.md)
 
 Below you'll find installation instructions for each platform and their requirements. The Chef Habitat CLI is currently supported on Linux, Mac, and Windows.
 

--- a/components/docs-chef-io/content/habitat/keys.md
+++ b/components/docs-chef-io/content/habitat/keys.md
@@ -1,6 +1,7 @@
 +++
 title = "Keys"
 description = "Chef Habitat Security"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,7 +10,6 @@ description = "Chef Habitat Security"
     parent = "habitat/reference"
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/keys.md)
 
 Chef Habitat has strong cryptography built into Chef Habitat Builder, the Supervisor, and the `hab` CLI commands. This means there are several different kinds of keys.
 

--- a/components/docs-chef-io/content/habitat/kubernetes.md
+++ b/components/docs-chef-io/content/habitat/kubernetes.md
@@ -1,6 +1,7 @@
 +++
 title = "Kubernetes"
 description = "Export your Chef Habitat package as a Docker and run it on a Kubernetes Pod"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Export your Chef Habitat package as a Docker and run it on a Kube
     identifier = "habitat/containers/kubernetes Kubernetes Development Patterns"
     parent = "habitat/containers"
     weight = 30
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/kubernetes.md)
 
 [Kubernetes](https://kubernetes.io/) is an open source container cluster manager that is available as a stand-alone platform or embedded in several distributed platforms including [Google's Container Engine](https://cloud.google.com/container-engine/), [AWS Elastic Kubernetes Service](https://aws.amazon.com/eks/), [Azure Kubernetes Service](https://azure.microsoft.com/services/kubernetes-service/), and [Red Hat OpenShift](https://openshift.com/).
 Chef Habitat and Kubernetes are complementary. While Kubernetes provides a platform for deployment, scaling, and operations of application containers across clusters of hosts, Chef Habitat manages the build pipeline and lifecycle of those application containers.

--- a/components/docs-chef-io/content/habitat/mesos_dcos.md
+++ b/components/docs-chef-io/content/habitat/mesos_dcos.md
@@ -1,6 +1,7 @@
 +++
 title = "Apache Mesos and DC/OS"
 description = "Apache Mesos and DC/OS"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,10 +9,7 @@ description = "Apache Mesos and DC/OS"
     identifier = "habitat/containers/mesos-dcos"
     parent = "habitat/containers"
     weight = 70
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/mesos_dcos.md)
-
 [Apache Mesos](https://mesos.apache.org/) is an open source distributed systems kernel and the distributed systems kernel for [Mesosphere's DC/OS](https://dcos.io) distributed platform.
 
 ## Mesos Containerizers

--- a/components/docs-chef-io/content/habitat/monitor_services.md
+++ b/components/docs-chef-io/content/habitat/monitor_services.md
@@ -1,6 +1,7 @@
 +++
 title = "Monitoring Services"
 description = "Monitoring Services"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Monitoring Services"
     parent = "habitat/services"
     weight = 70
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/monitor_services.md)
 
 Use the HTTP API to monitor services. When a service starts, the [Supervisor]({{< relref "sup_networks">}}) exposes the status of its services' health and other information through an HTTP API endpoint. This information can be useful in monitoring service health, results of leader elections, and so on.
 

--- a/components/docs-chef-io/content/habitat/on_prem_flow.md
+++ b/components/docs-chef-io/content/habitat/on_prem_flow.md
@@ -1,6 +1,7 @@
 +++
 title = "Chef Habitat Builder on-prem Flow"
 description = "Chef Habitat Builder on-prem Flow"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,7 +11,6 @@ description = "Chef Habitat Builder on-prem Flow"
     weight = 100
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/on_prem_flow.md)
 
 ![Chef Habitat On-premises Builder Depot Flow Diagram](/images/habitat/habitat-on-premises-builder-depot-flow.png)
 

--- a/components/docs-chef-io/content/habitat/origin_keys.md
+++ b/components/docs-chef-io/content/habitat/origin_keys.md
@@ -3,6 +3,7 @@ title = "Origin Keys"
 
 date = 2020-10-12T13:59:46-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -11,7 +12,6 @@ draft = false
     parent = "habitat/origins"
     weight = 20
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/origin_keys.md)
 
 Prerequisites:
 

--- a/components/docs-chef-io/content/habitat/origin_rbac.md
+++ b/components/docs-chef-io/content/habitat/origin_rbac.md
@@ -1,8 +1,8 @@
 +++
 title = "Origin Membership & RBAC"
-
 date = 2020-10-12T13:53:50-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -11,8 +11,6 @@ draft = false
     parent = "habitat/origins"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/origin_rbac.md)
 
 Prerequisites:
 

--- a/components/docs-chef-io/content/habitat/origin_settings.md
+++ b/components/docs-chef-io/content/habitat/origin_settings.md
@@ -1,8 +1,8 @@
 +++
 title = "Origin Settings"
-
 date = 2020-10-12T14:02:01-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -11,8 +11,6 @@ draft = false
     parent = "habitat/origins"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/origin_settings.md)
 
 The _Origin Settings_ tab contains:
 

--- a/components/docs-chef-io/content/habitat/origins.md
+++ b/components/docs-chef-io/content/habitat/origins.md
@@ -1,6 +1,7 @@
 +++
 title = "Create an Origin"
 description = "Create an Origin on Chef Habitat Builder"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Create an Origin on Chef Habitat Builder"
     identifier = "habitat/origins Create an Origin"
     parent = "habitat/origins"
     weight = 10
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/origins.md)
 
 An origin is a space on Chef Habitat Builder where you can store, share, and build packages. It is a unique namespace within Chef Habitat Builder, and while you can delete or transfer an origin, you can't rename an origin after it is created. One example of an origin is the "core" origin, which is the set of foundational packages managed and versioned by the core Chef Habitat maintainers.
 

--- a/components/docs-chef-io/content/habitat/package_build_flow.md
+++ b/components/docs-chef-io/content/habitat/package_build_flow.md
@@ -1,6 +1,7 @@
 +++
 title = "Initial Package Build Flow"
 description = "Initial Package Build Flow"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Initial Package Build Flow"
     identifier = "habitat/diagrams/package-build-flow"
     parent = "habitat/diagrams"
     weight = 20
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/package_build_flow.md)
 
 ![Chef Habitat Initial Package Build Flow Diagram](/images/habitat/habitat-initial-package-build-flow.png)
 

--- a/components/docs-chef-io/content/habitat/package_contents.md
+++ b/components/docs-chef-io/content/habitat/package_contents.md
@@ -1,15 +1,14 @@
 +++
 title = "Package Contents"
 description = "Package Contents"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
     title = "Package Contents"
     identifier = "habitat/reference/package-contents"
     parent = "habitat/reference"
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/package_contents.md)
 
 During the build process, the hab-plan-build script creates several files that specify dependency, build, and configuration information. When packages are unpacked (extracted) and installed during the initialization phase of a Chef Habitat service, these files define what those packages need to run.
 

--- a/components/docs-chef-io/content/habitat/pattern_library.md
+++ b/components/docs-chef-io/content/habitat/pattern_library.md
@@ -1,7 +1,7 @@
 +++
 title = "Pattern Library Introduction"
 description = "Example code for Chef Habitat plans and more!"
-
+gh_repo = "habitat"
 aliases = ["/habitat/pattern-library/"]
 
 [menu]
@@ -9,10 +9,7 @@ aliases = ["/habitat/pattern-library/"]
     title = "Pattern Library"
     identifier = "habitat/pattern_library"
     parent = "habitat/reference"
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/pattern_library.md)
-
 ## Chef Habitat Pattern Library
 
 The Chef Habitat Pattern Library is an evolving set of design patterns to use as starting-points. These patterns are examples and require configuration and customization for your unique situation.

--- a/components/docs-chef-io/content/habitat/pkg_binds.md
+++ b/components/docs-chef-io/content/habitat/pkg_binds.md
@@ -1,6 +1,7 @@
 +++
 title = "Runtime Binds"
 description = "Define runtime binds in your plan file"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Define runtime binds in your plan file"
     parent = "habitat/packages"
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/pkg_binds.md)
-
 *Runtime binding* in Chef Habitat refers to the ability for one service group to connect to another, forming a producer-consumer relationship where the consumer service can use the producer service's current configuration in order to configure itself at runtime. When the producer's configuration change, the consumer is notified and can reconfigure itself as needed.
 
 With runtime binding, a consumer service can use a "binding name" of their choosing in their configuration and lifecycle hook templates as a kind of handle to refer to the configuration values they need from the producer service. This name isn't inherently tied to any particular package or service group name. Instead, when the service is run, users associate a service group with that binding name, which gives Chef Habitat all the information it needs to wire the producer and consumer services together.

--- a/components/docs-chef-io/content/habitat/pkg_build.md
+++ b/components/docs-chef-io/content/habitat/pkg_build.md
@@ -1,6 +1,7 @@
 +++
 title = "Building Packages"
 description = "Building Packages in the Studio"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Building Packages in the Studio"
     identifier = "habitat/packages/pkg-build Build your Package"
     parent = "habitat/packages"
     weight = 10
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/pkg_build.md)
 
 When you have finished creating your plan and call `build` in Chef Habitat Studio, the build script does following steps:
 

--- a/components/docs-chef-io/content/habitat/pkg_exports.md
+++ b/components/docs-chef-io/content/habitat/pkg_exports.md
@@ -1,6 +1,7 @@
 +++
 title = "Exporting Packages"
 description = "Export Chef Habitat packages to Docker, Kubernetes, Helm, Mesos, DC/OS, Cloud Foundry, or as a tarball "
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Export Chef Habitat packages to Docker, Kubernetes, Helm, Mesos, 
     identifier = "habitat/packages/pkg-exports Export Chef Habitat Packages"
     parent = "habitat/packages"
     weight = 40
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/pkg_exports.md)
 
 Chef Habitat Artifacts--`.hart` files--can be exported in a number of different formats depending on what you need and where you need it. This is powerful because you can use the same immutable Chef Habitat artifact by exporting it into a format that you need for a specific job.
 

--- a/components/docs-chef-io/content/habitat/pkg_ids.md
+++ b/components/docs-chef-io/content/habitat/pkg_ids.md
@@ -1,15 +1,14 @@
 +++
 title = "Package Identifiers"
 description = "How to call a package in Chef Habitat Builder, Studio, and plan files"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
     title = "Package Identifiers"
     identifier = "habitat/reference/pkg_ids Package ID"
     parent = "habitat/reference"
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/pkg_ids.md)
 
 A Chef Habitat artifact the binary distribution for a given package built with Chef Habitat. A Chef Habitat artifact is a signed tarball with a `.hart` file extension. Chef Habitat artifacts are composed of a software library or application, the configuration information for that software, and lifecycle hooks. They are created from a the plan file, a `plan.sh` on Linux systems or a `plan.ps1` on Windows systems, and are built with Chef Habitat tools. Chef Habitat artifacts can be exported to a specific format, such as when creating a Docker image.
 

--- a/components/docs-chef-io/content/habitat/pkg_promote.md
+++ b/components/docs-chef-io/content/habitat/pkg_promote.md
@@ -1,6 +1,7 @@
 +++
 title = "Promote Packages"
 description = "Best practices for promoting packages in channels for building and testing code changes as part of continuous deployment with channel tags"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,7 +11,6 @@ description = "Best practices for promoting packages in channels for building an
     weight = 20
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/pkg_promote.md)
 
 Continuous deployment is a well-known software development practice of building and testing code changes in preparation for a release to a production environment.
 

--- a/components/docs-chef-io/content/habitat/plan_contents.md
+++ b/components/docs-chef-io/content/habitat/plan_contents.md
@@ -1,6 +1,7 @@
 +++
 title = "Plan Contents"
 description = "Best Practices for Plans"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Best Practices for Plans"
     identifier = "habitat/plans/plan-contents"
     parent = "habitat/plans"
     weight = 30
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/plan_contents.md)
 
 The following is a best practice guide to how to write a production quality plan. These best practices are reflected in the requirements for a user to contribute a plan to the Chef Habitat [Core Plans](https://github.com/habitat-sh/core-plans/).
 

--- a/components/docs-chef-io/content/habitat/plan_helpers.md
+++ b/components/docs-chef-io/content/habitat/plan_helpers.md
@@ -1,15 +1,14 @@
 +++
 title = "Configuration Helpers"
 description = "Define dynamic plan configuration settings with plan helpers"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
     title = "Plan Configuration Helpers"
     identifier = "habitat/reference/plan-helpers Plan Tuning"
     parent = "habitat/reference"
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/plan_helpers.md)
 
 Chef Habitat allows you to use [Handlebars-based](http://handlebarsjs.com) tuneables in your plan, and you can also use both built-in Handlebars helpers and Chef Habitat-specific helpers in defining your configuration logic.
 

--- a/components/docs-chef-io/content/habitat/plan_quickstart.md
+++ b/components/docs-chef-io/content/habitat/plan_quickstart.md
@@ -1,6 +1,7 @@
 +++
 title = "Plan Quickstart"
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ draft = false
     parent = "habitat/plans"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/plan_quickstart.md)
 
 All plans must have a `plan.sh` or `plan.ps1` at the root of the plan context. They may even include both if a package is targeting both Windows and Linux platforms. This file will be used by the `hab-plan-build` command to build your package. To create a plan, do the following:
 

--- a/components/docs-chef-io/content/habitat/plan_settings.md
+++ b/components/docs-chef-io/content/habitat/plan_settings.md
@@ -1,6 +1,7 @@
 +++
 title = "Plan Settings"
 description = "Define basic metadata about your artifact with plan settings"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,7 +9,6 @@ description = "Define basic metadata about your artifact with plan settings"
     identifier = "habitat/reference/plan-settings"
     parent = "habitat/reference"
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/plan_settings.md)
 
 Habitat reserves some names for internal use. You can set all of these values in your plan and use them as variables in your Habitat code.
 

--- a/components/docs-chef-io/content/habitat/plan_variables.md
+++ b/components/docs-chef-io/content/habitat/plan_variables.md
@@ -1,15 +1,14 @@
 +++
 title = "Plan Variables"
 description = "Set package, service, and cache paths, compiler options, install location and context with plan variables"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
     title = "Plan Variables"
     identifier = "habitat/reference/plan-variables"
     parent = "habitat/reference"
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/plan_variables.md)
 
 The following variables can be used in your plans to help get binaries and libraries
 to build and install in the correct locations in your package. The values for the

--- a/components/docs-chef-io/content/habitat/plan_writing.md
+++ b/components/docs-chef-io/content/habitat/plan_writing.md
@@ -1,8 +1,8 @@
 +++
 title = "Writing Plans"
 description = "Documentation for writing Chef Habitat Plan files including configuration templates, binds, and exporting"
-
 aliases = ["/habitat/developing-packages/"]
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,10 +10,7 @@ aliases = ["/habitat/developing-packages/"]
     identifier = "habitat/plans/plan-writing Chef Habitat Plan Overview"
     parent = "habitat/plans"
     weight = 10
-
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/plan_writing.md)
 
 In Chef Habitat the unit of automation is the application itself. This chapter includes content related specifically to the process and workflow of developing a plan that will instruct Chef Habitat in how to build, deploy, and manage your application.
 

--- a/components/docs-chef-io/content/habitat/promote_packages.md
+++ b/components/docs-chef-io/content/habitat/promote_packages.md
@@ -1,6 +1,7 @@
 +++
 title = "Promote Packages Through Channels"
 description = "Promote Packages Through Channels"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,8 +9,6 @@ description = "Promote Packages Through Channels"
     identifier = "habitat/diagrams/promote-packages"
     parent = "habitat/diagrams"
     weight = 70
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/promote_packages.md)
 
 ![Chef Habitat Promote Packages Through Channels Diagram](/images/habitat/habitat-promote-packages-through-channels.png)

--- a/components/docs-chef-io/content/habitat/running_habitat_linux_containers.md
+++ b/components/docs-chef-io/content/habitat/running_habitat_linux_containers.md
@@ -1,6 +1,7 @@
 +++
 title = "Running Chef Habitat Linux Containers"
 description = "Running Chef Habitat Linux Containers"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Running Chef Habitat Linux Containers"
     identifier = "habitat/containers/running-habitat-linux-containers Linux Containers"
     parent = "habitat/containers"
     weight = 70
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/running_habitat_linux_containers.md)
 
 When you run `hab pkg export docker`, you'll get a Docker container that provides a few things. First, a minimal Linux OS filesystem is provided, with just enough configuration (e.g., `/etc/passwd`, `/etc/resolv.conf`, etc.) to run. Second, the contents of the exported Chef Habitat package, along with its complete dependency tree, as well as a complete Chef Habitat Supervisor installation, are provided, unpacked, in the `/hab/pkgs` directory. Finally, an entry-point script that will start the Supervisor, running the exported Chef Habitat package, is provided, allowing the container itself to behave as though it were the Supervisor.
 

--- a/components/docs-chef-io/content/habitat/running_habitat_servers.md
+++ b/components/docs-chef-io/content/habitat/running_habitat_servers.md
@@ -1,6 +1,7 @@
 +++
 title = "Running Chef Habitat on Servers (Linux and Windows)"
 description = "Running Chef Habitat on Servers (Linux and Windows)"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Running Chef Habitat on Servers (Linux and Windows)"
     identifier = "habitat/supervisors/running-habitat-servers"
     parent = "habitat/supervisors"
     weight = 25
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/running_habitat_servers.md)
 
 Chef Habitat can be run on bare metal servers, as well as virtual machines. Currently, Chef Habitat can run on Linux and Windows platforms, and in all cases, running a Supervisor boils down to running `hab sup run`. How that happens depends on which platform you choose to use.
 

--- a/components/docs-chef-io/content/habitat/running_habitat_windows_containers.md
+++ b/components/docs-chef-io/content/habitat/running_habitat_windows_containers.md
@@ -1,6 +1,7 @@
 +++
 title = "Running Chef Habitat Windows Containers"
 description = "Running Chef Habitat Windows Containers"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Running Chef Habitat Windows Containers"
     identifier = "habitat/containers/running-habitat-windows-containers Windows Containers"
     parent = "habitat/containers"
     weight = 80
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/running_habitat_windows_containers.md)
 
 Exported Windows images use `microsoft/windowsservercore` as their base. This is the equivalent of a minimal Windows Server 2016 Core install. So you should not expect non default features and roles to be enabled such as IIS or Active Directory. Consider using an `init` hook to install any features needed by your Chef Habitat service.
 

--- a/components/docs-chef-io/content/habitat/runtime_binding.md
+++ b/components/docs-chef-io/content/habitat/runtime_binding.md
@@ -1,6 +1,7 @@
 +++
 title = "Runtime Services Group Binding"
 description = "Runtime Services Group Binding"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,6 +11,5 @@ description = "Runtime Services Group Binding"
     weight = 80
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/runtime_binding.md)
 
 ![Chef Habitat Runtime Services Group Binding Diagram](/images/habitat/habitat-runtime-service-group-binding.png)

--- a/components/docs-chef-io/content/habitat/scaffolding.md
+++ b/components/docs-chef-io/content/habitat/scaffolding.md
@@ -1,6 +1,7 @@
 +++
 title = "Scaffolding"
 description = "Scaffolding"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,9 +9,7 @@ description = "Scaffolding"
     identifier = "habitat/plans/scaffolding"
     parent = "habitat/plans"
     weight = 95
-
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/scaffolding.md)
 
 Chef Habitat scaffoldings are standardized plans for automated building and running your application. Each scaffolding is tuned to the way your application was built, which allows it to create the appropriate [application lifecycle hooks]({{< relref "application_lifecycle_hooks" >}}) and add in the correct runtime dependencies when building the package for your application. Scaffoldings also provide some default health check hooks where appropriate to ensure your application is functioning reliably. Customized Scaffolding can be created to facilitate re-usability of common patterns in your organization for developing, building, and running your applications.
 

--- a/components/docs-chef-io/content/habitat/service_group_configuration.md
+++ b/components/docs-chef-io/content/habitat/service_group_configuration.md
@@ -1,6 +1,7 @@
 +++
 title = "Service Group Configuration"
 description = "Update Services with File Uploads"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Update Services with File Uploads"
     parent = "habitat/services"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/service_group_configuration.md)
 
 ## Uploading Files to a Service Group
 

--- a/components/docs-chef-io/content/habitat/service_group_topologies.md
+++ b/components/docs-chef-io/content/habitat/service_group_topologies.md
@@ -1,6 +1,7 @@
 +++
 title = "Service Group Topologies"
 description = "Service Group Topologies"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Service Group Topologies"
     parent = "habitat/services"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/service_group_topologies.md)
 
 A topology describes the intended relationship between peers within a service group.
 Two topologies ship with Chef Habitat by default: **standalone** and **leader-follower**.

--- a/components/docs-chef-io/content/habitat/service_group_updates.md
+++ b/components/docs-chef-io/content/habitat/service_group_updates.md
@@ -1,6 +1,7 @@
 +++
 title = "Service Group Updates"
 description = "Update service groups with supervisor configuration"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Update service groups with supervisor configuration"
     parent = "habitat/services"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/service_group_updates.md)
 
 The Chef Habitat Supervisor can be configured to leverage an optional _update strategy_,
 which describes how the Supervisor and its peers within a service group should

--- a/components/docs-chef-io/content/habitat/service_groups.md
+++ b/components/docs-chef-io/content/habitat/service_groups.md
@@ -1,6 +1,7 @@
 +++
 title = "Service Groups"
 description = "Service Groups"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Service Groups"
     parent = "habitat/services"
     weight = 20
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/service_groups.md)
 
 A service group is a logical grouping of services with the same package and topology type connected together across a Supervisor network.
 They are created to share configuration and file updates among the services within those groups and can be segmented based on workflow or deployment needs (QA, Production, and so on).

--- a/components/docs-chef-io/content/habitat/service_updates.md
+++ b/components/docs-chef-io/content/habitat/service_updates.md
@@ -1,6 +1,7 @@
 +++
 title = "Single Service Updates"
 description = "Update single services at runtime or dynamically"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,10 +9,7 @@ description = "Update single services at runtime or dynamically"
     identifier = "habitat/services/service-updates Individual Configuration Updates"
     parent = "habitat/services"
     weight = 40
-
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/service_updates.md)
 
 One of the key features of Chef Habitat is the ability to define an immutable package with a default configuration which can then be updated dynamically at runtime. You can update service configuration on two levels: individual services (for testing purposes), or a service group.
 

--- a/components/docs-chef-io/content/habitat/studio.md
+++ b/components/docs-chef-io/content/habitat/studio.md
@@ -1,8 +1,8 @@
 +++
-
 title = "Studio"
 description = "About the Chef Habitat Studio"
 draft = true
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -12,8 +12,6 @@ draft = true
     weight = 80
 
 +++
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/studio.md)
-
 ## Customizing Studio
 
 When you enter a Studio, Chef Habitat will attempt to locate `/src/.studiorc` and

--- a/components/docs-chef-io/content/habitat/sup.md
+++ b/components/docs-chef-io/content/habitat/sup.md
@@ -1,10 +1,9 @@
 +++
 title = "Chef Habitat Supervisor"
-
 aliases = ["/habitat/best-practices/"]
-
 date = 2020-10-26T18:47:18-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -13,8 +12,6 @@ draft = false
     parent = "habitat/supervisors"
     weight = 10
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup.md)
 
 The Supervisor is a process manager that has two primary responsibilities. First, it starts and monitors child services defined in the plan it is running. Second, it receives and acts upon information from the other Supervisors to which it is connected. A service will be reconfigured through application lifecycle hooks if its configuration has changed.
 

--- a/components/docs-chef-io/content/habitat/sup_config.md
+++ b/components/docs-chef-io/content/habitat/sup_config.md
@@ -3,6 +3,7 @@ title = "Supervisor Configuration File"
 description = "Service Change Rollback"
 date = 2020-10-26T17:32:36-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -11,8 +12,6 @@ draft = false
     parent = "habitat/supervisors"
     weight = 85
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_config.md)
 
 Generate a Supervisor configuration file and use it to set any of the 40+ Supervisor configuration settings instead of configuring them on the command line.
 

--- a/components/docs-chef-io/content/habitat/sup_crypto.md
+++ b/components/docs-chef-io/content/habitat/sup_crypto.md
@@ -1,8 +1,8 @@
 +++
 title = "Supervisor Cryptography"
-
 date = 2020-10-26T19:09:25-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -11,8 +11,6 @@ draft = false
     parent = "habitat/supervisors"
     weight = 70
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_crypto.md)
 
 ## Leader Election
 

--- a/components/docs-chef-io/content/habitat/sup_design.md
+++ b/components/docs-chef-io/content/habitat/sup_design.md
@@ -1,10 +1,9 @@
 +++
 title = "Supervisor Design"
-
 aliases = ["/habitat/internals/"]
-
 date = 2020-10-26T18:55:28-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -13,8 +12,6 @@ draft = false
     parent = "habitat/supervisors"
     weight = 30
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_design.md)
 
 This section will dive into the implementation details of important Chef Habitat components. These topics are for advanced users. It is not necessary to learn these concepts in order to use Chef Habitat.
 

--- a/components/docs-chef-io/content/habitat/sup_elections.md
+++ b/components/docs-chef-io/content/habitat/sup_elections.md
@@ -1,8 +1,8 @@
 +++
 title = "Leader Elections"
-
 date = 2020-10-26T19:05:42-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -11,8 +11,6 @@ draft = false
     parent = "habitat/supervisors"
     weight = 40
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_elections.md)
 
 This document provides developer documentation on how the Chef Habitat system becomes self-sustaining. It is built upon the work from the [Linux from Scratch](http://www.linuxfromscratch.org/lfs/) project.
 

--- a/components/docs-chef-io/content/habitat/sup_guide.md
+++ b/components/docs-chef-io/content/habitat/sup_guide.md
@@ -1,8 +1,8 @@
 +++
 title = "Supervisor Guide"
-
 date = 2020-10-26T19:11:45-07:00
 draft = false
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -11,8 +11,6 @@ draft = false
     parent = "habitat/supervisors"
     weight = 120
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_guide.md)
 
 This document provides developer documentation on how the Chef Habitat system becomes self-sustaining. It is built upon the work from the [Linux from Scratch](http://www.linuxfromscratch.org/lfs/) project.
 

--- a/components/docs-chef-io/content/habitat/sup_launcher.md
+++ b/components/docs-chef-io/content/habitat/sup_launcher.md
@@ -1,6 +1,7 @@
 +++
 title = "Launcher"
 description = "Launcher"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,8 +11,6 @@ description = "Launcher"
     weight = 110
 
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_launcher.md)
 
 Chef Habitat's Launcher is a sidecar process for the Supervisor which provides a mechanism for launching processes on behalf of the Supervisor. It is the entry point for running the Supervisor and is the Supervisor for the Supervisor. Whereas the Supervisor is able to automatically update itself, the Launcher is currently released a bit differently, by design; it should be rare that the Launcher ever needs to change.
 

--- a/components/docs-chef-io/content/habitat/sup_log_configuration.md
+++ b/components/docs-chef-io/content/habitat/sup_log_configuration.md
@@ -1,6 +1,7 @@
 +++
 title = "Supervisor Log Configuration"
 description = "Dynamically adjust the logging configuration of a running Supervisor"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,10 +9,7 @@ description = "Dynamically adjust the logging configuration of a running Supervi
     identifier = "habitat/supervisors/sup-log-configuration"
     parent = "habitat/supervisors"
     weight = 90
-
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_log_configuration.md)
 
 With the 0.83.0 release of the Chef Habitat Supervisor, it is possible to have greater control over logging output, including the ability to dynamically adjust the logging configuration of a running Supervisor. There are two main ways of configuring logging, each of which has their own strengths and weaknesses: using environment variables, and using a configuration file.
 

--- a/components/docs-chef-io/content/habitat/sup_log_keys.md
+++ b/components/docs-chef-io/content/habitat/sup_log_keys.md
@@ -1,16 +1,14 @@
 +++
 title = "Supervisor Log Codes"
 description = "Supervisor log code key reference"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
     title = "Supervisor Log Codes"
     identifier = "habitat/reference/sup-log-key"
     parent = "habitat/reference"
-
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_log_keys.md)
 
 When running services with the Chef Habitat Supervisor you'll see log output similar to this:
 

--- a/components/docs-chef-io/content/habitat/sup_networks.md
+++ b/components/docs-chef-io/content/habitat/sup_networks.md
@@ -1,6 +1,7 @@
 +++
 title = "Supervisor Networks"
 description = "Robust Supervisor Networks"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,10 +9,7 @@ description = "Robust Supervisor Networks"
     identifier = "habitat/supervisors/sup-networks Supervisor Networks Explained"
     parent = "habitat/supervisors"
     weight = 60
-
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_networks.md)
 
 Chef Habitat Supervisors communicate amongst each other using "gossip" algorithms, which underpin the membership management, leadership election, and service discovery mechanics of Chef Habitat. By simply being "peered" to a single existing Supervisor, a new Supervisor will gradually come to know about _all_ the Supervisors in a Chef Habitat network. The gossip algorithm has built-in features to counteract brief network splits, but care must be taken to set up a robust Supervisor network.
 

--- a/components/docs-chef-io/content/habitat/sup_pkg_config.md
+++ b/components/docs-chef-io/content/habitat/sup_pkg_config.md
@@ -1,6 +1,7 @@
 +++
 title = "Supervisor Configuration"
 description = "Configure the Supervisor for faster package development"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Configure the Supervisor for faster package development"
     parent = "habitat/supervisors"
     weight = 100
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_pkg_config.md)
 
 To assist in creating new packages, or modifying existing ones, the Supervisor has an option to allow you to use the configuration directly from a specific directory, rather than the one it includes in the compiled artifact. This can significantly shorten the cycle time when working on configuration and application lifecycle hooks.
 

--- a/components/docs-chef-io/content/habitat/sup_remote_control.md
+++ b/components/docs-chef-io/content/habitat/sup_remote_control.md
@@ -1,6 +1,7 @@
 +++
 title = "Control Supervisors Remotely"
 description = "Controlling Supervisors Remotely"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -8,10 +9,7 @@ description = "Controlling Supervisors Remotely"
     identifier = "habitat/supervisors/sup-remote-control"
     parent = "habitat/supervisors"
     weight = 120
-
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_remote_control.md)
 
 Since the 0.56.0 Supervisor release, it is possible to command and control one or more Supervisors from a remote location. Before this, the only way to interact with a Supervisor was by taking action directly on machine on which the Supervisor was running. While that is still an option (and is indeed the default behavior), remote command and control opens up more possibilities for using and managing Chef Habitat.
 

--- a/components/docs-chef-io/content/habitat/sup_rings.md
+++ b/components/docs-chef-io/content/habitat/sup_rings.md
@@ -1,6 +1,7 @@
 +++
 title = "Setting Up a Ring"
 description = "Setting Up a Ring"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -9,8 +10,6 @@ description = "Setting Up a Ring"
     parent = "habitat/supervisors"
     weight = 50
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_rings.md)
 
 ## Bastion Ring / Permanent Peers
 

--- a/components/docs-chef-io/content/habitat/sup_run.md
+++ b/components/docs-chef-io/content/habitat/sup_run.md
@@ -1,6 +1,7 @@
 +++
 title = "Running Chef Habitat Supervisors"
 description = "Running Chef Habitat Packages"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,8 +11,6 @@ description = "Running Chef Habitat Packages"
     weight = 20
 
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_run.md)
 
 Use Chef Habitat packages to start services under the Chef Habitat Supervisor. At runtime, you can join services together in a service group running the same topology, send configuration updates to that group, and more. You can also export the Supervisor together with the package to an external immutable format, such as a Docker container or a virtual machine.
 

--- a/components/docs-chef-io/content/habitat/sup_secure.md
+++ b/components/docs-chef-io/content/habitat/sup_secure.md
@@ -1,6 +1,7 @@
 +++
 title = "Securing Supervisor Networks"
 description = "Securing Supervisor Networks"
+gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
@@ -10,8 +11,6 @@ description = "Securing Supervisor Networks"
     weight = 80
 
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/sup_secure.md)
 
 By default, a Supervisor runs unsecured. It communicates with other Supervisors in cleartext, and it allows any user to apply new configuration without authentication. While this is beneficial for demonstrating the concepts of Chef Habitat, users will want to provide external security on production deployments of Chef Habitat Supervisor networks.
 

--- a/components/docs-chef-io/content/habitat/supervisor_api.md
+++ b/components/docs-chef-io/content/habitat/supervisor_api.md
@@ -1,8 +1,6 @@
 +++
 title = "Chef Habitat Supervisor API"
-
 aliases = ["/habitat/api/supervisor/"]
-
 date = 2019-03-06T17:25:30-07:00
 draft = false
 layout = "data-api"
@@ -16,6 +14,4 @@ return_page = "/habitat/"
     parent = "habitat/reference/api"
     identifier = "habitat/reference/api Supervisor API"
 +++
-
-[\[edit on GitHub\]](https://github.com/habitat-sh/habitat/blob/master/components/docs-chef-io/content/habitat/supervisor_api.md)
 


### PR DESCRIPTION
This does two things:
- update how Edit on GitHub links are generated
- add product metadata to each page in docs.chef.io/habitat/

We've got a partial in chef-web-docs that handles Edit on GitHub links now, we just need specify which repo each page comes from.

We can use the [cascade parameter](https://gohugo.io/content-management/front-matter#front-matter-cascade) key in `content/habitat/_index.md` to add a product value to every page docs.chef.io/habitat/ so we can facet search results by that product

### Issues

chef/chef-web-docs#2878
chef/chef-web-docs#2775
