### PR TITLE
Release Notes

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -114,6 +114,10 @@ subscriptions:
       # "curlbash" installers get the right packages.
       - bash:.expeditor/scripts/purge_cdn.sh:
           post_commit: true
+      - bash:.expeditor/release_notes/publish-release-notes.sh:
+          post_commit: true
+      - bash:.expeditor/release_notes/announce-release.sh:
+          post_commit: true
       - trigger_pipeline:finish_release:
           post_commit: true
 

--- a/.expeditor/scripts/release_notes/announce-release.sh
+++ b/.expeditor/scripts/release_notes/announce-release.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -exou pipefail
+
+# Download the latest Hab manifest
+aws s3 cp "s3://chef-automate-artifacts/${EXPEDITOR_TARGET_CHANNEL}/latest/habitat/manifest.json" manifest.json --profile chef-cd
+
+build_version=$(jq -r -c ".version"  manifest.json)
+
+# Download the release-notes for our specific build
+curl -o release-notes.md "https://packages.chef.io/release-notes/${EXPEDITOR_PROJECT}/${build_version}.md"
+
+topic_title="Chef Habitat $build_version Released!"
+topic_body=$(cat <<EOH
+We are delighted to announce the availability of version $build_version of Chef Habitat.
+$(cat release-notes.md)
+
+---
+## Get the Build
+
+You can download binaries directly from [chef.io/downloads](https://www.chef.io/downloads/tools/habitat?v=$EXPEDITOR_VERSION).
+EOH
+)
+
+# Use Expeditor's built in Bash helper to post our message: https://git.io/JvxPm
+post_discourse_release_announcement "$topic_title" "$topic_body"
+
+# Cleanup
+rm release-notes.md
+rm manifest.json

--- a/.expeditor/scripts/release_notes/publish-release-notes.sh
+++ b/.expeditor/scripts/release_notes/publish-release-notes.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eou pipefail
+
+git clone https://x-access-token:${GITHUB_TOKEN}@github.com/habitat-sh/habitat.wiki.git
+
+# Download the latest Hab manifest
+aws s3 cp "s3://chef-automate-artifacts/${EXPEDITOR_TARGET_CHANNEL}/latest/habitat/manifest.json" manifest.json --profile chef-cd
+
+build_version=$(jq -r -c ".version"  manifest.json)
+
+pushd ./chef-server.wiki
+  # Publish release notes to S3
+  aws s3 cp Pending-Release-Notes.md "s3://chef-automate-artifacts/release-notes/${EXPEDITOR_PROJECT}/${build_version}.md" --acl public-read --content-type "text/plain" --profile chef-cd
+
+  # Reset "Stable Release Notes" wiki page
+  cat >./Pending-Release-Notes.md <<EOH
+## New Features
+-
+## Improvements
+-
+## Bug Fixes
+-
+## Backward Incompatibilities
+-
+EOH
+
+  # Push changes back up to GitHub
+  git add .
+  git commit -m "Release Notes for promoted build $build_version"
+  git push origin master
+popd
+
+# Cleanup
+rm -rf chef-server.wiki
+rm manifest.json

--- a/components/docs-chef-io/README.md
+++ b/components/docs-chef-io/README.md
@@ -146,6 +146,22 @@ See:
 - https://github.com/chef/chef-web-docs/blob/master/.expeditor/update_hugo_modules_project_promoted.sh
 - https://github.com/habitat-sh/habitat/pull/7993
 
+## Release Notes
+
+Release notes allow product engineering to communicate the list of features that are shipping in the builds being promoted to `stable`. Remember release notes are not changelogs! The audience is our end-users, not other engineers. If you need a quick primer on what goes into good release notes, take a look at these excellent articles:
+
+- [The Life-Changing Magic of Writing Release Notes](https://medium.com/@DigitalGov/the-life-changing-magic-of-writing-release-notes-4c460970565)
+- [Let’s All Appreciate These Great Release Notes Together](https://www.prodpad.com/blog/writing-release-notes/)
+
+Capture the release notes on the [Pending Release Notes wiki page](https://github.com/habitat-sh/habitat/wiki/Pending-Release-Notes). All edits should be completed and reviewed by a member of the Documentation Team before Habitat is promoted to `stable`. It is the responsibility of the _individual development teams_ to ensure the release notes are updated with any features and breaking changes that ship when Habitat is promoted to the `stable` channel. We encourage teams to make updating these release notes part of their weekly rituals. Whatever is in the wiki page at promotion time is what goes out with the release!
+
+During the promotion to the `stable` channel, the release notes will be extracted from the wiki page and published to an S3 bucket. The published release notes are then available at the following URLs:
+
+```text
+https://docs.chef.io/release_notes_habitat/
+https://packages.chef.io/release-notes/habitat/<VERSION>.md
+```
+
 ## Documentation Feedback
 
 We love getting feedback, questions, or comments.


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

Adds seamless release notes config to Expeditor.

What should happen (if I did this right):

On project promotion from current -> stable:

1. The publish-release-notes script runs. 
    This will:
    1. Pull down the latest Hab manifest from S3 and grab the version number
    2. Clone the pending release notes from the GitHub Wiki
    3. Push the pending release notes text up to S3 in a new release notes file which is named after the version number
    4. Reset the pending release note file in the GitHub Wiki
2. The announce-release-notes script runs.
     This will:
     1. Pull down the latest Hab manifest from S3 and grab the version number so Expeditor can grab the release notes file in the next step
     2. Pull down the release notes file from S3 that was just published
     3. Automatically announce the latest release of Hab to Chef Discourse

I also added some text about release notes to the docs README.md.

## Related

chef/chef-web-docs#3848
https://chefio.atlassian.net/browse/CHEFDOCS-188
