### PR TITLE
acquire lock for cache_key to fix a flaky unit test

### DIFF
--- a/components/sup/src/main.rs
+++ b/components/sup/src/main.rs
@@ -1261,6 +1261,9 @@ sys_ip_address = "7.8.9.0"
 
         #[test]
         fn test_hab_sup_run_config_file_peer() {
+            let lock = lock_var();
+            lock.unset();
+
             let temp_dir = TempDir::new().expect("Could not create tempdir");
 
             // Setup config file


### PR DESCRIPTION
I've been seeing this test fail a lot on arm because the cache key on both sides of the assert is different. This should fix that.