### PR TITLE
Remove Hugo and go versions from netlify config

### DIFF
--- a/components/docs-chef-io/netlify.toml
+++ b/components/docs-chef-io/netlify.toml
@@ -1,9 +1,7 @@
 [build]
 
 [build.environment]
-  HUGO_VERSION = "0.91.2"
   HUGO_ENABLEGITINFO = "true"
-  GO_VERSION = "1.15"
   NODE_ENV = "development"
 
 [build.processing]


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

Remove Hugo and go versions from netlify config. The current specified Hugo version has a bug that's making PR build previews fail and it's easier to set these in the Netlify Web UI. 