### PR TITLE
set UPLOAD_AND_PROMOTE var in builds to force upload and promote in release_habitat pipeline

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -344,7 +344,7 @@ steps:
   - label: "[:linux: upload hab binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     expeditor:
       executor:
         docker:
@@ -355,7 +355,7 @@ steps:
   - label: "[:linux: :two: upload hab binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     expeditor:
       executor:
         docker:
@@ -366,7 +366,7 @@ steps:
   - label: "[:windows: upload hab binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     expeditor:
       executor:
         docker:
@@ -377,7 +377,7 @@ steps:
   - label: "[:mac: x86_64 upload hab binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     expeditor:
       executor:
         docker:
@@ -388,7 +388,7 @@ steps:
   - label: "[:mac: aarch64 upload hab binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     expeditor:
       executor:
         docker:
@@ -399,7 +399,7 @@ steps:
   - label: "Update Habitat Documentation"
     command:
       - .expeditor/scripts/release_habitat/update_documentation.sh
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     artifact_paths:
       # See update_documentation.sh script for the naming of this path.
       - "generated-documentation/**"
@@ -430,7 +430,7 @@ steps:
 
   - label: ":docker: Upload containers to Docker Hub"
     command: .expeditor/scripts/release_habitat/dockerhub_upload.sh
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     env:
       BUILD_PKG_TARGET: "x86_64-linux"
     expeditor:
@@ -440,7 +440,7 @@ steps:
 
   - label: ":docker: :two: Upload containers to Docker Hub"
     command: .expeditor/scripts/release_habitat/dockerhub_upload.sh
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     env:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
     expeditor:
@@ -449,7 +449,7 @@ steps:
           privileged: true
 
   - label: ":docker: :windows: Upload windows 2016 container to Docker Hub"
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1
     expeditor:
       executor:
@@ -457,7 +457,7 @@ steps:
           os_version: 2016
 
   - label: ":docker: :windows: Upload windows 2019 container to Docker Hub"
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1
     expeditor:
       executor:
@@ -470,7 +470,7 @@ steps:
     command:
       - .expeditor/scripts/release_habitat/promote_artifacts_to_dev.sh habitat-release-$BUILDKITE_BUILD_ID
     # Only "real" executions of this pipeline, initiated by Expeditor, should promote anything
-    if: build.creator.name == 'Chef Expeditor'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE")
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
Hopefully now I can force a release build without stupid white space commits.

Signed-off-by: Matt Wrock <matt@mattwrock.com>