### PR TITLE
Correction to audit.toml used by `cargo audit` 

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -27,7 +27,7 @@ severity_threshold = "none" # CVSS severity ("none", "low", "medium", "high", "c
 
 # Advisory Database Configuration
 [database]
-path = "~/.cargo/advisory-db" # Path where advisory git repo will be cloned
+path = ".cargo/advisory-db" # Path where advisory git repo will be cloned
 url = "https://github.com/RustSec/advisory-db.git" # URL to git repo
 fetch = true # Perform a `git fetch` before auditing (default: true)
 stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: false)

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rustfmt
 *.sig.key
 *.sym.key
+.cargo/advisory-db/
 .DS_Store
 .envrc
 .secrets


### PR DESCRIPTION
I was attempting to write the advisory db to ~/.cargo but `cargo audit` was writing to $HAB_REPO/~/.cargo/advisory-db/ instead. Changed .cargo/audit.toml to write the advisory db to .cargo/advisory-db/ instead and added that directory to the .gitignore.