### PR TITLE
Update Hugo and fix docs build command

### DIFF
--- a/components/docs-chef-io/Makefile
+++ b/components/docs-chef-io/Makefile
@@ -14,7 +14,7 @@ serve: chef_web_docs
 
 chef_web_docs:
 	if [ -d "chef-web-docs/" ]; then \
-		pushd chef-web-docs && git reset HEAD --hard; git pull origin master && popd; \
+		pushd chef-web-docs && git reset HEAD --hard; git clean -fd; git pull --ff-only origin master; rm -rf public && popd;  \
 	else \
 		git clone https://github.com/chef/chef-web-docs.git; \
 	fi

--- a/components/docs-chef-io/README.md
+++ b/components/docs-chef-io/README.md
@@ -53,7 +53,7 @@ before the next promotion.
 
 We use [Hugo](https://gohugo.io/), [Go](https://golang.org/), [NPM](https://www.npmjs.com/),
 [go-swagger](https://goswagger.io/install.html), and [jq](https://stedolan.github.io/jq/).
-You will need Hugo 0.78.1 or higher installed and running to build and view our documentation properly.
+You will need Hugo 0.83.1 or higher installed and running to build and view our documentation properly.
 
 To install Hugo, NPM, and Go on Windows and macOS:
 

--- a/components/docs-chef-io/netlify.toml
+++ b/components/docs-chef-io/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 
 [build.environment]
-  HUGO_VERSION = "0.78.1"
+  HUGO_VERSION = "0.83.1"
   HUGO_ENABLEGITINFO = "true"
   GO_VERSION = "1.15"
   NODE_ENV = "development"


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>

Bump Hugo version to 0.83.1
Fix a docs build command that sometimes left pages that had been deleted or renamed.


chef/chef-web-docs#3125