### PR TITLE
fix flaky pkg uninstall e2e test 

### DIFF
--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -281,6 +281,7 @@ Function Invoke-BuildAndInstall($PackageName) {
     Invoke-Build $PackageName
     . ./results/last_build.ps1
     hab pkg install ./results/$pkg_artifact
+    hab studio run "rm /hab/pkgs/$pkg_ident/hooks"
 }
 
 function Stop-ComposeSupervisor($Remote) {


### PR DESCRIPTION
The linux pkg_uninstall_hook e2e test was failing about a third of the time. It ends up that in one of the tests where 2 on the fly builds are performed, if those builds are done within a second of each other and get the same release time stamp, the second build fails because the hooks directory from the previous hook is still there and the build thinks it is trying to save 2 uninstall hooks.

This removes that directory after the build. We don't need it. We just want the hart file.