### PR TITLE
pin bytes crate

### DIFF
--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -7,7 +7,7 @@ workspace = "../../"
 
 [dependencies]
 broadcast = "*"
-bytes = "*"
+bytes = "^0.5"
 chrono = "*"
 env = "*"
 futures = "*"

--- a/components/launcher-protocol/Cargo.toml
+++ b/components/launcher-protocol/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 workspace = "../../"
 
 [dependencies]
-bytes = "*"
+bytes = "^0.5"
 prost = "*"
 prost-derive = "*"
 serde = "*"

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -8,7 +8,7 @@ workspace = "../../"
 
 [dependencies]
 base64 = "*"
-bytes = "*"
+bytes = "^0.5"
 habitat_core = { path = "../core" }
 lazy_static = "^1.4.0"
 log = "^0.4.11"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-bytes = "*"
+bytes = "^0.5"
 actix-web = { version = "*", default-features = false, features = [ "rustls" ] }
 actix-rt = "*"
 byteorder = "*"


### PR DESCRIPTION
Pinning bytes in hopes that dependabot PRs don't try to bump it to 1.0.1 which will fail until some other deps update their version of bytes.

Signed-off-by: Matt Wrock <matt@mattwrock.com>