### PR TITLE
support windows 2022 docker images

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -470,6 +470,14 @@ steps:
         windows:
           os_version: 2019
 
+  - label: ":docker: :windows: Upload windows 2022 container to Docker Hub"
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1
+    expeditor:
+      executor:
+        windows:
+          os_version: 2022
+
   - wait
 
   - label: "[:habicat: Generate Manifest and promote to dev channel]"

--- a/.expeditor/scripts/release_habitat/build_docker_image.ps1
+++ b/.expeditor/scripts/release_habitat/build_docker_image.ps1
@@ -29,6 +29,7 @@ function Get-DefaultTagForHost {
             17134 { "1803" }
             17763 { "ltsc2019" }
             18362 { "1903" }
+            20348 { "ltsc2022" }
             Default { Write-Error "Cannot determine the base image tag for this windows build ${osVersion.Build}" }
         }
     }

--- a/components/core/src/util/docker.rs
+++ b/components/core/src/util/docker.rs
@@ -24,9 +24,10 @@ pub fn default_base_tag_for_host() -> Result<&'static str> {
         let info = os_info::get();
 
         if String::from_utf8(result.stdout)?.trim() == "'hyperv'" {
-            // hyperv isolation can build any version so we will default to 2019
-            // if the host supports it, otherwise 2016
-            if *info.version() >= Semantic(10, 0, 17763) {
+            // Match hyperv windows image with host kernel
+            if *info.version() >= Semantic(10, 0, 20348) {
+                Ok("ltsc2022")
+            } else if *info.version() >= Semantic(10, 0, 17763) {
                 Ok("ltsc2019")
             } else {
                 Ok("ltsc2016")
@@ -37,6 +38,7 @@ pub fn default_base_tag_for_host() -> Result<&'static str> {
                 Semantic(10, 0, 17134) => Ok("1803"),
                 Semantic(10, 0, 17763) => Ok("ltsc2019"),
                 Semantic(10, 0, 18362) => Ok("1903"),
+                Semantic(10, 0, 20348) => Ok("ltsc2022"),
                 unsupported_version => {
                     Err(Error::UnsupportedDockerHostKernel(unsupported_version.to_string()))
                 }


### PR DESCRIPTION
The docker studio on windows 11 is not running the supervisor in a service due to perm issues and the supervisor logs are not renderable. If I build using ltsc2022, this fixes it.

We still need expeditor support to officially release them.

Signed-off-by: Matt Wrock <matt@mattwrock.com>