### PR TITLE
opt out of pwsh telemetry to avoid shell startup issues

### DIFF
--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -233,11 +233,10 @@ pub trait Hook: fmt::Debug + Sized + Send {
         use habitat_core::util;
 
         let ps_cmd = format!("iex $(gc {} | out-string)", path.as_ref().to_string_lossy());
-        Ok(Child::spawn("pwsh.exe",
-                        &util::pwsh_args(ps_cmd.as_str()),
-                        &pkg.env.to_hash_map(),
-                        &pkg.svc_user,
-                        svc_encrypted_password)?)
+        Ok(util::spawn_pwsh(&ps_cmd,
+                            &pkg.env.to_hash_map(),
+                            &pkg.svc_user,
+                            svc_encrypted_password)?)
     }
 
     #[cfg(unix)]

--- a/components/core/src/util.rs
+++ b/components/core/src/util.rs
@@ -11,8 +11,10 @@ pub mod win_perm;
 use crate::{error::Result,
             os::process::windows_child::Child};
 
-use std::{collections::HashMap,
-          io::{self,
+#[cfg(windows)]
+use std::collections::HashMap;
+
+use std::{io::{self,
                BufRead},
           mem};
 
@@ -123,7 +125,7 @@ pub fn spawn_pwsh<U, P>(command: &str,
     let mut new_env = HashMap::new();
     // Opts out of powershell application insights telemetry code on shell startup
     new_env.insert("POWERSHELL_TELEMETRY_OPTOUT".to_string(), "1".to_string());
-    new_env.extend(env.into_iter().map(|(k, v)| (k.clone(), v.clone())));
+    new_env.extend(env.iter().map(|(k, v)| (k.clone(), v.clone())));
 
     Child::spawn("pwsh.exe",
                  &args,

--- a/components/core/src/util.rs
+++ b/components/core/src/util.rs
@@ -7,7 +7,12 @@ pub mod text_render;
 #[cfg(windows)]
 pub mod win_perm;
 
-use std::{io::{self,
+#[cfg(windows)]
+use crate::{error::Result,
+            os::process::windows_child::Child};
+
+use std::{collections::HashMap,
+          io::{self,
                BufRead},
           mem};
 
@@ -92,22 +97,39 @@ macro_rules! impl_try_from_str_and_into_string {
     };
 }
 
-/// returns the common arguments to pass to pwsh.exe when spawning a powershell instance.
-/// These arguments are optimized for a background powershell process running hooks.
-/// The NonInteractive flag specifies that the console is not intended to interact with
-/// human input and allows ctrl+break signals to trigger a graceful termination similar to
-/// a SIGTERM on linux rather than an interactive debugging prompt. The ExecutionPolicy
-/// ensures that if a more strict policy exists in the Windows Registry (ex "AllSigned"),
-/// hook execution will not fail because hook scripts are never signed. RemoteSigned is the
-/// default policy and just requires remote scripts to be signeed. Supervisor hooks are
-/// always local so "RemoteSigned" does not interfere with supervisor behavior.
+/// Spawns a background powershell process optimized for running hooks.
 #[cfg(windows)]
-pub fn pwsh_args(command: &str) -> Vec<&str> {
-    vec!["-NonInteractive",
-         "-ExecutionPolicy",
-         "RemoteSigned",
-         "-Command",
-         command]
+pub fn spawn_pwsh<U, P>(command: &str,
+                        env: &HashMap<String, String>,
+                        svc_user: U,
+                        svc_encrypted_password: Option<P>)
+                        -> Result<Child>
+    where U: ToString,
+          P: ToString
+{
+    // The NonInteractive flag specifies that the console is not intended to interact with
+    // human input and allows ctrl+break signals to trigger a graceful termination similar to
+    // a SIGTERM on linux rather than an interactive debugging prompt. The ExecutionPolicy
+    // ensures that if a more strict policy exists in the Windows Registry (ex "AllSigned"),
+    // hook execution will not fail because hook scripts are never signed. RemoteSigned is the
+    // default policy and just requires remote scripts to be signeed. Supervisor hooks are
+    // always local so "RemoteSigned" does not interfere with supervisor behavior.
+    let args = vec!["-NonInteractive",
+                    "-ExecutionPolicy",
+                    "RemoteSigned",
+                    "-Command",
+                    command];
+
+    let mut new_env = HashMap::new();
+    // Opts out of powershell application insights telemetry code on shell startup
+    new_env.insert("POWERSHELL_TELEMETRY_OPTOUT".to_string(), "1".to_string());
+    new_env.extend(env.into_iter().map(|(k, v)| (k.clone(), v.clone())));
+
+    Child::spawn("pwsh.exe",
+                 &args,
+                 &new_env,
+                 svc_user,
+                 svc_encrypted_password)
 }
 
 // This is copied from [here](https://github.com/rust-lang/rust/blob/d3cba254e464303a6495942f3a831c2bbd7f1768/src/libstd/io/mod.rs#L2495),

--- a/components/sup/src/manager/service/pipe_hook_client.rs
+++ b/components/sup/src/manager/service/pipe_hook_client.rs
@@ -4,7 +4,6 @@ use habitat_common::{error::{Error,
                      outputln,
                      templating::package::Pkg};
 use habitat_core::{env as henv,
-                   os::process::windows_child::Child,
                    util::{self,
                           BufReadLossy}};
 use mio::{windows::NamedPipe,
@@ -171,11 +170,10 @@ impl PipeHookClient {
                              process::id());
 
         // Start instance of powershell to host named pipe server for this client
-        let child = Child::spawn("pwsh.exe",
-                                 &util::pwsh_args(ps_cmd.as_str()),
-                                 &pkg.env.to_hash_map(),
-                                 &pkg.svc_user,
-                                 svc_encrypted_password)?;
+        let child = util::spawn_pwsh(&ps_cmd,
+                                     &pkg.env.to_hash_map(),
+                                     &pkg.svc_user,
+                                     svc_encrypted_password)?;
         debug!("spawned powershell server for {} {} hook on pipe: {}",
                service_group, self.hook_name, self.pipe_name);
 


### PR DESCRIPTION
We had a user running several services on a single supervisor. One of the health check hooks appeared to not be running. It ends up that the hooks `pwsh` process was hanging. Based on a memory dump, it was locked waiting on some telemetry synchronization. This sets `POWERSHELL_TELEMETRY_OPTOUT` which effectively opts out of the telemetry synchronization.

Note that this also gets rid of some old code that would fall back to powershell.exe if pwsh.exe was not present. This scenario should no longer be possible.

Signed-off-by: Matt Wrock <matt@mattwrock.com>