### PR TITLE
Restore notify crate for all OSes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,7 +2286,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58ea850aa68a06e48fdb069c0ec44d0d64c8dbffa49bf3b6f7f0a901fdea1ba9"
 dependencies = [
  "bitflags",
+ "crossbeam-channel 0.5.1",
  "filetime",
+ "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -39,6 +39,7 @@ libc = "*"
 log = "*"
 log4rs = "*"
 multimap = "*"
+notify = "*"
 num_cpus = "*"
 parking_lot = "*"
 pin-project = "*"
@@ -71,12 +72,10 @@ valico = "*"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "*"
-notify = { version = "*", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 ctrlc = "*"
 habitat-launcher-protocol = { path = "../launcher-protocol" }
-notify = { version = "*", default-features = false }
 mio = { version = "^0.8", features = ["os-ext"] }
 winapi = { version = "^0.3", features = ["namedpipeapi", "tlhelp32"] }
 


### PR DESCRIPTION
When I did the work on the notify crate I tried to limit dependencies we weren't directly relying on by specifying it as a dependency for linux and widows without default features.  This broke the build on macOS and this commit puts it back as a unbounded dependency for all OSes with its defaults.