### PR TITLE
Address protoc availability during release builds

### DIFF
--- a/.expeditor/scripts/release_habitat/build_arm_hab_binary.sh
+++ b/.expeditor/scripts/release_habitat/build_arm_hab_binary.sh
@@ -8,7 +8,7 @@ source .expeditor/scripts/release_habitat/shared.sh
 export DEBIAN_FRONTEND=noninteractive
 
 # Ensure all build and test dependencies are installed
-apt-get update && apt-get install -y ca-certificates sudo gcc libc6-dev wget openssl make pkg-config libzmq3-dev curl cmake
+apt-get update && apt-get install -y ca-certificates sudo gcc libc6-dev wget openssl make pkg-config libzmq3-dev curl cmake protobuf-compiler
 
 # Build all binaries
 cargo build --release

--- a/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
+++ b/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
@@ -11,6 +11,10 @@ eval "$(vault-util fetch-secret-env)"
 export HAB_AUTH_TOKEN="${PIPELINE_HAB_AUTH_TOKEN}"
 export HAB_BLDR_URL="${PIPELINE_HAB_BLDR_URL}"
 
+
+echo "--- Executing: brew install protobuf"
+brew install protobuf
+
 channel=$(get_release_channel)
 
 echo "--- Channel: $channel - bldr url: $HAB_BLDR_URL"


### PR DESCRIPTION
Added apt and brew commands to make protoc available for linux and macOS on release builds