### PR TITLE
Minor doc fix: use systemd, not SystemD

### DIFF
--- a/components/docs-chef-io/content/habitat/running_habitat_servers.md
+++ b/components/docs-chef-io/content/habitat/running_habitat_servers.md
@@ -24,11 +24,11 @@ sudo groupadd hab
 sudo useradd -g hab hab
 ```
 
-Finally, you will need to wire Chef Habitat up to your systems init system. This may be SysVinit, SystemD, runit, etc. The details will be different for each system, but in the end, you must call `hab sup run`.
+Finally, you will need to wire Chef Habitat up to your systems init system. This may be SysVinit, systemd, runit, etc. The details will be different for each system, but in the end, you must call `hab sup run`.
 
-### Running under SystemD
+### Running under systemd
 
-A basic SystemD unit file for Chef Habitat might look like this. This assumes that you have already created the `hab` user and group, as instructed above, and that your `hab` binary is linked to `/bin/hab`.
+A basic systemd unit file for Chef Habitat might look like this. This assumes that you have already created the `hab` user and group, as instructed above, and that your `hab` binary is linked to `/bin/hab`.
 
 ```toml
     [Unit]

--- a/components/docs-chef-io/content/habitat/sup_run.md
+++ b/components/docs-chef-io/content/habitat/sup_run.md
@@ -20,7 +20,7 @@ Information about [installing Chef Habitat]({{< relref "install_habitat" >}}) an
 
 ## Starting the Supervisor
 
-In order to run a Chef Habitat-packaged service, you must first run a Chef Habitat Supervisor. There are two ways to start up a Supervisor, and it is important to know the implications of each, and which method is appropriate for your circumstances. These instructions describe the behavior of the 0.56.0 Supervisor and later, which dramatically simplified how Supervisors start up. These instructions also deal with the Supervisor "by itself"; later on, we'll see how to integrate it into different operational scenarios (e.g., SystemD, Windows Services, etc.). It is useful to understand the underlying concepts first.
+In order to run a Chef Habitat-packaged service, you must first run a Chef Habitat Supervisor. There are two ways to start up a Supervisor, and it is important to know the implications of each, and which method is appropriate for your circumstances. These instructions describe the behavior of the 0.56.0 Supervisor and later, which dramatically simplified how Supervisors start up. These instructions also deal with the Supervisor "by itself"; later on, we'll see how to integrate it into different operational scenarios (e.g., systemd, Windows Services, etc.). It is useful to understand the underlying concepts first.
 
 For further details about these commands, including all the arguments and options they take, please consult [the hab documentation]({{< relref "habitat_cli" >}}).
 


### PR DESCRIPTION
Per the [systemd authors](https://www.freedesktop.org/wiki/Software/systemd/#:~:text=Spelling,System%20D%2C%20or%20even%20SystemD.), the preferred spelling is `systemd`.