### PR TITLE
Hab-sup-run arguments modified.

### DIFF
--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -1,6 +1,8 @@
-use super::{svc::{ConfigOptSharedLoad,
-                  SharedLoad,
-                  DEFAULT_SVC_CONFIG_DIR},
+use super::{svc::{SharedLoad,
+                  CHANNEL_IDENT_DEFAULT,
+                  DEFAULT_SVC_CONFIG_DIR,
+                  GROUP_DEFAULT,
+                  HEALTH_CHECK_INTERVAL_DEFAULT},
             util::{tls::{CertificateChainCli,
                          PrivateKeyCli,
                          RootCertificateStoreCli},
@@ -30,8 +32,14 @@ use habitat_common::{cli::{RING_ENVVAR,
                      FEATURE_FLAGS};
 use habitat_core::{env::Config,
                    fs::HAB_CTL_KEYS_CACHE,
+                   os::process::ShutdownTimeout,
                    package::PackageIdent,
-                   util as core_util};
+                   service::ServiceBind,
+                   util as core_util,
+                   ChannelIdent};
+use habitat_sup_protocol::types::{BindingMode,
+                                  UpdateCondition,
+                                  UpdateStrategy};
 use rants::{error::Error as RantsError,
             Address as NatsAddress};
 use std::{fmt,
@@ -41,6 +49,7 @@ use std::{fmt,
           str::FromStr};
 use structopt::{clap::AppSettings,
                 StructOpt};
+use url::Url;
 
 // All commands relating to the Supervisor (ie commands handled by both the `hab` and `hab-sup`
 // binary)
@@ -322,9 +331,95 @@ pub struct SupRun {
                 default_value = DEFAULT_SVC_CONFIG_DIR,
                 hidden = !FEATURE_FLAGS.contains(FeatureFlag::SERVICE_CONFIG_FILES))]
     pub svc_config_paths: Vec<PathBuf>,
-    #[structopt(flatten)]
-    #[serde(flatten)]
-    pub shared_load: SharedLoad,
+    /// Receive updates from the specified release channel
+    #[structopt(long = "channel", default_value = &*CHANNEL_IDENT_DEFAULT)]
+    #[serde(default)]
+    pub channel: ChannelIdent,
+    /// Specify an alternate Builder endpoint. If not specified, the value will be taken from
+    /// the HAB_BLDR_URL environment variable if defined. (default: https://bldr.habitat.sh)
+    #[structopt(short = "u", long = "url")]
+    bldr_url: Option<Url>,
+    /// The service group with shared config and topology
+    #[structopt(long = "group", requires = "PKG_IDENT_OR_ARTIFACT")]
+    group: Option<String>,
+    /// Service topology
+    #[structopt(long = "topology",
+            short = "t",
+            possible_values = &["standalone", "leader"],
+            requires = "PKG_IDENT_OR_ARTIFACT")]
+    topology: Option<habitat_sup_protocol::types::Topology>,
+    /// The update strategy
+    #[structopt(long = "strategy",
+                short = "s",
+                possible_values = &["none", "at-once", "rolling"],
+                requires = "PKG_IDENT_OR_ARTIFACT")]
+    strategy: Option<habitat_sup_protocol::types::UpdateStrategy>,
+    /// The condition dictating when this service should update
+    #[structopt(long = "update-condition",
+                possible_values = UpdateCondition::VARIANTS,
+                requires = "PKG_IDENT_OR_ARTIFACT")]
+    update_condition: Option<UpdateCondition>,
+    /// One or more service groups to bind to a configuration
+    #[structopt(long = "bind", requires = "PKG_IDENT_OR_ARTIFACT")]
+    bind: Vec<ServiceBind>,
+    /// Governs how the presence or absence of binds affects service startup
+    #[structopt(long = "binding-mode",
+                possible_values = &["strict", "relaxed"],
+                requires = "PKG_IDENT_OR_ARTIFACT")]
+    binding_mode: Option<habitat_sup_protocol::types::BindingMode>,
+    /// The interval in seconds on which to run health checks
+    #[structopt(long = "health-check-interval",
+                short = "i",
+                requires = "PKG_IDENT_OR_ARTIFACT")]
+    health_check_interval: Option<u64>,
+    /// The delay in seconds after sending the shutdown signal to wait before killing the service
+    /// process
+    #[structopt(long = "shutdown-timeout", requires = "PKG_IDENT_OR_ARTIFACT")]
+    shutdown_timeout: Option<ShutdownTimeout>,
+    #[cfg(target_os = "windows")]
+    /// Password of the service user
+    #[structopt(long = "password", requires = "PKG_IDENT_OR_ARTIFACT")]
+    password: Option<String>,
+    // TODO (DM): This flag can eventually be removed.
+    // See https://github.com/habitat-sh/habitat/issues/7339
+    /// DEPRECATED
+    #[structopt(long = "application", short = "a", takes_value = false, hidden = true)]
+    #[serde(skip)]
+    application: Vec<String>,
+    // TODO (DM): This flag can eventually be removed.
+    // See https://github.com/habitat-sh/habitat/issues/7339
+    /// DEPRECATED
+    #[structopt(long = "environment", short = "e", takes_value = false, hidden = true)]
+    #[serde(skip)]
+    environment: Vec<String>,
+    /// Use the package config from this path rather than the package itself
+    #[structopt(long = "config-from", requires = "PKG_IDENT_OR_ARTIFACT")]
+    config_from: Option<PathBuf>,
+}
+
+impl From<&SupRun> for SharedLoad {
+    fn from(sup_run: &SupRun) -> Self {
+        Self { channel: sup_run.channel.clone(),
+               bldr_url: sup_run.bldr_url.clone(),
+               group: sup_run.group
+                             .as_ref()
+                             .unwrap_or(&GROUP_DEFAULT::get())
+                             .to_string(),
+               topology: sup_run.topology,
+               strategy: sup_run.strategy.unwrap_or(UpdateStrategy::None),
+               bind: sup_run.bind.clone(),
+               update_condition: sup_run.update_condition.unwrap_or(UpdateCondition::Latest),
+               binding_mode: sup_run.binding_mode.unwrap_or(BindingMode::Strict),
+               health_check_interval:
+                   sup_run.health_check_interval
+                          .unwrap_or_else(|| u64::from_str(HEALTH_CHECK_INTERVAL_DEFAULT).unwrap()),
+               shutdown_timeout: sup_run.shutdown_timeout,
+               #[cfg(target_os = "windows")]
+               password: sup_run.password.clone(),
+               environment: sup_run.environment.clone(),
+               application: sup_run.application.clone(),
+               config_from: sup_run.config_from.clone(), }
+    }
 }
 
 #[derive(ConfigOpt, StructOpt)]

--- a/components/hab/src/cli/hab/svc.rs
+++ b/components/hab/src/cli/hab/svc.rs
@@ -23,13 +23,15 @@ use habitat_sup_protocol::{ctl,
 use std::{convert::TryFrom,
           iter::FromIterator,
           path::{Path,
-                 PathBuf}};
+                 PathBuf},
+          str::FromStr};
 use structopt::StructOpt;
 use url::Url;
 use walkdir::WalkDir;
 
 const DEFAULT_SVC_CONFIG_FILE: &str = "/hab/sup/default/config/svc.toml";
 pub const DEFAULT_SVC_CONFIG_DIR: &str = "/hab/sup/default/config/svc";
+pub const HEALTH_CHECK_INTERVAL_DEFAULT: &str = "30";
 
 /// Commands relating to Habitat services
 #[derive(ConfigOpt, StructOpt)]
@@ -128,15 +130,17 @@ pub struct KeyGenerate {
 }
 
 lazy_static::lazy_static! {
-    static ref CHANNEL_IDENT_DEFAULT: String = ChannelIdent::default().to_string();
-    static ref GROUP_DEFAULT: String = String::from("default");
+   pub static ref CHANNEL_IDENT_DEFAULT: String = ChannelIdent::default().to_string();
+   pub static ref GROUP_DEFAULT: String = String::from("default");
 }
 
 impl GROUP_DEFAULT {
-    fn get() -> String { GROUP_DEFAULT.clone() }
+    pub fn get() -> String { GROUP_DEFAULT.clone() }
 }
 
-fn health_check_interval_default() -> u64 { 30 }
+pub fn health_check_interval_default() -> u64 {
+    u64::from_str(HEALTH_CHECK_INTERVAL_DEFAULT).unwrap()
+}
 
 #[derive(ConfigOpt, StructOpt, Deserialize, Debug)]
 #[configopt(attrs(serde), derive(Clone, Debug))]
@@ -201,7 +205,7 @@ pub struct SharedLoad {
     // serialization format. We want to allow the user to simply specify a `u64` to be consistent
     // with the CLI, but we cannot change the serialization because the spec file depends on the map
     // based format.
-    #[structopt(long = "health-check-interval", short = "i", default_value = "30")]
+    #[structopt(long = "health-check-interval", short = "i", default_value = HEALTH_CHECK_INTERVAL_DEFAULT)]
     #[serde(default = "health_check_interval_default")]
     pub health_check_interval: u64,
     /// The delay in seconds after sending the shutdown signal to wait before killing the service

--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -22,7 +22,7 @@ const LAUNCH_PKG_IDENT: &str = "core/hab-launcher";
 
 pub async fn start(ui: &mut UI, sup_run: SupRun, args: &[OsString]) -> Result<()> {
     init()?;
-    let channel = sup_run.shared_load.channel;
+    let channel = sup_run.channel;
     if henv::var(SUP_CMD_ENVVAR).is_err() {
         let version: Vec<&str> = VERSION.split('/').collect();
         exec::command_from_min_pkg_with_channel(ui,

--- a/components/sup/src/cli.rs
+++ b/components/sup/src/cli.rs
@@ -44,12 +44,14 @@ mod test {
                         "PKG_IDENT_OR_ARTIFACT" => "core/redis");
 
         assert_cli_cmd!(should_handle_multiple_bind_flags,
-                        "hab-sup run --bind test:service.group1 --bind test:service.group2",
-                        "BIND" => ["test:service.group1", "test:service.group2"]);
+                        "hab-sup run --bind test:service.group1 --bind test:service.group2 -- core/redis",
+                        "BIND" => ["test:service.group1", "test:service.group2"],
+                        "PKG_IDENT_OR_ARTIFACT" => "core/redis");
 
         assert_cli_cmd!(should_handle_single_bind_flag_with_multiple_values,
-                        "hab-sup run --bind test:service.group1 test2:service.group2",
-                        "BIND" => ["test:service.group1", "test2:service.group2"]);
+                        "hab-sup run --bind test:service.group1 test2:service.group2 -- core/redis",
+                        "BIND" => ["test:service.group1", "test2:service.group2"],
+                        "PKG_IDENT_OR_ARTIFACT" => "core/redis");
 
         assert_cli_cmd!(should_handle_bind_flag_with_arguments,
                         "hab-sup run --bind test:service.group1 test:service.group2 -- core/redis",

--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -241,9 +241,7 @@ async fn split_apart_sup_run(sup_run: SupRun,
                              feature_flags: FeatureFlag)
                              -> Result<(ManagerConfig, Option<sup_proto::ctl::SvcLoad>)> {
     let ring_key = get_ring_key(&sup_run)?;
-
-    let shared_load = sup_run.shared_load;
-
+    let shared_load = hab::cli::hab::svc::SharedLoad::from(&sup_run);
     let event_stream_config = if sup_run.event_stream_url.is_some() {
         Some(EventStreamConfig { environment:
                                      sup_run.event_stream_environment


### PR DESCRIPTION
Raise usage errors if inappropriate hab svc load options are given in hab sup run.

Signed-off-by: dikshagupta1 <diksha.gupta@progress.com>