### PR TITLE
bump crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "log 0.4.16",
+ "log 0.4.17",
  "pin-project-lite",
  "tokio",
  "tokio-util",
@@ -44,7 +44,7 @@ dependencies = [
  "itoa 0.4.7",
  "language-tags",
  "local-channel",
- "log 0.4.16",
+ "log 0.4.17",
  "mime",
  "once_cell",
  "percent-encoding",
@@ -77,7 +77,7 @@ checksum = "2ad299af73649e1fc893e333ccf86f377751eb95ff875d095131574c6f43452c"
 dependencies = [
  "bytestring",
  "http",
- "log 0.4.16",
+ "log 0.4.17",
  "regex 1.5.6",
  "serde",
 ]
@@ -103,7 +103,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "futures-core",
- "log 0.4.16",
+ "log 0.4.17",
  "mio 0.7.13",
  "num_cpus",
  "slab",
@@ -134,7 +134,7 @@ dependencies = [
  "derive_more",
  "futures-core",
  "http",
- "log 0.4.16",
+ "log 0.4.17",
  "tokio-rustls",
  "tokio-util",
  "webpki-roots",
@@ -176,7 +176,7 @@ dependencies = [
  "futures-util",
  "itoa 0.4.7",
  "language-tags",
- "log 0.4.16",
+ "log 0.4.17",
  "mime",
  "once_cell",
  "paste",
@@ -779,7 +779,7 @@ checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
- "log 0.4.16",
+ "log 0.4.17",
  "regex 1.5.6",
  "termcolor",
 ]
@@ -790,7 +790,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
 dependencies = [
- "log 0.4.16",
+ "log 0.4.17",
  "url",
 ]
 
@@ -1044,7 +1044,7 @@ checksum = "c1d9279ca822891c1a4dae06d185612cf8fc6acfe5dff37781b41297811b12ee"
 dependencies = [
  "cc",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "rustversion",
  "winapi 0.3.9",
 ]
@@ -1136,7 +1136,7 @@ dependencies = [
  "handlebars 0.29.1",
  "lazy_static 1.4.0",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "pbr",
  "rants",
  "reqwest",
@@ -1174,7 +1174,7 @@ dependencies = [
  "habitat_core",
  "ipc-channel",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "nix 0.24.1",
  "prost",
  "semver 1.0.9",
@@ -1193,7 +1193,7 @@ dependencies = [
  "habitat_core",
  "ipc-channel",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "prost",
  "serde",
  "thiserror",
@@ -1216,7 +1216,7 @@ dependencies = [
  "clap",
  "env_logger",
  "habitat_butterfly",
- "log 0.4.16",
+ "log 0.4.17",
 ]
 
 [[package]]
@@ -1227,7 +1227,7 @@ dependencies = [
  "habitat-sup-protocol",
  "habitat_common",
  "habitat_core",
- "log 0.4.16",
+ "log 0.4.17",
  "prost",
  "rustls",
  "termcolor",
@@ -1243,7 +1243,7 @@ dependencies = [
  "bytes",
  "habitat_core",
  "lazy_static 1.4.0",
- "log 0.4.16",
+ "log 0.4.17",
  "prost",
  "prost-build",
  "rand 0.8.5",
@@ -1265,7 +1265,7 @@ dependencies = [
  "futures",
  "habitat_core",
  "habitat_http_client",
- "log 0.4.16",
+ "log 0.4.17",
  "pbr",
  "percent-encoding",
  "rand 0.8.5",
@@ -1289,7 +1289,7 @@ dependencies = [
  "habitat_common",
  "habitat_core",
  "lazy_static 1.4.0",
- "log 0.4.16",
+ "log 0.4.17",
  "mktemp",
  "parking_lot 0.12.0",
  "prometheus",
@@ -1321,7 +1321,7 @@ dependencies = [
  "handlebars 0.28.3",
  "lazy_static 1.4.0",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "native-tls",
  "nix 0.24.1",
  "owning_ref",
@@ -1364,7 +1364,7 @@ dependencies = [
  "hex",
  "lazy_static 1.4.0",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "native-tls",
  "nix 0.24.1",
  "num_cpus",
@@ -1405,7 +1405,7 @@ dependencies = [
  "env_proxy",
  "habitat_core",
  "httparse",
- "log 0.4.16",
+ "log 0.4.17",
  "native-tls",
  "pem 1.0.2",
  "reqwest",
@@ -1429,7 +1429,7 @@ dependencies = [
  "handlebars 0.29.1",
  "lazy_static 1.4.0",
  "linked-hash-map",
- "log 0.4.16",
+ "log 0.4.17",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_ecr",
@@ -1454,7 +1454,7 @@ dependencies = [
  "habitat_core",
  "handlebars 0.29.1",
  "lazy_static 1.4.0",
- "log 0.4.16",
+ "log 0.4.17",
  "mktemp",
  "serde",
  "serde_json",
@@ -1495,7 +1495,7 @@ dependencies = [
  "hyper",
  "lazy_static 1.4.0",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "log4rs",
  "mio 0.7.13",
  "nix 0.24.1",
@@ -1537,7 +1537,7 @@ name = "habitat_win_users"
 version = "0.0.0"
 dependencies = [
  "cc",
- "log 0.4.16",
+ "log 0.4.17",
  "widestring 0.5.1",
  "winapi 0.3.9",
 ]
@@ -1932,14 +1932,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.16",
+ "log 0.4.17",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -1964,7 +1964,7 @@ dependencies = [
  "fnv",
  "humantime",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "log-mdc",
  "parking_lot 0.11.2",
  "regex 1.5.6",
@@ -2088,7 +2088,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "miow 0.2.2",
  "net2",
  "slab",
@@ -2102,7 +2102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
@@ -2115,7 +2115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 dependencies = [
  "lazycell",
- "log 0.4.16",
+ "log 0.4.17",
  "mio 0.6.23",
  "slab",
 ]
@@ -2164,7 +2164,7 @@ checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
 dependencies = [
  "lazy_static 1.4.0",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2357,7 +2357,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d2536ab8ff7605e8dc7044ec2f3eb0d49750cb559af9e5373c4564a3706cdd"
 dependencies = [
- "log 0.4.16",
+ "log 0.4.17",
  "serde",
  "winapi 0.3.9",
 ]
@@ -2660,7 +2660,7 @@ dependencies = [
  "heck 0.4.0",
  "itertools",
  "lazy_static 1.4.0",
- "log 0.4.16",
+ "log 0.4.17",
  "multimap",
  "petgraph",
  "prost",
@@ -2818,7 +2818,7 @@ source = "git+https://github.com/habitat-sh/rants.git#1c2c8674f48aab2166c0016eb1
 dependencies = [
  "bytes",
  "futures",
- "log 0.4.16",
+ "log 0.4.17",
  "native-tls",
  "nom",
  "owning_ref",
@@ -2936,7 +2936,7 @@ dependencies = [
  "ipnet",
  "js-sys",
  "lazy_static 1.4.0",
- "log 0.4.16",
+ "log 0.4.17",
  "mime",
  "native-tls",
  "percent-encoding",
@@ -2992,7 +2992,7 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "lazy_static 1.4.0",
- "log 0.4.16",
+ "log 0.4.17",
  "rusoto_credential",
  "rusoto_signature",
  "rustc_version 0.4.0",
@@ -3049,7 +3049,7 @@ dependencies = [
  "hmac",
  "http",
  "hyper",
- "log 0.4.16",
+ "log 0.4.17",
  "md-5",
  "percent-encoding",
  "pin-project-lite",
@@ -3100,7 +3100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64",
- "log 0.4.16",
+ "log 0.4.17",
  "ring",
  "sct",
  "webpki 0.21.4",
@@ -3801,7 +3801,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
- "log 0.4.16",
+ "log 0.4.17",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -4033,7 +4033,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
- "log 0.4.16",
+ "log 0.4.17",
  "try-lock",
 ]
 
@@ -4069,7 +4069,7 @@ checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static 1.4.0",
- "log 0.4.16",
+ "log 0.4.17",
  "proc-macro2",
  "quote",
  "syn",
@@ -4366,7 +4366,7 @@ source = "git+https://github.com/habitat-sh/rust-zmq?branch=v0.9.2-symlinks-remo
 dependencies = [
  "bitflags",
  "libc",
- "log 0.4.16",
+ "log 0.4.17",
  "zmq-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,18 +257,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 dependencies = [
  "backtrace",
 ]
 
 [[package]]
 name = "arc-swap"
-version = "0.4.8"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
 name = "arrayref"
@@ -839,7 +839,7 @@ checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -1953,9 +1953,9 @@ checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
 
 [[package]]
 name = "log4rs"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1572a880d1115ff867396eee7ae2bc924554225e67a0d3c85c745b3e60ca211"
+checksum = "893eaf59f4bef8e2e94302adf56385db445a0306b9823582b0b8d5a06d8822f3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1966,14 +1966,13 @@ dependencies = [
  "libc",
  "log 0.4.17",
  "log-mdc",
- "parking_lot 0.11.2",
- "regex 1.5.6",
+ "parking_lot 0.12.0",
  "serde",
  "serde-value",
  "serde_json",
  "serde_yaml",
  "thiserror",
- "thread-id 3.3.0",
+ "thread-id",
  "typemap",
  "winapi 0.3.9",
 ]
@@ -2401,7 +2400,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -2416,9 +2415,9 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "petgraph",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "smallvec",
- "thread-id 4.0.0",
+ "thread-id",
  "windows-sys",
 ]
 
@@ -2847,12 +2846,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -2867,7 +2860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.3",
- "redox_syscall 0.2.10",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3569,7 +3562,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.5",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -3626,23 +3619,12 @@ dependencies = [
 
 [[package]]
 name = "thread-id"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
-dependencies = [
- "libc",
- "redox_syscall 0.1.57",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "thread-id"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fdfe0627923f7411a43ec9ec9c39c3a9b4151be313e0922042581fb6c9b717f"
 dependencies = [
  "libc",
- "redox_syscall 0.2.10",
+ "redox_syscall",
  "winapi 0.3.9",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,7 +1177,7 @@ dependencies = [
  "log 0.4.17",
  "nix 0.24.1",
  "prost",
- "semver 1.0.9",
+ "semver 1.0.12",
  "thiserror",
  "winapi 0.3.9",
 ]
@@ -3090,7 +3090,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.9",
+ "semver 1.0.12",
 ]
 
 [[package]]
@@ -3202,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "semver-parser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,7 +1158,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "webpki 0.22.0",
- "widestring 0.5.1",
+ "widestring 1.0.2",
  "winapi 0.3.9",
  "winreg 0.9.0",
 ]
@@ -1391,7 +1391,7 @@ dependencies = [
  "typemap",
  "url",
  "webpki 0.22.0",
- "widestring 0.5.1",
+ "widestring 1.0.2",
  "winapi 0.3.9",
  "windows-acl",
  "xz2",
@@ -1538,7 +1538,7 @@ version = "0.0.0"
 dependencies = [
  "cc",
  "log 0.4.17",
- "widestring 0.5.1",
+ "widestring 1.0.2",
  "winapi 0.3.9",
 ]
 
@@ -4175,9 +4175,9 @@ checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "widestring"
-version = "0.5.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,9 +2321,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-src"
-version = "111.20.0+1.1.1o"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92892c4f87d56e376e469ace79f1128fdaded07646ddf73aa0be4706ff712dec"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,7 +1155,7 @@ dependencies = [
  "tokio",
  "toml 0.5.9",
  "url",
- "uuid",
+ "uuid 1.1.2",
  "walkdir",
  "webpki 0.22.0",
  "widestring 1.0.2",
@@ -1301,7 +1301,7 @@ dependencies = [
  "tempfile",
  "threadpool",
  "toml 0.5.9",
- "uuid",
+ "uuid 1.1.2",
  "winapi 0.3.9",
  "zmq",
 ]
@@ -1341,7 +1341,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml 0.5.9",
- "uuid",
+ "uuid 1.1.2",
  "valico",
  "winapi 0.3.9",
 ]
@@ -1527,7 +1527,7 @@ dependencies = [
  "tokio-util",
  "toml 0.5.9",
  "url",
- "uuid",
+ "uuid 1.1.2",
  "valico",
  "winapi 0.3.9",
 ]
@@ -1769,7 +1769,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "tempfile",
- "uuid",
+ "uuid 0.8.2",
  "winapi 0.3.9",
 ]
 
@@ -2147,7 +2147,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975de676448231fcde04b9149d2543077e166b78fc29eae5aa219e7928410da2"
 dependencies = [
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -2830,7 +2830,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-stream",
  "tokio-util",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3977,6 +3977,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom 0.2.3",
+]
+
+[[package]]
 name = "valico"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,7 +4004,7 @@ dependencies = [
  "serde_json",
  "uritemplate-next",
  "url",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -158,7 +158,7 @@ impl Member {
 
 impl Default for Member {
     fn default() -> Self {
-        Member { id:          Uuid::new_v4().to_simple_ref().to_string(),
+        Member { id:          Uuid::new_v4().as_simple().to_string(),
                  incarnation: Incarnation::default(),
                  // TODO (CM): DANGER DANGER DANGER
                  // This is a lousy default, and suggests that the notion

--- a/components/butterfly/src/rumor.rs
+++ b/components/butterfly/src/rumor.rs
@@ -538,7 +538,7 @@ mod tests {
 
     impl Default for FakeRumor {
         fn default() -> FakeRumor {
-            FakeRumor { id:  format!("{}", Uuid::new_v4().to_simple_ref()),
+            FakeRumor { id:  format!("{}", Uuid::new_v4().as_simple()),
                         key: String::from("fakerton"), }
         }
     }
@@ -579,7 +579,7 @@ mod tests {
 
     impl Default for TrumpRumor {
         fn default() -> TrumpRumor {
-            TrumpRumor { id:  format!("{}", Uuid::new_v4().to_simple_ref()),
+            TrumpRumor { id:  format!("{}", Uuid::new_v4().as_simple()),
                          key: String::from("fakerton"), }
         }
     }

--- a/components/butterfly/src/rumor/heat.rs
+++ b/components/butterfly/src/rumor/heat.rs
@@ -405,7 +405,7 @@ mod tests {
 
     impl Default for FakeRumor {
         fn default() -> FakeRumor {
-            FakeRumor { id:  format!("{}", Uuid::new_v4().to_simple_ref()),
+            FakeRumor { id:  format!("{}", Uuid::new_v4().as_simple()),
                         key: String::from("fakerton"), }
         }
     }


### PR DESCRIPTION
Crate bumps:
Bump log from 0.4.16 to 0.4.17
Bump semver from 1.0.9 to 1.0.12
Bump openssl-src from 111.20.0+1.1.1o to 111.22.0+1.1.1q
Bump widestring from 0.5.1 to 1.0.2
Bump uuid from 0.8.2 to 1.1.2
Bump log4rs from 1.0.0 to 1.1.1
Bump anyhow from 1.0.42 to 1.0.58

The following PRs can be closed after this PR completes.
https://github.com/habitat-sh/habitat/pull/8512
https://github.com/habitat-sh/habitat/pull/8558
https://github.com/habitat-sh/habitat/pull/8560
https://github.com/habitat-sh/habitat/pull/8563
https://github.com/habitat-sh/habitat/pull/8546
https://github.com/habitat-sh/habitat/pull/8549
