### PR TITLE
SockerAddressProxy type support

### DIFF
--- a/.expeditor/test/utilities.bats
+++ b/.expeditor/test/utilities.bats
@@ -16,6 +16,7 @@ teardown() {
 }
 
 @test "get_version_from_repo for real releases" {
+    git config --global --add safe.directory /test
     assert_equal $(get_version_from_repo) $(cat "VERSION")
 }
 

--- a/components/hab/src/cli/hab/sup.rs
+++ b/components/hab/src/cli/hab/sup.rs
@@ -9,9 +9,9 @@ use super::{svc::{ConfigOptSharedLoad,
                    ConfigOptRemoteSup,
                    DurationProxy,
                    RemoteSup,
+                   SocketAddrProxy,
                    SubjectAlternativeName}};
-use crate::{error::Error,
-            VERSION};
+use crate::VERSION;
 use configopt::{self,
                 configopt_fields,
                 ConfigOpt};
@@ -37,8 +37,7 @@ use rants::{error::Error as RantsError,
 use serde::{Deserialize,
             Serialize};
 use std::{fmt,
-          net::{IpAddr,
-                SocketAddr},
+          net::IpAddr,
           path::PathBuf,
           str::FromStr};
 use structopt::{clap::AppSettings,
@@ -129,10 +128,6 @@ impl From<EventStreamAddress> for NatsAddress {
     fn from(address: EventStreamAddress) -> Self { address.0 }
 }
 
-fn parse_peer(s: &str) -> Result<SocketAddr, Error> {
-    Ok(habitat_common::util::resolve_socket_addr_with_default_port(s, GossipListenAddr::DEFAULT_PORT)?.1)
-}
-
 /// Run the Habitat Supervisor
 #[configopt_fields]
 #[derive(ConfigOpt, StructOpt, Deserialize)]
@@ -187,11 +182,8 @@ pub struct SupRun {
     #[structopt(long = "org")]
     pub organization: Option<String>,
     /// The listen address of one or more initial peers (IP[:PORT])
-    // TODO (DM): Currently there is not a good way to use `parse_peer` when deserializing. Due to
-    // https://github.com/serde-rs/serde/issues/723. There are workarounds but they are all ugly.
-    // This means that you have to specify the port when setting this with a config file.
-    #[structopt(long = "peer", parse(try_from_str = parse_peer))]
-    pub peer: Vec<SocketAddr>,
+    #[structopt(long = "peer")]
+    pub peer: Vec<SocketAddrProxy>,
     /// Make this Supervisor a permanent peer
     #[structopt(long = "permanent-peer", short = "I")]
     pub permanent_peer: bool,

--- a/components/plan-build/bin/environment.bash
+++ b/components/plan-build/bin/environment.bash
@@ -356,7 +356,7 @@ dedupe_path(){
 
     if [ -n "${original_path}" ]; then
       while [ -n "${original_path}" ]; do
-        path_item="${original_path%%${separator}*}"       # the first remaining entry
+        path_item="${original_path%%"${separator}"*}"       # the first remaining entry
         case "${new_path}" in
             *${separator}${path_item})
               ;&
@@ -368,9 +368,9 @@ dedupe_path(){
               new_path="${new_path}${separator}${path_item}"
               ;;    # not there yet
         esac
-        original_path="${original_path#*${separator}}"
+        original_path="${original_path#*"${separator}"}"
       done
-      new_path="${new_path#${separator}}"
+      new_path="${new_path#"${separator}"}"
     fi
 
     echo "${new_path}"

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -959,9 +959,7 @@ _determine_hab_bin() {
     build_line "NO_INSTALL_DEPS set: no package dependencies will be installed"
   fi
 
-  if [[ -n "${HAB_BIN:-}" ]]; then
-    HAB_BIN=$HAB_BIN
-  else
+  if [[ -z "${HAB_BIN:-}" ]]; then
     HAB_BIN="$_hab_cmd"
   fi
   build_line "Using HAB_BIN=$HAB_BIN for installs, signing, and hashing"
@@ -2056,7 +2054,7 @@ _do_copy_templates() {
     done
     find "$PLAN_CONTEXT/$1" "${find_exclusions[@]}" | while read -r FILE
     do
-      local plan_context_relative_path="$pkg_prefix${FILE#$PLAN_CONTEXT}"
+      local plan_context_relative_path="$pkg_prefix${FILE#"$PLAN_CONTEXT"}"
       if [[ -d "$FILE" ]]; then
         mkdir -p "$plan_context_relative_path"
       else


### PR DESCRIPTION
This merge fixes the bug - HABC-115 which points towards the parsing issues while using a config.toml file in the cab sup run --config-files option.
