### PR TITLE
add e2e test with a real automate instance

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -747,7 +747,8 @@ steps:
       - "*.log"
     expeditor:
       executor:
-        docker:
+        linux:
+          single-use: true
           privileged: true
           environment:
             - BUILD_PKG_TARGET=x86_64-linux

--- a/.expeditor/scripts/end_to_end/run_e2e_test.sh
+++ b/.expeditor/scripts/end_to_end/run_e2e_test.sh
@@ -7,7 +7,7 @@ test_name=${2:-}
 
 source .expeditor/scripts/end_to_end/setup_environment.sh "$channel"
 if [ -n "$test_name" ]; then
-    pwsh .expeditor/scripts/end_to_end/run_e2e_test_core.ps1 "$test_name"
+    sudo -E hab pkg exec core/powershell pwsh .expeditor/scripts/end_to_end/run_e2e_test_core.ps1 "$test_name"
 else
     bash
 fi

--- a/test/end-to-end/automate/Dockerfile
+++ b/test/end-to-end/automate/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu
+
+# We need curl
+RUN apt-get update && apt-get -y install curl
+
+# Download latest release of automate
+RUN curl https://packages.chef.io/files/current/latest/chef-automate-cli/chef-automate_linux_amd64.zip | gunzip - > chef-automate && chmod +x chef-automate
+
+# Configure automate. Make sure its fqdn is set to localhost and not the build containers
+# IP or hostname which will only work in the build environment
+RUN ./chef-automate init-config --fqdn localhost
+
+# Docker environment may not have a systemd so hint to automate not to use it
+ENV CHEF_AUTOMATE_SKIP_SYSTEMD="true"
+
+ENV HAB_LICENSE=accept-no-persist
+
+# Get all the automate services deployed and running
+RUN mkdir -p /hab/sup/default
+RUN ./chef-automate deploy config.toml --skip-preflight --accept-terms-and-mlsa
+
+# This is how containers will start automate
+CMD hab sup run

--- a/test/end-to-end/test_event_stream.ps1
+++ b/test/end-to-end/test_event_stream.ps1
@@ -1,13 +1,9 @@
 # Test the event stream connection to a NATS server
 
-$natsPkg = "$(Get-EndToEndTestingOrigin)/nats-event-stream-test"
-
-$authToken = "my_token="
-
-Describe "event stream connection to nats" {
+Describe "event stream not connected to nats" {
     $env:RUST_LOG = "rants=trace"
 
-    It "fails to start with no NATS server and --event-stream-connect-timeout set" {
+    It "fails to start with --event-stream-connect-timeout set" {
         {
             $supLog = New-SupervisorLogFile("event_stream-fails_to_start_with_no_NATS_server_with_timeout")
             Start-Supervisor -LogFile $supLog -Timeout 3 -SupArgs @( `
@@ -15,35 +11,58 @@ Describe "event stream connection to nats" {
                     "--event-stream-environment=MY_ENV", `
                     "--event-stream-site=MY_SITE", `
                     "--event-stream-url='127.0.0.1:4222'", `
-                    "--event-stream-token=$authToken", `
+                    "--event-stream-token=blah", `
                     "--event-stream-connect-timeout=2" `
             )
         } | Should -Throw
     }
+}
 
-    # Start the supervisor but do not require an initial event stream connection
-    $supLog =  New-SupervisorLogFile("test_event_stream")
-    Start-Supervisor -Timeout 45 -LogFile $supLog -SupArgs @( `
-            "--event-stream-application=MY_APP", `
-            "--event-stream-environment=MY_ENV", `
-            "--event-stream-site=MY_SITE", `
-            "--event-stream-url=127.0.0.1:4222", `
-            "--event-stream-token=$authToken" `
-    )
+Describe "event stream connected to automate" {
+    BeforeAll {
+        Write-Host "Building automate image..."
+        docker build -t automate ./test/end-to-end/automate
+        Write-Host "starting automate container..."
+        $script:cid = docker run --rm -d -p 4222:4222 automate
+        Write-Host "Waiting for automate to get healthy..."
+        docker exec $cid chef-automate status -w
+        Write-Host "Automate is healthy!"
+        $authToken = $(docker exec $cid chef-automate iam token create my_token --admin)
+        Write-Host "Obtained token: $authToken"
+        $cert = New-TemporaryFile
+        docker exec $cid chef-automate external-cert show | Out-File $cert -Encoding utf8
+        Write-Host "Retrieved server certificate to $cert"
 
-    # Start the NATS Server
-    Load-SupervisorService -PackageName $natsPkg -HealthCheckInterval 1
-
-    It "event stream connects and sends a health check" {
-        # Wait for a few health checks to run
-        Start-Sleep -Seconds 3
-
-        # Check that the output contains a connect message and that the server received a health check message
-        $out = (Get-Content $supLog) -join "`r`n"
-        $out | Should -BeLike "*INFO rants] Transitioned to state 'Connecting(127.0.0.1:4222)' from 'Connecting(127.0.0.1:4222)'*"
-        $out | Should -BeLike "*NATS server is healthy*"
+        # Start the supervisor but do not require an initial event stream connection
+        $supLog =  New-SupervisorLogFile("test_event_stream")
+        Write-Host "Starting Supervisor..."
+        Start-Supervisor -Timeout 45 -LogFile $supLog -SupArgs @( `
+                "--event-stream-application=MY_APP", `
+                "--event-stream-environment=MY_ENV", `
+                "--event-stream-site=MY_SITE", `
+                "--event-stream-url=localhost:4222", `
+                "--event-stream-token=$authToken", `
+                "--event-stream-server-certificate=$cert" `
+        )
+        Write-Host "Loading test-probe"
+        Load-SupervisorService -PackageName "habitat-testing/test-probe"
+        Write-Host "Service Loaded"
     }
 
-    Unload-SupervisorService -PackageName $natsPkg -Timeout 20
-    Stop-Supervisor
+    AfterAll {
+        Unload-SupervisorService -PackageName "habitat-testing/test-probe" -Timeout 20
+        Stop-Supervisor
+        docker stop $script:cid
+        docker rmi -f automate
+    }
+
+    It "connects and sends a health check" {
+        # test-probe has a long init hook, and we want
+        # to let the health-check hoo
+        Start-Sleep -Seconds 20
+
+        # Check that the output contains a connect message and that the server received a health check message
+        $out = (docker exec $cid chef-automate applications show-svcs --service-name test-probe)
+        $out | Should -BeLike "*OK"
+    }
 }


### PR DESCRIPTION
This includes a `Dockerfile` that builds a automate image of of the latest release of automate and then runs the supervisor connecting to that container. It then queries the chef-automate CLI to see that the application's health check was recorded.

Signed-off-by: Matt Wrock <matt@mattwrock.com>