### PR TITLE
Bump hugo to 0.91.2

### DIFF
--- a/components/docs-chef-io/netlify.toml
+++ b/components/docs-chef-io/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 
 [build.environment]
-  HUGO_VERSION = "0.83.1"
+  HUGO_VERSION = "0.91.2"
   HUGO_ENABLEGITINFO = "true"
   GO_VERSION = "1.15"
   NODE_ENV = "development"


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

Bump Hugo to 0.91.2 in the docs.