### PR TITLE
fix segmentation faults of musl binaries with static relocation-model

### DIFF
--- a/components/hab/habitat/plan.sh
+++ b/components/hab/habitat/plan.sh
@@ -69,6 +69,12 @@ do_prepare() {
   # variables.
   export PROTOC="$(pkg_path_for protobuf)/bin/protoc"
   export PROTOC_INCLUDE="$(pkg_path_for protobuf)/include"
+
+  # rust 1.46.0 enabled Position Independent Executables(PIE) for x86_64-unknown-linux-musl.
+  # This causes the compiled binary to segfault when building with GCC versions that
+  # support it. While we should investigate if there is something in the way we compile
+  # GCC which causes this. Setting relocation-model to static suppresses PIE.
+  export RUSTFLAGS='-C relocation-model=static'
 }
 
 do_build() {

--- a/components/pkg-export-container/habitat/plan.sh
+++ b/components/pkg-export-container/habitat/plan.sh
@@ -79,6 +79,12 @@ do_prepare() {
   # better refactoring may be called for.
   export PROTOC="$(pkg_path_for protobuf)/bin/protoc"
   export PROTOC_INCLUDE="$(pkg_path_for protobuf)/include"
+
+  # rust 1.46.0 enabled Position Independent Executables(PIE) for x86_64-unknown-linux-musl.
+  # This causes the compiled binary to segfault when building with GCC versions that
+  # support it. While we should investigate if there is something in the way we compile
+  # GCC which causes this. Setting relocation-model to static suppresses PIE.
+  export RUSTFLAGS='-C relocation-model=static'
 }
 
 do_build() {

--- a/components/pkg-export-tar/habitat/plan.sh
+++ b/components/pkg-export-tar/habitat/plan.sh
@@ -64,6 +64,12 @@ do_prepare() {
   PLAN_TAR_PKG_IDENT=$(pkg_path_for tar | sed "s,^$HAB_PKG_PATH/,,")
   export PLAN_TAR_PKG_IDENT
   build_line "Setting PLAN_TAR_PKG_IDENT=$PLAN_TAR_PKG_IDENT"
+
+  # rust 1.46.0 enabled Position Independent Executables(PIE) for x86_64-unknown-linux-musl.
+  # This causes the compiled binary to segfault when building with GCC versions that
+  # support it. While we should investigate if there is something in the way we compile
+  # GCC which causes this. Setting relocation-model to static suppresses PIE.
+  export RUSTFLAGS='-C relocation-model=static'
 }
 
 do_build() {

--- a/components/sup/static/plan.sh
+++ b/components/sup/static/plan.sh
@@ -25,4 +25,10 @@ do_prepare() {
   # package proper--it won't find its way into the final binaries.
   export LD_LIBRARY_PATH=$(pkg_path_for gcc)/lib
   build_line "Setting LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+
+  # rust 1.46.0 enabled Position Independent Executables(PIE) for x86_64-unknown-linux-musl.
+  # This causes the compiled binary to segfault when building with GCC versions that
+  # support it. While we should investigate if there is something in the way we compile
+  # GCC which causes this. Setting relocation-model to static suppresses PIE.
+  export RUSTFLAGS='-C relocation-model=static'
 }


### PR DESCRIPTION
Rust 1.46.0 [enabled Position Independent Executables(PIE) for x86_64-unknown-linux-musl] (https://github.com/rust-lang/rust/pull/70740/). This causes the compiled binary to segfault when building with GCC versions that support it. For instance a plain cargo build on ubuntu 18.04 works fine because it comes with v7.5.0 which does not support PIE. However a plan guild will build with v9.1.0 which does and these builds emit a segmentation fault. While we should investigate if there is something in the way we compile GCC which causes this. Setting relocation-model to static suppresses PIE.

Also note that while troubleshooting this, I tried building with rust 1.44.1 and set `export RUSTFLAGS='-C link-args=-pie'` which worked so there must be some additional nuances in compiler flags beyond simply turning on pie.

Signed-off-by: Matt Wrock <matt@mattwrock.com>