### PR TITLE
Revert "Bump actix-rt from 1.1.1 to 2.1.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log 0.4.11",
- "tokio 0.2.23",
+ "tokio",
  "tokio-util 0.2.0",
 ]
 
@@ -27,7 +27,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project 0.4.23",
- "tokio 0.2.23",
+ "tokio",
  "tokio-util 0.3.1",
 ]
 
@@ -38,7 +38,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "177837a10863f15ba8d3ae3ec12fac1099099529ed20083a27fdfe247381d0dc"
 dependencies = [
  "actix-codec 0.3.0",
- "actix-rt 1.1.1",
+ "actix-rt",
  "actix-service",
  "actix-utils 2.0.0",
  "derive_more",
@@ -61,7 +61,7 @@ checksum = "452299e87817ae5673910e53c243484ca38be3828db819b6011736fc6982e874"
 dependencies = [
  "actix-codec 0.3.0",
  "actix-connect",
- "actix-rt 1.1.1",
+ "actix-rt",
  "actix-service",
  "actix-threadpool",
  "actix-tls",
@@ -110,16 +110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbcb2b608f0accc2f5bcf3dd872194ce13d94ee45b571487035864cf966b04ef"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "actix-router"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,24 +128,13 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
 dependencies = [
- "actix-macros 0.1.2",
+ "actix-macros",
  "actix-threadpool",
  "copyless",
  "futures-channel",
  "futures-util",
  "smallvec",
- "tokio 0.2.23",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4e57bc1a3915e71526d128baf4323700bd1580bc676239e2298a4c5b001f18"
-dependencies = [
- "actix-macros 0.2.0",
- "futures-core",
- "tokio 1.2.0",
+ "tokio",
 ]
 
 [[package]]
@@ -165,7 +144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d74b464215a473c973a2d7d03a69cc10f4ce1f4b38a7659c5193dc5c675630"
 dependencies = [
  "actix-codec 0.2.0",
- "actix-rt 1.1.1",
+ "actix-rt",
  "actix-service",
  "actix-utils 1.0.6",
  "futures-channel",
@@ -194,8 +173,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47239ca38799ab74ee6a8a94d1ce857014b2ac36f242f70f3f75a66f691e791c"
 dependencies = [
- "actix-macros 0.1.2",
- "actix-rt 1.1.1",
+ "actix-macros",
+ "actix-rt",
  "actix-server",
  "actix-service",
  "log 0.4.11",
@@ -240,7 +219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf8f5631bf01adec2267808f00e228b761c60c0584cc9fa0b5364f41d147f4e"
 dependencies = [
  "actix-codec 0.2.0",
- "actix-rt 1.1.1",
+ "actix-rt",
  "actix-service",
  "bitflags",
  "bytes",
@@ -258,7 +237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9022dec56632d1d7979e59af14f0597a28a830a9c1c7fec8b2327eb9f16b5a"
 dependencies = [
  "actix-codec 0.3.0",
- "actix-rt 1.1.1",
+ "actix-rt",
  "actix-service",
  "bitflags",
  "bytes",
@@ -279,9 +258,9 @@ checksum = "e641d4a172e7faa0862241a20ff4f1f5ab0ab7c279f00c2d4587b77483477b86"
 dependencies = [
  "actix-codec 0.3.0",
  "actix-http",
- "actix-macros 0.1.2",
+ "actix-macros",
  "actix-router",
- "actix-rt 1.1.1",
+ "actix-rt",
  "actix-server",
  "actix-service",
  "actix-testing",
@@ -439,7 +418,7 @@ checksum = "b381e490e7b0cfc37ebc54079b0413d8093ef43d14a4e4747083f7fa47a9e691"
 dependencies = [
  "actix-codec 0.3.0",
  "actix-http",
- "actix-rt 1.1.1",
+ "actix-rt",
  "actix-service",
  "base64 0.13.0",
  "bytes",
@@ -1268,7 +1247,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.23",
+ "tokio",
  "tokio-util 0.3.1",
  "tracing",
 ]
@@ -1314,7 +1293,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "thiserror",
- "tokio 0.2.23",
+ "tokio",
  "toml 0.5.7",
  "url",
  "uuid 0.8.1",
@@ -1392,7 +1371,7 @@ dependencies = [
  "prost",
  "rustls",
  "termcolor",
- "tokio 0.2.23",
+ "tokio",
  "tokio-util 0.3.1",
 ]
 
@@ -1412,7 +1391,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "tempfile",
- "tokio 0.2.23",
+ "tokio",
  "tokio-util 0.3.1",
  "toml 0.5.7",
 ]
@@ -1438,7 +1417,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tee",
- "tokio 0.2.23",
+ "tokio",
  "tokio-util 0.3.1",
  "url",
 ]
@@ -1507,7 +1486,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "thiserror",
- "tokio 0.2.23",
+ "tokio",
  "toml 0.5.7",
  "uuid 0.8.1",
  "valico",
@@ -1555,7 +1534,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "tokio 0.2.23",
+ "tokio",
  "tokio-rustls",
  "toml 0.5.7",
  "typemap",
@@ -1608,7 +1587,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "termcolor",
- "tokio 0.2.23",
+ "tokio",
  "url",
 ]
 
@@ -1632,7 +1611,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "tokio 0.2.23",
+ "tokio",
  "url",
 ]
 
@@ -1640,7 +1619,7 @@ dependencies = [
 name = "habitat_sup"
 version = "0.0.0"
 dependencies = [
- "actix-rt 2.1.0",
+ "actix-rt",
  "actix-web",
  "byteorder",
  "bytes",
@@ -1694,7 +1673,7 @@ dependencies = [
  "tempfile",
  "termcolor",
  "thiserror",
- "tokio 0.2.23",
+ "tokio",
  "tokio-rustls",
  "tokio-util 0.3.1",
  "toml 0.5.7",
@@ -1855,7 +1834,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.1",
  "socket2",
- "tokio 0.2.23",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1870,7 +1849,7 @@ dependencies = [
  "bytes",
  "hyper",
  "native-tls",
- "tokio 0.2.23",
+ "tokio",
  "tokio-tls",
 ]
 
@@ -3157,7 +3136,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "tokio 0.2.23",
+ "tokio",
  "tokio-native-tls",
  "tokio-util 0.2.0",
  "uuid 0.7.4",
@@ -3296,7 +3275,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.23",
+ "tokio",
  "tokio-tls",
  "url",
  "wasm-bindgen",
@@ -3321,7 +3300,7 @@ version = "1.0.0"
 source = "git+https://github.com/habitat-sh/retry#955385fba7da7a2f1bf1f8d7d2f2b33bd173a7b6"
 dependencies = [
  "rand 0.7.3",
- "tokio 0.2.23",
+ "tokio",
 ]
 
 [[package]]
@@ -3363,7 +3342,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "tokio 0.2.23",
+ "tokio",
  "xml-rs",
 ]
 
@@ -3383,7 +3362,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
- "tokio 0.2.23",
+ "tokio",
  "zeroize",
 ]
 
@@ -3423,7 +3402,7 @@ dependencies = [
  "serde",
  "sha2",
  "time 0.2.16",
- "tokio 0.2.23",
+ "tokio",
 ]
 
 [[package]]
@@ -3948,7 +3927,7 @@ dependencies = [
 name = "test-probe"
 version = "0.1.0"
 dependencies = [
- "actix-rt 2.1.0",
+ "actix-rt",
  "actix-web",
  "clap",
  "serde",
@@ -4138,22 +4117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
-dependencies = [
- "autocfg 1.0.1",
- "libc",
- "mio 0.7.6",
- "once_cell",
- "parking_lot",
- "pin-project-lite 0.2.0",
- "signal-hook-registry",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,7 +4134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd608593a919a8e05a7d1fc6df885e40f6a88d3a70a3a7eff23ff27964eda069"
 dependencies = [
  "native-tls",
- "tokio 0.2.23",
+ "tokio",
 ]
 
 [[package]]
@@ -4182,7 +4145,7 @@ checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.23",
+ "tokio",
  "webpki",
 ]
 
@@ -4193,7 +4156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio 0.2.23",
+ "tokio",
 ]
 
 [[package]]
@@ -4207,7 +4170,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite 0.1.7",
- "tokio 0.2.23",
+ "tokio",
 ]
 
 [[package]]
@@ -4222,7 +4185,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite 0.1.7",
- "tokio 0.2.23",
+ "tokio",
 ]
 
 [[package]]
@@ -4289,7 +4252,7 @@ dependencies = [
  "rand 0.7.3",
  "smallvec",
  "thiserror",
- "tokio 0.2.23",
+ "tokio",
  "url",
 ]
 
@@ -4309,7 +4272,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio 0.2.23",
+ "tokio",
  "trust-dns-proto",
 ]
 

--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -271,9 +271,9 @@ impl Server {
             if let Ok(b) = bind {
                 // Starting the server could be simplified
                 // See https://github.com/habitat-sh/habitat/issues/7352
-                System::new().block_on(async move {
-                                 b.run().await.expect("to start http server");
-                             })
+                System::new("actix-rt").block_on(async move {
+                                           b.run().await.expect("to start http server");
+                                       })
             }
         });
     }


### PR DESCRIPTION
Reverts habitat-sh/habitat#8086

Conflicts with actix-web.