### PR TITLE
fix credentials for creating github release

### DIFF
--- a/.expeditor/finish_release.pipeline.yml
+++ b/.expeditor/finish_release.pipeline.yml
@@ -20,7 +20,7 @@ steps:
     expeditor:
       secrets:
         GITHUB_TOKEN:
-          account: github
+          account: github/habitat-sh
           field: token
       executor:
         docker:


### PR DESCRIPTION
This was something that broke in the last release (https://buildkite.com/chef/habitat-sh-habitat-main-finish-release/builds/137#01862d57-59a9-4458-adab-00b8d4d595a1).

Other jobs that succeeded to auth with github use `github/habitat-sh` instead of `habitat-sh`.