### PR TITLE
remove checks for empty events in specwatcher tests

### DIFF
--- a/components/sup/src/manager/spec_watcher.rs
+++ b/components/sup/src/manager/spec_watcher.rs
@@ -192,9 +192,6 @@ mod tests {
         while !sw.has_events() {
             wait_for_debounce_interval();
         }
-
-        assert!(!sw.has_events(),
-                "Should be no more events after you've checked");
     }
 
     /// Currently, the spec watcher will respond to changes to any
@@ -218,9 +215,6 @@ mod tests {
         while !sw.has_events() {
             wait_for_debounce_interval();
         }
-
-        assert!(!sw.has_events(),
-                "Should be no more events after you've checked");
     }
 
     #[test]
@@ -243,8 +237,5 @@ mod tests {
         while !sw.has_events() {
             wait_for_debounce_interval();
         }
-
-        assert!(!sw.has_events(),
-                "Should be no more events after you've checked");
     }
 }


### PR DESCRIPTION
The SpecWatcher tests fail pretty frequently on ARM when checking that all the events have been processed. Now that the notify crate no longer supports DebouncedEvents, we are getting each specific event and thus there are often more events. This check really is not necessary or helpful.