### PR TITLE
Fixes several Rolling Update bugs

### DIFF
--- a/components/butterfly/protocols/newscast.proto
+++ b/components/butterfly/protocols/newscast.proto
@@ -20,6 +20,7 @@ message Service {
   optional uint64 incarnation = 3;
   optional bool initialized = 8;
   optional string pkg = 9;
+  optional uint64 pkg_incarnation = 13;
   optional bytes cfg = 10;
   optional SysInfo sys = 12;
 }

--- a/components/butterfly/src/protocol/newscast.rs
+++ b/components/butterfly/src/protocol/newscast.rs
@@ -72,13 +72,14 @@ impl From<CElectionUpdate> for Rumor {
 
 impl From<CService> for Rumor {
     fn from(value: CService) -> Self {
-        let payload = Service { member_id:     Some(value.member_id.clone()),
-                                service_group: Some(value.service_group.to_string()),
-                                incarnation:   Some(value.incarnation),
-                                initialized:   Some(value.initialized),
-                                pkg:           Some(value.pkg),
-                                cfg:           Some(value.cfg),
-                                sys:           Some(value.sys.into()), };
+        let payload = Service { member_id:       Some(value.member_id.clone()),
+                                service_group:   Some(value.service_group.to_string()),
+                                incarnation:     Some(value.incarnation),
+                                initialized:     Some(value.initialized),
+                                pkg:             Some(value.pkg),
+                                pkg_incarnation: Some(value.pkg_incarnation),
+                                cfg:             Some(value.cfg),
+                                sys:             Some(value.sys.into()), };
         Rumor { r#type:  RumorType::Service as i32,
                 tag:     Vec::default(),
                 from_id: Some(value.member_id),

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -1442,13 +1442,14 @@ mod tests {
     fn check_quorum_returns(val: bool) -> impl Fn(&str) -> bool { move |_: &str| val }
 
     fn mock_service(member: &Member) -> Service {
-        Service { member_id:     member.id.clone(),
-                  service_group: ServiceGroup::from_str("group.default").unwrap(),
-                  incarnation:   Default::default(),
-                  initialized:   Default::default(),
-                  pkg:           Default::default(),
-                  cfg:           Default::default(),
-                  sys:           Default::default(), }
+        Service { member_id:       member.id.clone(),
+                  service_group:   ServiceGroup::from_str("group.default").unwrap(),
+                  incarnation:     Default::default(),
+                  pkg_incarnation: Default::default(),
+                  initialized:     Default::default(),
+                  pkg:             Default::default(),
+                  cfg:             Default::default(),
+                  sys:             Default::default(), }
     }
 
     #[test]

--- a/components/sup/doc/render_context_schema.json
+++ b/components/sup/doc/render_context_schema.json
@@ -100,6 +100,10 @@
                     "description": "The identifier of the release the member is running",
                     "$ref": "#/definitions/package_identifier"
                 },
+                "pkg_incarnation": {
+                    "description": "Incarnation number associated with this package update",
+                    "type": "integer"
+                },
                 "package": {
                     "description": "The package identifier",
                     "type": "string"
@@ -194,6 +198,7 @@
                 "update_leader",
                 "update_follower",
                 "pkg",
+                "pkg_incarnation",
                 "sys",
                 "cfg",
                 "persistent",

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -658,6 +658,7 @@ pub struct Manager {
     // something else (maybe a HashMap?) in order to cleanly manage
     // the different operations.
     busy_services:                Arc<Mutex<HashSet<PackageIdent>>>,
+    updated_services:             Arc<Mutex<HashMap<ServiceGroup, u64>>>,
     services_need_reconciliation: ReconciliationFlag,
 
     feature_flags: FeatureFlag,
@@ -796,6 +797,7 @@ impl Manager {
                      sys: Arc::new(sys),
                      http_disable: cfg.http_disable,
                      busy_services: Arc::default(),
+                     updated_services: Arc::default(),
                      services_need_reconciliation: ReconciliationFlag::new(false),
                      feature_flags: cfg.feature_flags,
                      pid_source,
@@ -953,7 +955,12 @@ impl Manager {
         // write files to them.
         service.write_initial_service_files(&self.census_ring.read());
 
-        self.gossip_latest_service_rumor_rsw_mlw_rhw(&service);
+        // if this service is being started as a result of an update
+        // then we want to pass along the incarnation in updated_services
+        self.gossip_latest_service_rumor_rsw_mlw_rhw(&service,
+                                                     self.updated_services
+                                                         .lock()
+                                                         .remove(&service.service_group));
         if service.topology() == Topology::Leader {
             self.butterfly
                 .start_election_rsw_mlr_rhw_msr(&service.service_group, 0);
@@ -967,8 +974,6 @@ impl Manager {
         }
 
         self.maybe_uninstall_old_packages(&ident).await;
-
-        self.service_updater.lock().register(&service);
 
         event::service_started(&service);
 
@@ -1048,7 +1053,13 @@ impl Manager {
 
         // This serves to start up any services that need starting
         // (which will be all of them at this point!)
-        self.maybe_spawn_service_futures_rsw_mlw_gsw_rhw_msw().await;
+        for ident in self.maybe_spawn_service_futures_rsw_mlw_gsw_rhw_msw().await {
+            if let Some(wrapper) = self.state.services.lock_msr().get(&ident) {
+                if let Some(service) = wrapper.service() {
+                    self.service_updater.lock().register(service);
+                }
+            }
+        }
 
         // Ensure that the updated census state is saved to the gateway
         self.persist_state_rsr_mlr_gsw_msr().await;
@@ -1254,28 +1265,31 @@ impl Manager {
             // directory, as well as whether or not we need to
             // reexamine specs after finishing some asynchronous
             // operation on a service.
-            if self.spec_watcher.has_events() || self.services_need_reconciliation.is_set() {
-                // This call *must* come first. If some other future
-                // happens to complete before we get done spawning our
-                // current batch of futures, it could set the flag to
-                // true, but we wouldn't have taken another look at
-                // its spec file to see if we needed to do anything
-                // else. Thus, we could "lose" that signal if we
-                // toggle *after* spawning these futures.
-                //
-                // This could mean, say, the "start" part of a service
-                // restart could be greatly delayed (until some file
-                // event in the specs directory is registered, or
-                // another service finishes shutting down).
-                self.services_need_reconciliation.toggle_if_set();
-                self.maybe_spawn_service_futures_rsw_mlw_gsw_rhw_msw().await;
-            }
+            let mut updaters_to_register =
+                if self.spec_watcher.has_events() || self.services_need_reconciliation.is_set() {
+                    // This call *must* come first. If some other future
+                    // happens to complete before we get done spawning our
+                    // current batch of futures, it could set the flag to
+                    // true, but we wouldn't have taken another look at
+                    // its spec file to see if we needed to do anything
+                    // else. Thus, we could "lose" that signal if we
+                    // toggle *after* spawning these futures.
+                    //
+                    // This could mean, say, the "start" part of a service
+                    // restart could be greatly delayed (until some file
+                    // event in the specs directory is registered, or
+                    // another service finishes shutting down).
+                    self.services_need_reconciliation.toggle_if_set();
+                    self.maybe_spawn_service_futures_rsw_mlw_gsw_rhw_msw().await
+                } else {
+                    Vec::new()
+                };
 
             self.update_peers_from_watch_file_mlr_imlw()?;
             self.update_running_services_from_user_config_watcher_msw();
 
             // Restart all services that need it
-            self.restart_services_rsw_mlr_rhw_msw();
+            self.restart_services_rsw_mlr_rhw_msw(&mut updaters_to_register);
 
             self.restart_elections_rsw_mlr_rhw_msr(self.feature_flags);
             self.census_ring
@@ -1292,13 +1306,24 @@ impl Manager {
                 self.persist_state_rsr_mlr_gsw_msr().await;
             }
 
+            // we do not want to register the services for updating until the
+            // census is updated from the rumors above. Otherwise the updater
+            // threads may have stale census data
+            for ident in updaters_to_register {
+                if let Some(wrapper) = self.state.services.lock_msr().get(&ident) {
+                    if let Some(service) = wrapper.service() {
+                        self.service_updater.lock().register(service);
+                    }
+                }
+            }
+
             for service_state in self.state.services.lock_msw().services() {
                 // time will be recorded automatically by HistogramTimer's drop implementation when
                 // this var goes out of scope
                 #[allow(unused_variables)]
                 let service_timer = service_hist.start_timer();
                 if service_state.tick(&self.census_ring.read(), &self.launcher) {
-                    self.gossip_latest_service_rumor_rsw_mlw_rhw(service_state.service().expect("Service missing in PersistentServiceWrapper"));
+                    self.gossip_latest_service_rumor_rsw_mlw_rhw(service_state.service().expect("Service missing in PersistentServiceWrapper"), None);
                 }
                 if service_state.is_ready_for_restart() {
                     debug!("Service ready to restart, setting reconciliation flag");
@@ -1387,8 +1412,8 @@ impl Manager {
     /// * `MemberList::entries` (read)
     /// * `RumorHeat::inner` (write)
     /// * `ManagerServices::inner` (write)
-    fn restart_services_rsw_mlr_rhw_msw(&mut self) {
-        let service_updater = self.service_updater.lock();
+    fn restart_services_rsw_mlr_rhw_msw(&mut self, updaters_to_register: &mut Vec<PackageIdent>) {
+        let mut service_updater = self.service_updater.lock();
 
         let mut state_services = self.state.services.lock_msw();
         let mut idents_to_restart_and_latest_desired_on_restart = Vec::new();
@@ -1397,13 +1422,36 @@ impl Manager {
             let mut has_update = false;
             if let Some(service) = service_state.service() {
                 if let Some(new_ident) = service_updater.has_update(&service.service_group) {
-                    outputln!("Restarting {} with package {}", ident, new_ident);
-                    has_update = true;
-                    event::service_update_started(service, &new_ident);
-                    // The supervisor always runs the latest package on disk. When we have an update
-                    // ensure that the lastest package on disk is the package we updated to.
-                    idents_to_restart_and_latest_desired_on_restart.push((ident.clone(),
-                                                                          Some(new_ident)));
+                    if service.pkg.ident.as_ref() == &new_ident.ident {
+                        // Here a rolling follower got asked to update to the same version it
+                        // already had This is because the leader had a
+                        // higher incarnation but the same ident
+                        // which can happen if a leader was rolled back in the middle uf a rolling
+                        // update before other followers could update. Se
+                        // now we just want to gossip this followers
+                        // new incarnation (which should now be synced with the leader) and spin up
+                        // a new service updater.
+                        self.gossip_latest_service_rumor_rsw_mlw_rhw(service,
+                                                                     new_ident.incarnation);
+                        service_updater.remove(&service.service_group);
+                        // ident here should just be the spec ident origin/pkg
+                        updaters_to_register.push(ident.clone());
+                    } else {
+                        outputln!("Restarting {} with package {}", ident, new_ident.ident);
+                        has_update = true;
+                        // stash this updated service's incarnation for later gossiping
+                        if let Some(incarnation) = new_ident.incarnation {
+                            self.updated_services
+                                .lock()
+                                .insert(service.service_group.clone(), incarnation);
+                        }
+                        event::service_update_started(service, &new_ident.ident);
+                        // The supervisor always runs the latest package on disk. When we have an
+                        // update ensure that the lastest package on disk is
+                        // the package we updated to.
+                        idents_to_restart_and_latest_desired_on_restart.push((ident.clone(),
+                                                                            Some(new_ident.ident)));
+                    }
                 } else if service_state.should_shutdown_for_restart() {
                     idents_to_restart_and_latest_desired_on_restart.push((ident.clone(), None));
                 } else {
@@ -1441,7 +1489,9 @@ impl Manager {
     /// * `RumorStore::list` (write)
     /// * `MemberList::entries` (write)
     /// * `RumorHeat::inner` (write)
-    fn gossip_latest_service_rumor_rsw_mlw_rhw(&self, service: &Service) {
+    fn gossip_latest_service_rumor_rsw_mlw_rhw(&self,
+                                               service: &Service,
+                                               maybe_incarnation: Option<u64>) {
         let incarnation = self.butterfly
                               .service_store
                               .lock_rsr()
@@ -1450,7 +1500,7 @@ impl Manager {
                               .unwrap_or(1);
 
         self.butterfly
-            .insert_service_rsw_mlw_rhw(service.to_rumor(incarnation));
+            .insert_service_rsw_mlw_rhw(service.to_rumor(incarnation, maybe_incarnation));
     }
 
     fn check_for_departure(&self) -> bool { self.butterfly.is_departed() }
@@ -1763,10 +1813,10 @@ impl Manager {
     /// * `GatewayState::inner` (write)
     /// * `RumorHeat::inner` (write)
     /// * `ManagerServices::inner` (write)
-    async fn maybe_spawn_service_futures_rsw_mlw_gsw_rhw_msw(&mut self) {
+    async fn maybe_spawn_service_futures_rsw_mlw_gsw_rhw_msw(&mut self) -> Vec<PackageIdent> {
         let ops = self.compute_service_operations_msr();
         self.spawn_futures_from_operations_rsw_mlw_gsw_rhw_msw(ops)
-            .await;
+            .await
     }
 
     /// # Locking (see locking.md)
@@ -1792,9 +1842,12 @@ impl Manager {
     /// * `GatewayState::inner` (write)
     /// * `RumorHeat::inner` (write)
     /// * `ManagerServices::inner` (write)
-    async fn spawn_futures_from_operations_rsw_mlw_gsw_rhw_msw<O>(&mut self, ops: O)
+    async fn spawn_futures_from_operations_rsw_mlw_gsw_rhw_msw<O>(&mut self,
+                                                                  ops: O)
+                                                                  -> Vec<PackageIdent>
         where O: IntoIterator<Item = ServiceOperation>
     {
+        let mut services_started = Vec::new();
         for op in ops.into_iter() {
             match op {
                 ServiceOperation::Restart { to_stop: spec, .. } | ServiceOperation::Stop(spec) => {
@@ -1829,7 +1882,8 @@ impl Manager {
                            .get(&spec.ident)
                            .map_or(true, PersistentServiceWrapper::is_ready_for_restart)
                     {
-                        self.add_service_rsw_mlw_rhw_msr(spec).await;
+                        self.add_service_rsw_mlw_rhw_msr(spec.clone()).await;
+                        services_started.push(spec.ident.clone());
                     }
                 }
                 ServiceOperation::Update(spec, ops) => {
@@ -1841,7 +1895,7 @@ impl Manager {
                                                    .and_then(PersistentServiceWrapper::service_mut)
                     {
                         service.set_spec(spec);
-                        self.gossip_latest_service_rumor_rsw_mlw_rhw(service);
+                        self.gossip_latest_service_rumor_rsw_mlw_rhw(service, None);
                         for op in ops {
                             match op {
                                 RefreshOperation::RestartUpdater => {
@@ -1861,6 +1915,7 @@ impl Manager {
                 }
             }
         }
+        services_started
     }
 
     /// Determine what services we need to start, stop, or restart in

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -1093,7 +1093,7 @@ impl Service {
         (template_data_changed, template_update)
     }
 
-    pub fn to_rumor(&self, incarnation: u64) -> ServiceRumor {
+    pub fn to_rumor(&self, incarnation: u64, pkg_incarnation: Option<u64>) -> ServiceRumor {
         let exported = match self.cfg.to_exported(&self.pkg) {
             Ok(exported) => Some(exported),
             Err(err) => {
@@ -1109,6 +1109,9 @@ impl Service {
                                           self.sys.as_sys_info(),
                                           exported);
         rumor.incarnation = incarnation;
+        if let Some(pi) = pkg_incarnation {
+            rumor.pkg_incarnation = pi;
+        }
         rumor
     }
 

--- a/components/sup/src/manager/service/context.rs
+++ b/components/sup/src/manager/service/context.rs
@@ -458,6 +458,7 @@ two = 2
         let ident = PackageIdent::new("core", "test_pkg", Some("1.0.0"), Some("20180321150416"));
         let census_member = CensusMember { member_id: "MEMBER_ID".into(),
                                            pkg: ident,
+                                           pkg_incarnation: 0,
                                            service: "foo".into(),
                                            group: "default".into(),
                                            org: None,

--- a/components/sup/tests/fixtures/sample_render_context.json
+++ b/components/sup/tests/fixtures/sample_render_context.json
@@ -227,6 +227,7 @@
         "release": "20180315155739",
         "version": "0.1.0"
       },
+      "pkg_incarnation": 0,
       "service": "template-probe",
       "suspect": false,
       "sys": {
@@ -270,6 +271,7 @@
         "release": "20180315155739",
         "version": "0.1.0"
       },
+      "pkg_incarnation": 0,
       "service": "template-probe",
       "suspect": false,
       "sys": {
@@ -312,6 +314,7 @@
           "release": "20180315155739",
           "version": "0.1.0"
         },
+        "pkg_incarnation": 0,
         "service": "template-probe",
         "suspect": false,
         "sys": {
@@ -362,6 +365,7 @@
           "release": "20180302152133",
           "version": "7114"
         },
+        "pkg_incarnation": 0,
         "service": "builder-router",
         "suspect": false,
         "sys": {
@@ -404,6 +408,7 @@
             "release": "20180302152133",
             "version": "7114"
           },
+          "pkg_incarnation": 0,
           "service": "builder-router",
           "suspect": false,
           "sys": {

--- a/test/end-to-end/multi-supervisor/run_all.sh
+++ b/test/end-to-end/multi-supervisor/run_all.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+docker-compose --version
+
 # TODO (CM): Pass the name of a single test case to run
 
 channel=${1:-stable}

--- a/test/end-to-end/multi-supervisor/testcases/rolling_update_demote_mid_update/Dockerfile
+++ b/test/end-to-end/multi-supervisor/testcases/rolling_update_demote_mid_update/Dockerfile
@@ -1,0 +1,7 @@
+FROM habitat_integration_base
+
+# Always accept the license when we run this image.
+ENV HAB_LICENSE=accept-no-persist
+
+COPY run_test.ps1 /run_test.ps1
+CMD pwsh /scripts/end_to_end/run_e2e_test_core.ps1 /run_test.ps1

--- a/test/end-to-end/multi-supervisor/testcases/rolling_update_demote_mid_update/docker-compose.override.yml
+++ b/test/end-to-end/multi-supervisor/testcases/rolling_update_demote_mid_update/docker-compose.override.yml
@@ -1,0 +1,36 @@
+version: '2.4'
+services:
+  tester:
+    extends:
+      service: test_base
+    environment:
+      HAB_AUTH_TOKEN: ${PIPELINE_HAB_AUTH_TOKEN}
+    depends_on:
+      - bastion
+      - alpha
+      - beta
+      - gamma
+
+  alpha:
+    environment:
+      - HAB_UPDATE_STRATEGY_FREQUENCY_MS=3000
+      - HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK=1
+
+  beta:
+    environment:
+      - HAB_UPDATE_STRATEGY_FREQUENCY_MS=3000
+      - HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK=1
+
+  gamma:
+    extends:
+      service: sup_base
+    hostname: gamma
+    environment:
+      - HAB_UPDATE_STRATEGY_FREQUENCY_MS=3000
+      - HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK=1
+    networks:
+      default:
+        aliases:
+        - gamma.habitat.dev
+    depends_on:
+      - bastion

--- a/test/end-to-end/multi-supervisor/testcases/rolling_update_demote_mid_update/run_test.ps1
+++ b/test/end-to-end/multi-supervisor/testcases/rolling_update_demote_mid_update/run_test.ps1
@@ -1,0 +1,62 @@
+# This tests that removing the leader from a functioning leader topology
+# service group that has enough nodes to maintain quorum after the leader is
+# lost, it will continue to perform a succesful rolling update after a new
+# leader is elected.
+#
+# We will load services on three nodes and then stop the supervisor on
+# the leader node prompting a new election where one of the two follower nodes
+# becomes a leader. Next we perform an update and expect both nodes to update.
+# Prior to https://github.com/habitat-sh/habitat/pull/7167, the update after a
+# new leader is elected would never occur because the new leader would continue
+# to behave like a follower and wait for instructions to update.
+
+$testChannel = "rolling-$([DateTime]::Now.Ticks)"
+
+Describe "Rolling Update demotes a package in the middle of an update" {
+    $release1="habitat-testing/nginx/1.17.4/20191115184838"
+    $release2="habitat-testing/nginx/1.17.4/20191115185517"
+    $release3="habitat-testing/nginx/1.17.4/20191115185900"
+    hab pkg promote $release1 $testChannel
+    Load-SupervisorService "habitat-testing/nginx" -Remote "alpha.habitat.dev" -Topology leader -Strategy rolling -Channel $testChannel -UpdateCondition track-channel
+    Load-SupervisorService "habitat-testing/nginx" -Remote "beta.habitat.dev" -Topology leader -Strategy rolling -Channel $testChannel -UpdateCondition track-channel
+    Load-SupervisorService "habitat-testing/nginx" -Remote "gamma.habitat.dev" -Topology leader -Strategy rolling -Channel $testChannel -UpdateCondition track-channel
+
+    @("alpha", "beta", "gamma") | ForEach-Object {
+        It "loads initial release on $_" {
+            Wait-Release -Ident $release1 -Remote $_
+        }
+    }
+
+    Context "Promote Package" {
+        $leader = Get-Leader "bastion" "nginx.default"
+        hab pkg promote $release2 $testChannel
+
+        It "updates $($leader.Name) to $release2" {
+            Wait-Release -Ident $release2 -Remote $leader.Name
+        }
+    }
+
+    Context "Demote Package" {
+        hab pkg demote $release2 $testChannel
+
+        @("alpha", "beta", "gamma") | ForEach-Object {
+            It "updates to $release1 on $_" {
+                Wait-Release -Ident $release1 -Remote $_
+            }
+        }
+    }
+
+    Context "Promote Package after demote" {
+        hab pkg promote $release3 $testChannel
+
+        @("alpha", "beta", "gamma") | ForEach-Object {
+            It "updates to $release3 on $_" {
+                Wait-Release -Ident $release3 -Remote $_ -Timeout 30
+            }
+        }
+    }
+
+    AfterAll {
+        hab bldr channel destroy $testChannel --origin habitat-testing
+    }
+}


### PR DESCRIPTION
Fixes #8441 

This fixes the following bugs with rolling updates:

* There is a race condition that I can only replicate on Windows where a supervisor is updated, it gossips the new service version, it starts a new rolling update worker, and then updates it census state. It is possible (and is in fact happening reliably on windows) that after starting the rolling update thread, that thread will read and act upon stale census data and indefinitely wait for a new update. This fix registers the new updater workers after the census is repopulated.
* There is a delay that should be waited for before checking for updates. In the case of rolling updates, the leader checks to see if there is an update and then the followers all update to that version. The leader should honor the delay before each update check, but the followers should update asap after one another. There was some refactoring here a couple years ago that causes each follower to incur the delay that potentially causes a rolling update to take much longer than it should. This also opens the possibility for other undesirable edge cases making it easier for a roll back to happen in the middlw of an update or a update leaser to be removed during an update. If the followers do not wait, there is a much smaller liklihood that these events would occur in the middle of an update. This PR still fixes those cases, but by removing the delay for followers, those cases would heve been much harder to reproduce.
* Rolling update followers that track the head of a channel could get into a state where they are indefinitely receiving 404s from builder if an update has been rolled back before a rolling update has completed. Although the followers have been told the exact version to update to, they are still checking the channel to see what is at the head. If their version has been demoted, that version will not be there. In the case where rolling followers are updating to a fully qualified version, we should just update them to that version without checking the channel. That is the leader's responsibility.
* In the case where an update has been rolled back before an update completes, we ideally want to stop followers from updating that have not yet updated. Once we see that they are already on the leader's version, we should just cancel their update.
* In the case where a leader dies mid update, a new follower will be elected and promoted to leader. That leader may initially have a stale version and we don't want to initiate a rollback for followers that have already updated.