### PR TITLE
gossip service rumor after update

### DIFF
--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -1140,6 +1140,11 @@ impl Manager {
                         if let Err(err) = self.state.cfg.save_spec_for(&service_spec) {
                             warn!("Tried to update '{}', but couldn't write the spec: {:?}",
                                   service_spec.ident, err);
+                        } else {
+                            let mut services = self.state.services.lock_msw();
+                            if let Some(s) = services.get_mut(&service_spec.ident) {
+                                self.gossip_latest_service_rumor_rsw_mlw_rhw(&s);
+                            }
                         }
                     }
                 }

--- a/test/end-to-end/test_svc_update.ps1
+++ b/test/end-to-end/test_svc_update.ps1
@@ -139,8 +139,12 @@ Describe "hab svc update" {
 
         $proc = Get-Process "nginx"
 
-        It "starts updating from the first channel" {
+        It "reflects channel in spec file" {
             '/hab/sup/default/specs/nginx.spec' | Should -FileContentMatchExactly "channel = `"$testChannelOne`""
+        }
+
+        It "reflects channel in api" {
+            ((Invoke-WebRequest "http://localhost:9631/services/nginx/default" -UseBasicParsing).content | ConvertFrom-Json).channel | Should -Be $testChannelOne
         }
 
         hab svc update $nginx_pkg --channel $testChannelTwo
@@ -153,6 +157,10 @@ Describe "hab svc update" {
         It "has the new channel in the spec file" {
             '/hab/sup/default/specs/nginx.spec' | Should -FileContentMatchExactly "channel = `"$testChannelTwo`""
             '/hab/sup/default/specs/nginx.spec' | Should -FileContentMatchExactly 'update_strategy = "at-once"'
+        }
+
+        It "reflects updated channel in api" {
+            ((Invoke-WebRequest "http://localhost:9631/services/nginx/default" -UseBasicParsing).content | ConvertFrom-Json).channel | Should -Be $testChannelTwo
         }
 
         It "does not restart the service process" {


### PR DESCRIPTION
Updating a service via `hab svc update` does not gossip a service rumor and therefore the json api data is not updated. This fixes that and adds a test for it as well.

Signed-off-by: Matt Wrock <matt@mattwrock.com>