### PR TITLE
remove deadlock detection from linux butterfly tests

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -115,7 +115,7 @@ steps:
 
   - label: "[unit] :linux: butterfly lock_as_mutex"
     command:
-      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_mutex deadlock_detection" -- --test-threads=1 --format=pretty
+      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_mutex" -- --test-threads=1 --format=pretty
     expeditor:
       executor:
         docker:
@@ -125,7 +125,7 @@ steps:
 
   - label: "[unit] :linux: butterfly lock_as_rwlock"
     command:
-      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_rwlock deadlock_detection" -- --test-threads=1 --format=pretty
+      - .expeditor/scripts/verify/run_cargo_test.sh butterfly --features "lock_as_rwlock" -- --test-threads=1 --format=pretty
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
This at least gets the butterfly unit tests running. I am not sure how relevant the deadlock detection is for these tests. I think we can make that call if we see the tests locking. They require nightly rust which is painful to wire up so lets just see if it is necessary at all.

Signed-off-by: Matt Wrock <matt@mattwrock.com>