### PR TITLE
force basic rolling update/rollback e2e to terminate process

### DIFF
--- a/test-services/force-kill/hooks/run
+++ b/test-services/force-kill/hooks/run
@@ -1,0 +1,11 @@
+_term() {
+  echo "run hook is terminating"
+  sleep 30
+}
+
+trap _term TERM
+
+while true; do
+      echo "Working"
+      sleep 3
+done

--- a/test-services/force-kill/plan.sh
+++ b/test-services/force-kill/plan.sh
@@ -1,0 +1,7 @@
+pkg_name="force-kill"
+pkg_origin="habitat-testing"
+pkg_version="0.1.0"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+
+do_build() { :; }
+do_install() { :; }

--- a/test/end-to-end/multi-supervisor/testcases/rolling_update/docker-compose.override.yml
+++ b/test/end-to-end/multi-supervisor/testcases/rolling_update/docker-compose.override.yml
@@ -9,12 +9,62 @@ services:
       - bastion
       - alpha
       - beta
+      - gamma1
+      - gamma2
+      - gamma3
   alpha:
     environment:
       HAB_UPDATE_STRATEGY_FREQUENCY_MS: 3000
       HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK: 1
+      RUST_LOG: habitat_sup::manager::service_updater=debug
 
   beta:
     environment:
       HAB_UPDATE_STRATEGY_FREQUENCY_MS: 3000
       HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK: 1
+      RUST_LOG: habitat_sup::manager::service_updater=debug
+
+  gamma1:
+    extends:
+      service: sup_base
+    hostname: gamma1
+    environment:
+      HAB_UPDATE_STRATEGY_FREQUENCY_MS: 3000
+      HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK: 1
+      RUST_LOG: habitat_sup::manager::service_updater=debug
+    networks:
+      default:
+        aliases:
+        - gamma1.habitat.dev
+    depends_on:
+      - bastion
+
+  gamma2:
+    extends:
+      service: sup_base
+    hostname: gamma2
+    environment:
+      HAB_UPDATE_STRATEGY_FREQUENCY_MS: 3000
+      HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK: 1
+      RUST_LOG: habitat_sup::manager::service_updater=debug
+    networks:
+      default:
+        aliases:
+        - gamma2.habitat.dev
+    depends_on:
+      - bastion
+
+  gamma3:
+    extends:
+      service: sup_base
+    hostname: gamma3
+    environment:
+      HAB_UPDATE_STRATEGY_FREQUENCY_MS: 3000
+      HAB_UPDATE_STRATEGY_FREQUENCY_BYPASS_CHECK: 1
+      RUST_LOG: habitat_sup::manager::service_updater=debug
+    networks:
+      default:
+        aliases:
+        - gamma3.habitat.dev
+    depends_on:
+      - bastion

--- a/test/end-to-end/multi-supervisor/testcases/rolling_update/run_test.ps1
+++ b/test/end-to-end/multi-supervisor/testcases/rolling_update/run_test.ps1
@@ -1,19 +1,24 @@
 # This is a simple "happy path" test of a rolling update.
-# We will load services on two nodes to achieve quorum and
-# then promote an update and expect the new release to show
-# up after waiting 15 seconds. Note: we set HAB_UPDATE_STRATEGY_FREQUENCY_MS
-# to 3000 in the docker-compose.override.yml.
+# We will load services on five nodes then promote an update and expect the new release to show
+# up after waiting 15 seconds. Then we demote the package and validate that the nodes
+# rolled back. The package will "hang" upon receiving its SIGTERM which will trigger the supervisor
+# to forcefully terminate the service. This tests an edge case where the package incarnation was being
+# reset to 0 and causing nodes to get stuck and not update or roll back.
+# Note: we set HAB_UPDATE_STRATEGY_FREQUENCY_MS to 3000 in the docker-compose.override.yml.
 
 $testChannel = "rolling-$([DateTime]::Now.Ticks)"
 
 Describe "Rolling Update and Rollback" {
-    $initialRelease="habitat-testing/nginx/1.17.4/20191115184838"
-    $updatedRelease="habitat-testing/nginx/1.17.4/20191115185517"
+    $initialRelease="habitat-testing/force-kill/0.1.0/20230214152940"
+    $updatedRelease="habitat-testing/force-kill/0.1.0/20230214154036"
     hab pkg promote $initialRelease $testChannel
-    Load-SupervisorService "habitat-testing/nginx" -Remote "alpha.habitat.dev" -Topology leader -Strategy rolling -UpdateCondition "track-channel" -Channel $testChannel
-    Load-SupervisorService "habitat-testing/nginx" -Remote "beta.habitat.dev" -Topology leader -Strategy rolling -UpdateCondition "track-channel" -Channel $testChannel
+    Load-SupervisorService "habitat-testing/force-kill" -Remote "alpha.habitat.dev" -Topology leader -Strategy rolling -UpdateCondition "track-channel" -Channel $testChannel
+    Load-SupervisorService "habitat-testing/force-kill" -Remote "beta.habitat.dev" -Topology leader -Strategy rolling -UpdateCondition "track-channel" -Channel $testChannel
+    Load-SupervisorService "habitat-testing/force-kill" -Remote "gamma1.habitat.dev" -Topology leader -Strategy rolling -UpdateCondition "track-channel" -Channel $testChannel
+    Load-SupervisorService "habitat-testing/force-kill" -Remote "gamma2.habitat.dev" -Topology leader -Strategy rolling -UpdateCondition "track-channel" -Channel $testChannel
+    Load-SupervisorService "habitat-testing/force-kill" -Remote "gamma3.habitat.dev" -Topology leader -Strategy rolling -UpdateCondition "track-channel" -Channel $testChannel
 
-    @("alpha", "beta") | ForEach-Object {
+    @("alpha", "beta", "gamma1", "gamma2", "gamma3") | ForEach-Object {
         It "loads initial release on $_" {
             Wait-Release -Ident $initialRelease -Remote $_
         }
@@ -22,7 +27,7 @@ Describe "Rolling Update and Rollback" {
     Context "promote update" {
         hab pkg promote $updatedRelease $testChannel
 
-        @("alpha", "beta") | ForEach-Object {
+        @("alpha", "beta", "gamma1", "gamma2", "gamma3") | ForEach-Object {
             It "updates release on $_" {
                 Wait-Release -Ident $updatedRelease -Remote $_
             }
@@ -32,7 +37,7 @@ Describe "Rolling Update and Rollback" {
     Context "demote update" {
         hab pkg demote $updatedRelease $testChannel
 
-        @("alpha", "beta") | ForEach-Object {
+        @("alpha", "beta", "gamma1", "gamma2", "gamma3") | ForEach-Object {
             It "rollback release on $_" {
                 Wait-Release -Ident $initialRelease -Remote $_
             }


### PR DESCRIPTION
This tests the edge case where a follower node was not updating/rolling back if the service does not gracefully exit and there are 5 or more nodes in the rolling update/rollback.

Before finalizing this PR, I hacked the test harness to test against the old 1.6.607 supervisor and validated that it was repeatedly failing on that supervisor with the expected log messages we were seeing in the broken state.