### PR TITLE
comma separate multiple test features

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -115,7 +115,7 @@ steps:
 
   - label: "[unit] :linux: butterfly lock_as_mutex"
     command:
-      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_mutex deadlock_detection" -- --test-threads=1 --format=pretty
+      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_mutex,deadlock_detection" -- --test-threads=1 --format=pretty
     expeditor:
       executor:
         docker:
@@ -125,7 +125,7 @@ steps:
 
   - label: "[unit] :linux: butterfly lock_as_rwlock"
     command:
-      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_rwlock deadlock_detection" -- --test-threads=1 --format=pretty
+      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_rwlock,deadlock_detection" -- --test-threads=1 --format=pretty
     expeditor:
       executor:
         docker:
@@ -247,7 +247,7 @@ steps:
 
   - label: "[unit] :linux: sup lock_as_rwlock"
     command:
-      - .expeditor/scripts/verify/run_cargo_test.sh sup --features "ignore_integration_tests lock_as_rwlock"
+      - .expeditor/scripts/verify/run_cargo_test.sh sup --features "ignore_integration_tests,lock_as_rwlock"
     expeditor:
       executor:
         docker:
@@ -259,7 +259,7 @@ steps:
 
   - label: "[unit] :linux: sup lock_as_mutex"
     command:
-      - .expeditor/scripts/verify/run_cargo_test.sh sup --features "ignore_integration_tests lock_as_mutex"
+      - .expeditor/scripts/verify/run_cargo_test.sh sup --features "ignore_integration_tests,lock_as_mutex"
     expeditor:
       executor:
         docker:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -115,7 +115,7 @@ steps:
 
   - label: "[unit] :linux: butterfly lock_as_mutex"
     command:
-      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_mutex,deadlock_detection" -- --test-threads=1 --format=pretty
+      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_mutex deadlock_detection" -- --test-threads=1 --format=pretty
     expeditor:
       executor:
         docker:
@@ -125,7 +125,7 @@ steps:
 
   - label: "[unit] :linux: butterfly lock_as_rwlock"
     command:
-      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_rwlock,deadlock_detection" -- --test-threads=1 --format=pretty
+      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_rwlock deadlock_detection" -- --test-threads=1 --format=pretty
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
This should get butterfly and sup unit tests running on linux. It looks as though ever since we removed the `+toolchain` from `cargo` and started just using the hab package, the cli parsing changed and it was filtering out all tests when using multiple feature filters. Comma separating the features seems to fix this.

Signed-off-by: Matt Wrock <matt@mattwrock.com>