### PR TITLE
temp fix for multi e2e failures

### DIFF
--- a/test/end-to-end/automate/Dockerfile
+++ b/test/end-to-end/automate/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu@sha256:9101220a875cee98b016668342c489ff0674f247f6ca20dfc91b91c0f28581ae
 
 # We need curl
 RUN apt-get update && apt-get -y install curl

--- a/test/end-to-end/multi-supervisor/Dockerfile
+++ b/test/end-to-end/multi-supervisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu@sha256:9101220a875cee98b016668342c489ff0674f247f6ca20dfc91b91c0f28581ae
 
 # Channel from which to install Habitat-related packages
 ARG CHANNEL=stable


### PR DESCRIPTION
Signed-off-by: Matt Wrock <matt@mattwrock.com>

A couple weeks ago we began to see failures in the e2e pipeline. This occured when ubuntu updated its `latest` tag from `20.04` to `22.04`. At first we thought updateing buildkite's version of docker would fix this but it did not. Ends up we need to update runc to 1.0.3. While we are working on that. This change will force the tests to use the 20.04 image.