### PR TITLE
Minor updates to script to generate CLI docs

### DIFF
--- a/.expeditor/scripts/release_habitat/generate-cli-docs.js
+++ b/.expeditor/scripts/release_habitat/generate-cli-docs.js
@@ -92,7 +92,8 @@ draft= false
     weight = 10
 +++
 
-<!-- This is a generated file, do not edit it directly. See https://github.com/habitat-sh/habitat/blob/master/.expeditor/scripts/finish_release/generate-cli-docs.js -->
+<!-- markdownlint-disable-file -->
+<!-- This is a generated file, do not edit it directly. See https://github.com/habitat-sh/habitat/blob/main/.expeditor/scripts/release_habitat/generate-cli-docs.js -->
 
 
 The commands for the Chef Habitat CLI (\`hab\`) are listed below.


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

Two things:

1. Update the location of the generate-cli-docs.js script in the output CLI docs file.
2. Add `markdownlint-disable-file` to disable markdownlint for the entire file. See [PR](https://github.com/chef/chef-web-docs/pull/3500/files#diff-5ab4c098ff6b3c3fbbde9113ff10c7281794c54baba9d8708dd2977a0f2d1df7L12) / chef/chef-web-docs#3500 and the [Markdownlint docs](https://github.com/DavidAnson/markdownlint#configuration).