### PR TITLE
bumped buildkit timeout from 30 to 60 

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,7 +1,7 @@
 expeditor:
   defaults:
     buildkite:
-      timeout_in_minutes: 30
+      timeout_in_minutes: 60
 
 steps:
 #######################################################################
@@ -16,7 +16,7 @@ steps:
     plugins:
       - docker#v3.13.0:
           image: "rust:1.62.1-buster"
-  
+
   - label: "[lint] :linux: :bash: Shellcheck"
     command:
       - .expeditor/scripts/verify/shellcheck.sh


### PR DESCRIPTION
I asked Sean Simmons about the ARM builds that were consistently failing all day.  He suggested that I bump the buildkit timeout from 30 to 60.  In so doing several whitespace formatting changes came along.  I believe that's due to my having installed Red Hat's YAML plugin which did the formatting on file save.  I can scrap those but thought I would initially submit this with them in place.