### PR TITLE
search for nginx* process in e2e

### DIFF
--- a/test/end-to-end/test_svc_update.ps1
+++ b/test/end-to-end/test_svc_update.ps1
@@ -137,7 +137,7 @@ Describe "hab svc update" {
         Load-SupervisorService $nginx_pkg -Force -Strategy "at-once" -Channel $testChannelOne
         Start-Sleep 10
 
-        $proc = Get-Process "nginx"
+        $proc = Get-Process "nginx*"
 
         It "reflects channel in spec file" {
             '/hab/sup/default/specs/nginx.spec' | Should -FileContentMatchExactly "channel = `"$testChannelOne`""
@@ -164,7 +164,7 @@ Describe "hab svc update" {
         }
 
         It "does not restart the service process" {
-            $currentProc = Get-Process "nginx"
+            $currentProc = Get-Process "nginx*"
             $proc.Id | Should -Be $currentProc.Id
         }
     }


### PR DESCRIPTION
This fixes a broken e2e test that was failing because `get-process` was not matching any `nginx` process. Thats because the process running was `nginx: master process nginx`. What confuses me is how this ever passed. At this point I will allow myself to embrace the mystery of computers.

Signed-off-by: Matt Wrock <matt@mattwrock.com>