### PR TITLE
going back to latest ubuntu images

### DIFF
--- a/test/end-to-end/automate/Dockerfile
+++ b/test/end-to-end/automate/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu@sha256:9101220a875cee98b016668342c489ff0674f247f6ca20dfc91b91c0f28581ae
+FROM ubuntu
 
 # We need curl
 RUN apt-get update && apt-get -y install curl

--- a/test/end-to-end/multi-supervisor/Dockerfile
+++ b/test/end-to-end/multi-supervisor/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu@sha256:9101220a875cee98b016668342c489ff0674f247f6ca20dfc91b91c0f28581ae
+FROM ubuntu
 
 # Channel from which to install Habitat-related packages
 ARG CHANNEL=stable


### PR DESCRIPTION
Signed-off-by: Matt Wrock <matt@mattwrock.com>

We can revert the pinned ubuntu image now that buildkite updates runc.