### PR TITLE
bump tokio and add dep contraints for winapi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3563,9 +3563,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3573,13 +3573,12 @@ dependencies = [
  "memchr",
  "mio 0.8.6",
  "num_cpus",
- "once_cell",
  "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi 0.3.9",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "*", features = ["v4"] }
 zmq = { git = "https://github.com/habitat-sh/rust-zmq", branch = "v0.9.2-symlinks-removed" }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "*", features = ["handleapi", "winbase"] }
+winapi = { version = "^0.3", features = ["handleapi", "winbase"] }
 
 [dev-dependencies]
 mktemp = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -53,7 +53,7 @@ valico = "*"
 nix = "*"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "*", features = ["consoleapi", "processenv"] }
+winapi = { version = "^0.3", features = ["consoleapi", "processenv"] }
 
 [features]
 default = []

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -55,7 +55,7 @@ caps = "*"
 ctrlc = "*"
 habitat_win_users = { path = "../win-users" }
 widestring = "*"
-winapi = { version = "*", features = ["dpapi", "ioapiset", "namedpipeapi", "userenv", "winbase", "wincrypt", "winerror"] }
+winapi = { version = "^0.3", features = ["dpapi", "ioapiset", "namedpipeapi", "userenv", "winbase", "wincrypt", "winerror"] }
 windows-acl = "*"
 
 [dev-dependencies]

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -62,7 +62,7 @@ features = ["v4"]
 
 [target.'cfg(windows)'.dependencies]
 widestring = "*"
-winapi = { version = "*", features = ["winuser", "windef"] }
+winapi = { version = "^0.3", features = ["winuser", "windef"] }
 winreg = "*"
 
 [features]

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -33,4 +33,4 @@ anyhow = { version = "*", features = ["backtrace"] }
 nix = "*"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "*", features = ["tlhelp32"] }
+winapi = { version = "^0.3", features = ["tlhelp32"] }

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -77,8 +77,8 @@ notify = { version = "*", default-features = false }
 ctrlc = "*"
 habitat-launcher-protocol = { path = "../launcher-protocol" }
 notify = { version = "*", default-features = false }
-mio = { version = "*", features = ["os-ext"] }
-winapi = { version = "*", features = ["namedpipeapi", "tlhelp32"] }
+mio = { version = "^0.8", features = ["os-ext"] }
+winapi = { version = "^0.3", features = ["namedpipeapi", "tlhelp32"] }
 
 [dev-dependencies]
 habitat_core = { path = "../core" }

--- a/components/win-users/Cargo.toml
+++ b/components/win-users/Cargo.toml
@@ -15,4 +15,4 @@ log = "*"
 
 [target.'cfg(windows)'.dependencies]
 widestring = "*"
-winapi = { version = "*", features = ["winbase", "winerror", "handleapi", "sddl", "securitybaseapi"] }
+winapi = { version = "^0.3", features = ["winbase", "winerror", "handleapi", "sddl", "securitybaseapi"] }


### PR DESCRIPTION
This gets rid of a couple more security alerts. I had to add the winapi and mio constraints because otherwise `cargo update` gets confused.