### PR TITLE
Correct the channels response parsing

### DIFF
--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -134,6 +134,14 @@ pub struct OriginChannelIdent {
     pub name: String,
 }
 
+
+#[derive(Clone, Deserialize)]
+pub struct OriginChannelWithPromotion {
+    pub name:        String,
+    pub created_at:  String,
+    pub promoted_at: String
+}
+
 pub struct BuilderAPIClient(ApiClient);
 
 impl BuilderAPIClient {
@@ -915,8 +923,9 @@ impl BuilderAPIClient {
         let encoded = resp.text().await.map_err(Error::BadResponseBody)?;
         trace!(target: "habitat_http_client::api_client::package_channels", "{:?}", encoded);
 
-        Ok(serde_json::from_str::<Vec<String>>(&encoded)?.into_iter()
-                                                         .collect())
+        let results: Vec<OriginChannelWithPromotion> = serde_json::from_str(&encoded)?;
+        let channels = results.into_iter().map(|o| o.name).collect();
+        Ok(channels)
     }
 
     /// Upload a public origin key to a remote Builder.

--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -134,7 +134,6 @@ pub struct OriginChannelIdent {
     pub name: String,
 }
 
-
 #[derive(Clone, Deserialize)]
 pub struct OriginChannelWithPromotion {
     pub name:        String,

--- a/components/builder-api-client/src/builder.rs
+++ b/components/builder-api-client/src/builder.rs
@@ -139,7 +139,7 @@ pub struct OriginChannelIdent {
 pub struct OriginChannelWithPromotion {
     pub name:        String,
     pub created_at:  String,
-    pub promoted_at: String
+    pub promoted_at: String,
 }
 
 pub struct BuilderAPIClient(ApiClient);


### PR DESCRIPTION
Closes #8457

The API for fetching package channels includes the created and promoted time in the response.

Below is the updated response format:
`[{"name":"unstable","created_at":"2022-03-01T17:32:35.154847","promoted_at":"2022-03-01T17:32:35.154847"},{"name":"mac_m1_hab","created_at":"2022-03-01T17:49:23.744922","promoted_at":"2022-03-01T17:49:23.744922"}]`

The fix is to properly handle the response and show the package channels.

Signed-off-by: Phani Sajja <psajja@progress.com>