### PR TITLE
run arm builds in --release mode to reduce memory

### DIFF
--- a/.expeditor/scripts/verify/run_native_cargo_test.sh
+++ b/.expeditor/scripts/verify/run_native_cargo_test.sh
@@ -15,7 +15,7 @@ useradd -rm -d /home/$TEST_USER -s /bin/bash -g root -G sudo -u 1001 $TEST_USER
 chown -R ubuntu:root /workdir
 
 # Build binaries to be used in integration test
-sudo -u $TEST_USER -H -E --preserve-env=PATH bash -c "cargo build"
+sudo -u $TEST_USER -H -E --preserve-env=PATH bash -c "cargo build --release"
 
 # Run all test cases without stopping for failures
-sudo -u $TEST_USER -H -E --preserve-env=PATH bash -c "cargo test --no-fail-fast"
+sudo -u $TEST_USER -H -E --preserve-env=PATH bash -c "cargo test --release --no-fail-fast"


### PR DESCRIPTION
Our ARM verify builds have been failing quite a bit over the past couple weeks with this linking error:

```
= note: collect2: fatal error: ld terminated with signal 9 [Killed]
--
  | compilation terminated.
```

After some research, it looks like this is related to OOM issues on the box. A few suggestions prevail:

* add memory (duh)
* use `--jobs 1` in cargo build and test but this can increase the build time quite a bit.
* use `--release` in the build which requires less memory than `--debug`

This PR opts for the third option above since it is the least impactful and our build does not need any debug symbols.