### PR TITLE
add SYSTEM ACL to /hab/svc in docker studio

### DIFF
--- a/.expeditor/scripts/release_habitat/build_docker_image.ps1
+++ b/.expeditor/scripts/release_habitat/build_docker_image.ps1
@@ -95,7 +95,12 @@ RUN `$env:HAB_LICENSE='accept-no-persist'; ``
     &/hab/pkgs/$ident/bin/hab/hab.exe pkg install core/windows-service --channel=$ReleaseChannel --url=$BldrUrl; ``
     (Get-Content /hab/svc/windows-service/HabService.dll.config).replace('--no-color', '') | Set-Content /hab/svc/windows-service/HabService.dll.config; ``
     (Get-Content /hab/svc/windows-service/log4net.xml).replace('%date - ', '') | Set-Content /hab/svc/windows-service/log4net.xml; ``
-    Remove-Item /hab/cache -Recurse -Force
+    Remove-Item /hab/cache -Recurse -Force; ``
+    `$acl = get-acl C:/hab/svc; ``
+    `$new='NT AUTHORITY\SYSTEM','FullControl','ContainerInherit,ObjectInherit','None','Allow'; ``
+    `$accessRule = new-object System.Security.AccessControl.FileSystemAccessRule `$new; ``
+    `$acl.AddAccessRule(`$accessRule); ``
+    `$acl | Set-Acl C:/hab/svc
 ENTRYPOINT ["/hab/pkgs/$ident/bin/powershell/pwsh.exe", "-ExecutionPolicy", "bypass", "-NoLogo", "-file", "/hab/pkgs/$ident/bin/hab-studio.ps1"]
 "@ | Out-File "$tmpRoot/Dockerfile" -Encoding ascii
 


### PR DESCRIPTION
Signed-off-by: Matt Wrock <matt@mattwrock.com>

The LocalSystem account that the Habitat windows service runs under is failing when started with an Access Denied error. After digging further this is due to a missing ACL in /hab/svc and its child files and folders for `NT AUTHORITY\SYSTEM`. Adding this ACL recursively fixes the Access Denied error.

It is still unclear why this recently started. I'm assuming it is only related to Windows 11 because my laptop upgraded around the time this started happening. Also perplexing is why if I build the image locally, the ACL gets added automatically but not on the buildkite server. My suspicion is this is related to building on a client SKU (win 11) vs a server SKU (server 2022) which has slightly different rules for default folder ACLs.