### PR TITLE
Fix windows 7 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "ipc-channel"
-version = "0.16.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb1d9211085f0ea6f1379d944b93c4d07e8207aa3bcf49f37eda12b85081887"
+checksum = "ad9b32d360ae2d4662212f1d29bc8a277256f49029cea20fd6c182b89819aea7"
 dependencies = [
  "bincode",
  "crossbeam-channel 0.4.4",

--- a/components/launcher-client/Cargo.toml
+++ b/components/launcher-client/Cargo.toml
@@ -11,7 +11,13 @@ env_logger = "*"
 habitat_core = { path = "../core" }
 habitat-launcher-protocol = { path = "../launcher-protocol" }
 habitat_common = { path = "../common" }
-ipc-channel = { version = "*" }
+# TODO: In order to support certain customers who are still using Windows 7 until
+# January 2024, it is necessary to freeze the version of this crate at 0.15.0. 
+# Newer versions of this crate use a Windows syscall called 'GetOverlappedResultEx',
+# which is not supported on versions of Windows prior to 8. 
+# For more information about 'GetOverlappedResultEx', please refer to the following documentation: https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getoverlappedresultex
+# The commit that introduced the change can be found here: https://github.com/servo/ipc-channel/commit/eb08381a30bc71a534a0a73ab98c05bca7a12f82
+ipc-channel = { version = "0.15.0" }
 libc = "*"
 log = "*"
 prost = "*"

--- a/components/launcher-client/src/error.rs
+++ b/components/launcher-client/src/error.rs
@@ -1,5 +1,7 @@
 use habitat_launcher_protocol as protocol;
-use std::io;
+use ipc_channel::ipc::IpcError;
+use std::{fmt,
+          io};
 use thiserror::Error;
 
 /// Errors that occur when attempting to estabish an IPC channel to the Habitat Launcher
@@ -64,7 +66,7 @@ pub enum ReceiveError {
     #[error("Failed to read launcher command response")]
     IPCRead(#[from] IPCReadError),
     #[error("Failed to receive IPC command response from launcher")]
-    IPCReceive(#[from] ipc_channel::ipc::IpcError),
+    IPCReceive(#[from] IPCError),
 }
 
 /// Errors that occur when attempting to non-blocking receive command responses from the Habitat
@@ -74,7 +76,39 @@ pub enum TryReceiveError {
     #[error("Failed to try reading launcher command response")]
     IPCRead(#[from] IPCReadError),
     #[error("Failed to try receiving IPC command response from launcher")]
-    IPCReceive(#[from] ipc_channel::ipc::IpcError),
+    IPCReceive(#[from] IPCError),
     #[error("Timed out trying to receive IPC command response from launcher")]
     Timeout,
+}
+
+// TODO: Remove this wrapper type once we upgrade ipc-channel to 0.16+
+// This is a wrapper type around the ipc_channel::ipc::IpcError that is
+// required because it does not implement std::error::Error prior to
+// version 0.16+. We need an older version of the crate to ensure that
+// habitat works for some of our customers using Windows 7 until Jan 2024.
+#[derive(Debug)]
+pub struct IPCError(pub ipc_channel::ipc::IpcError);
+
+impl From<ipc_channel::ipc::IpcError> for IPCError {
+    fn from(value: ipc_channel::ipc::IpcError) -> Self { IPCError(value) }
+}
+
+impl fmt::Display for IPCError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self.0 {
+            IpcError::Bincode(ref err) => write!(fmt, "bincode error: {}", err),
+            IpcError::Io(ref err) => write!(fmt, "io error: {}", err),
+            IpcError::Disconnected => write!(fmt, "disconnected"),
+        }
+    }
+}
+
+impl std::error::Error for IPCError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self.0 {
+            IpcError::Bincode(ref err) => Some(err),
+            IpcError::Io(ref err) => Some(err),
+            IpcError::Disconnected => None,
+        }
+    }
 }

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -15,7 +15,13 @@ env_logger = "*"
 habitat_common = { path = "../common" }
 habitat_core = { path = "../core" }
 habitat-launcher-protocol = { path = "../launcher-protocol" }
-ipc-channel = { version = "*" }
+# TODO: In order to support certain customers who are still using Windows 7 until
+# January 2024, it is necessary to freeze the version of this crate at 0.15.0. 
+# Newer versions of this crate use a Windows syscall called 'GetOverlappedResultEx',
+# which is not supported on versions of Windows prior to 8. 
+# For more information about 'GetOverlappedResultEx', please refer to the following documentation: https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getoverlappedresultex
+# The commit that introduced the change can be found here: https://github.com/servo/ipc-channel/commit/eb08381a30bc71a534a0a73ab98c05bca7a12f82
+ipc-channel = { version = "0.15.0" }
 libc = "*"
 log = "*"
 prost = "*"


### PR DESCRIPTION
* The version of the "ipc-channel" crate is frozen at 0.15.0 to avoid the usage of the "GetOverlappedResultEx" system call, which was introduced in version 0.16.0.
* An error type wrapper named "IPCError" is created around "ipc_channel::ipc::IpcError" because it does not implement the "std::error::Error" trait, which is required to use it with the "#[from]" attribute of the "thiserror" crate's "Error" derive macro.

It is important to note that these changes should ideally be reverted once support for Windows 7 is discontinued around January 2024. This will allow for the usage of the "GetOverlappedResultEx" system call and the "ipc_channel::ipc::IpcError" trait. More information about "GetOverlappedResultEx" can be found at the following link: https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getoverlappedresultex And the information about the commit that introduced the change can be found at: https://github.com/servo/ipc-channel/commit/eb08381a30bc71a534a0a73ab98c05bca7a12f82

Signed-off-by: Johny Jose <johny.jose@progress.com>