### PR TITLE
exclude libressl install in rootless studio build

### DIFF
--- a/components/rootless_studio/Dockerfile
+++ b/components/rootless_studio/Dockerfile
@@ -1,12 +1,10 @@
 FROM alpine
-MAINTAINER Elliott Davis <elliott@excellent.io>
 ARG HAB_VERSION=
 ARG PACKAGE_TARGET
 RUN set -ex \
   && apk add --no-cache --virtual .build-deps \
     ca-certificates \
     gnupg \
-    libressl \
     wget \
     bash \
   \


### PR DESCRIPTION
Fixes pipeline failures as of alpine 3.14 which includes `libretls`

Signed-off-by: Matt Wrock <matt@mattwrock.com>