### PR TITLE
fixes rolling update leader resetting pkg_incarnation

### DIFF
--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -1093,7 +1093,7 @@ impl Service {
         (template_data_changed, template_update)
     }
 
-    pub fn to_rumor(&self, incarnation: u64, pkg_incarnation: Option<u64>) -> ServiceRumor {
+    pub fn to_rumor(&self, incarnation: u64, pkg_incarnation: u64) -> ServiceRumor {
         let exported = match self.cfg.to_exported(&self.pkg) {
             Ok(exported) => Some(exported),
             Err(err) => {
@@ -1109,9 +1109,7 @@ impl Service {
                                           self.sys.as_sys_info(),
                                           exported);
         rumor.incarnation = incarnation;
-        if let Some(pi) = pkg_incarnation {
-            rumor.pkg_incarnation = pi;
-        }
+        rumor.pkg_incarnation = pkg_incarnation;
         rumor
     }
 


### PR DESCRIPTION
During rolling updates, the update worker relies on the value of the service group's "pkg_incarnation" to determine if an update has occurred. If a leader in the group has a higher pkg_incarnation than the followers, the followers will update to the leader's package.

This commit addresses a bug that caused a leader to reset it's pkg_incarnation to 0 in certain scenarios, resulting in followers remaining in a perpetual state of waiting for the leader to catch up to the latest pkg_incarnation.

Signed-off-by: Johny Jose <johny.jose@progress.com>