### PR TITLE
Docs Hab landing page

### DIFF
--- a/components/docs-chef-io/config.toml
+++ b/components/docs-chef-io/config.toml
@@ -1,2 +1,79 @@
 [params.habitat]
 gh_path = "https://github.com/habitat-sh/habitat/tree/main/components/docs-chef-io/content/"
+
+####
+# Chef Habitat Menu
+####
+
+[[menu.habitat]]
+title = "Chef Habitat"
+identifier = "habitat"
+
+  [[menu.habitat]]
+  title = "Install Habitat"
+  identifier = "habitat/install"
+  parent = "habitat"
+  weight = 15
+
+  [[menu.habitat]]
+  title = "Builder"
+  identifier = "habitat/builder"
+  parent = "habitat"
+  weight = 20
+
+  [[menu.habitat]]
+  title = "Origins"
+  identifier = "habitat/origins"
+  parent = "habitat"
+  weight = 30
+
+  [[menu.habitat]]
+  title = "Packages"
+  identifier = "habitat/packages"
+  parent = "habitat"
+  weight = 40
+
+  [[menu.habitat]]
+  title = "Plans"
+  identifier = "habitat/plans"
+  parent = "habitat"
+  weight = 50
+
+  [[menu.habitat]]
+  title = "Services"
+  identifier = "habitat/services"
+  parent = "habitat"
+  weight = 60
+
+  [[menu.habitat]]
+  title = "Supervisors"
+  identifier = "habitat/supervisors"
+  parent = "habitat"
+  weight = 70
+
+  [[menu.habitat]]
+  title = "Reference"
+  identifier = "habitat/reference"
+  parent = "habitat"
+  weight = 90
+
+    [[menu.habitat]]
+    title = "API"
+    identifier = "habitat/reference/api"
+    parent = "habitat/reference"
+
+  [[menu.habitat]]
+  title = "Containers"
+  identifier = "habitat/containers"
+  parent = "habitat"
+  weight = 200
+
+  [[menu.habitat]]
+  title = "Diagrams"
+  identifier = "habitat/diagrams"
+  parent = "habitat"
+  weight = 500
+
+####
+# End Chef Habitat Menu
+####

--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -33,7 +33,7 @@ For more information, see the [Chef Habitat Builder]({{< relref "/habitat/builde
 
 ### Habitat Package
 
-A Habitat Package is an artifact that contains the application codebase, lifecycle hooks, and build dependencies of the application.
+A Habitat Package is an artifact that contains the application codebase, lifecycle hooks, and a manifest that defines build and runtime dependencies of the application.
 The package is bundled into a Habitat Artifact (.HART) file, which is a binary distribution of a given package built with Chef Habitat.
 The package is immutable and cryptographically signed with a key so you can verify that the artifact came from the place you expected it to come from.
 Artifacts can be exported to run in a variety of runtimes with zero refactoring or rewriting.

--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -1,5 +1,5 @@
 +++
-title = "About Chef Habitat"
+title = "Chef Habitat Overview"
 aliases = ["/habitat/reference/", "/habitat/glossary/", "/habitat/diagrams/"]
 gh_repo = "habitat"
 
@@ -8,39 +8,101 @@ gh_repo = "habitat"
 
 [menu]
   [menu.habitat]
-    title = "About Chef Habitat"
-    identifier = "habitat/About Chef Habitat"
+    title = "Overview"
+    identifier = "habitat/Overview"
     parent = "habitat"
-    weight = 5
+    weight = 1
 +++
 
-Chef Habitat centers application configuration, management, and behavior around the application itself, not the infrastructure that the app runs on.
-It provides automation that can programmatically and declaratively build, deploy, and manage your application and services, both stateful and stateless.
-You can deploy and run your Chef Habitat app on many different infrastructure environments including bare metal, VM, containers, and PaaS.
+Chef Habitat is a workload-packaging, orchestration, and deployment system that allows you to build, package, deploy, and manage applications and services without worrying about which infrastructure your application will deploy on, and without any rewriting or refactoring if you switch to a different infrastructure.
 
-## Chef Habitat Builder
+Habitat separates the platform-independent parts of your application—the build dependencies, runtime dependencies, lifecycle events, and application codebase—from the operating system or deployment environment that the application will run on, and bundles it into an immutable Habitat Package.
+The package is sent to the Chef Habitat Builder (SaaS or on-prem), which acts as a package store like Docker Hub where you can store, build, and deploy your Habitat package.
+Habitat Supervisor pulls packages from Habitat Builder, and will start, stop, run, monitor, and update your application based on the plan and lifecycle hooks you define in the package.
+Habitat Supervisor runs on bare metal, virtual machines, containers, or Platform-as-a-Service environments.
+A package under management by a Supervisor is called a service.
+Services can be joined together in a service group, which is a collection of services with the same package and topology type that are connected together across a Supervisor network.
 
-[Chef Habitat Builder]({{< relref "builder_overview" >}}) acts as the core of Chef's Application Delivery Enterprise hub. You can run Chef Habitat Builder as a cloud-based service or on-premises.
+## Components
 
-Chef Habitat Builder provides package storage, search, and an API for clients.
+### Habitat Builder
 
-The contents of your app are stored in the Chef Habitat Builder SaaS, where the Chef Habitat community can view and access them. You can also use the on-prem version of Chef Habitat Builder, where you can store and maintain your apps locally.
+{{< readfile file="content/habitat/reusable/md/habitat_builder_overview.md" >}}
 
-## Plans
+For more information, see the [Chef Habitat Builder]({{< relref "/habitat/builder_overview" >}}) documentation.
 
-A [plan]({{< relref "plan_writing" >}}) is the file where you define how you will build, deploy, and manage your app. A plan file is named `plan.sh` for Linux systems or `plan.ps1` for Windows, and your app can have plan files for both Linux and Windows operating systems. You can find your plan file in the `habitat` directory, which you install at the root of your app with `hab plan init`.
+### Habitat Package
 
-## Supervisor
+A Habitat Package is an artifact that contains the application codebase, lifecycle hooks, and build dependencies of the application.
+The package is bundled into a Habitat Artifact (.HART) file, which is a binary distribution of a given package built with Chef Habitat.
+The package is immutable and cryptographically signed with a key so you can verify that the artifact came from the place you expected it to come from.
+Artifacts can be exported to run in a variety of runtimes with zero refactoring or rewriting.
 
-A Supervisor is a process manager that runs the app packages that you defined in your plan. A Supervisor has two primary responsibilities:
+### Plan
 
-1. A Supervisor is a process manager and is responsible for running your app's services. It starts, stops, updates, and monitors the services according to your plan.
-1. Supervisors can talk to each other. You can connect Supervisors together into a network and instruct them to send information to each other and take actions based on that information.
+{{< readfile file="content/habitat/reusable/md/habitat_plans_overview.md" >}}
 
-## Services
+For more information, see the [plan]({{< relref "plan_writing" >}}) documentation.
 
-A [service]({{< relref "about_services" >}}) is your Chef Habitat package that is run and managed by a Supervisor. Services can be joined together into a [service group]({{< relref "service_groups" >}}), which is a collection of services with the same package and topology type that are connected together across a Supervisor network.
+### Services
 
-## Installing Chef Habitat
+{{< readfile file="content/habitat/reusable/md/habitat_services_overview.md" >}}
 
-The Chef Habitat CLI can be [installed]({{< relref "install_habitat" >}}) on Linux, Mac, and Windows.
+See the [services documentation]({{< relref "about_services" >}}) for more information.
+
+### Habitat Studio
+
+{{< readfile file="content/habitat/reusable/md/habitat_studio_overview.md" >}}
+
+See the [Habitat Studio documentation]({{< relref "studio" >}}) for more information.
+
+### Habitat Supervisor
+
+{{< readfile file="content/habitat/reusable/md/habitat_supervisor_overview.md" >}}
+
+See the [Habitat Supervisor documentation]({{< relref "sup" >}}) for more information.
+
+## When Should I Use Chef Habitat?
+
+Chef Habitat allows you to build and package your applications and deploy them anywhere without having to refactor or rewrite your package for each platform.
+Everything that the application needs to run is defined, without assuming anything about the underlying infrastructure that the application is running on.
+
+This will allow you to repackage and modernize legacy workloads in-place to increase their manageability, make them portable, and migrate them to modern operating systems or even cloud-native infrastructure like containers.
+
+You can also develop your application if you are unsure of the infrastructure your application will run on, or in the event that business requirements change and you have to switch your application to a different environment.
+
+## Next Steps
+
+- [Download and install the Chef Habitat CLI]({{< relref "/habitat/install_habitat" >}}).
+- [Create an account]({{< relref "/habitat/builder_account" >}}) on the [Habitat Builder SaaS](https://bldr.habitat.sh).
+- Try our [getting started guide](get_started) for Chef Habitat.
+
+## Additional Resources
+
+### Download
+
+- [Download Chef Habitat](https://www.chef.io/downloads/tools/habitat)
+- [Install documentation]({{< relref "/habitat/install_habitat" >}})
+
+### Learning
+
+- [Learn Chef: Deliver Applications with Chef Habitat](https://learn.chef.io/courses/course-v1:chef+Habitat101+Perpetual/about)
+- [Chef Habitat webinars](https://www.chef.io/webinars?products=chef-habitat&page=1)
+- [Resource Library](https://www.chef.io/resources?products=chef-habitat&page=1)
+
+### Community
+
+- [Chef Habitat on Discourse](https://discourse.chef.io/c/habitat/12)
+- [Chef Habitat in the Chef Blog](https://www.chef.io/blog/category/chef-habitat)
+- [Chef Habitat Community Resources](https://community.chef.io/tools/chef-habitat)
+
+### Support
+
+- [Chef Support](https://www.chef.io/support)
+
+### GitHub Repositories
+
+- [Chef Habitat repository](https://github.com/habitat-sh/habitat)
+- [Chef Habitat Core Plans repository](https://github.com/habitat-sh/core-plans)
+- [Chef Habitat Builder repository](https://github.com/habitat-sh/builder)
+- [Chef Habitat Builder on-prem repository](https://github.com/habitat-sh/on-prem-builder)

--- a/components/docs-chef-io/content/habitat/hab_setup.md
+++ b/components/docs-chef-io/content/habitat/hab_setup.md
@@ -6,8 +6,8 @@ gh_repo = "habitat"
 [menu]
   [menu.habitat]
     title = "Set up the Chef Habitat CLI"
-    identifier = "habitat/get_started/hab-setup Install Chef Habitat"
-    parent = "habitat/get_started"
+    identifier = "habitat/install/hab-setup Install Chef Habitat"
+    parent = "habitat/install"
     weight = 20
 +++
 

--- a/components/docs-chef-io/content/habitat/install_faq.md
+++ b/components/docs-chef-io/content/habitat/install_faq.md
@@ -7,8 +7,8 @@ gh_repo = "habitat"
 [menu]
   [menu.habitat]
     title = "Download and Install FAQ"
-    identifier = "habitat/get_started/install-faq Install Frequently Asked Questions FAQ"
-    parent = "habitat/get_started"
+    identifier = "habitat/install/install-faq Install Frequently Asked Questions FAQ"
+    parent = "habitat/install"
     weight = 30
 +++
 

--- a/components/docs-chef-io/content/habitat/install_habitat.md
+++ b/components/docs-chef-io/content/habitat/install_habitat.md
@@ -7,8 +7,8 @@ gh_repo = "habitat"
 [menu]
   [menu.habitat]
     title = "Get Chef Habitat"
-    identifier = "habitat/get_started/installing-packages"
-    parent = "habitat/get_started"
+    identifier = "habitat/install/installing-packages"
+    parent = "habitat/install"
     weight = 10
 +++
 

--- a/components/docs-chef-io/content/habitat/reusable/index.md
+++ b/components/docs-chef-io/content/habitat/reusable/index.md
@@ -1,0 +1,7 @@
++++
+headless=true
+
+# This creates a headless bundle.
+# See: https://gohugo.io/content-management/page-bundles/#headless-bundle
+# and https://docs.chef.io/style_guide/reuse/#reusable-text-files
++++

--- a/components/docs-chef-io/content/habitat/reusable/md/habitat_builder_overview.md
+++ b/components/docs-chef-io/content/habitat/reusable/md/habitat_builder_overview.md
@@ -1,4 +1,4 @@
 Chef Habitat Builder acts as the core of Chef's Application Delivery Enterprise hub.
-It provides a repository for all available plan files built by Chef and the supporting community, as well as search and an API for clients.
+It provides a repository for all available Chef Habitat packages built by Chef and the supporting community, as well as search and an API for clients.
 
 You can store application plans on the Chef Habitat Builder SaaS where the Chef Habitat community can view and access them. You can also deploy the [on-prem version of Chef Habitat Builder](https://github.com/habitat-sh/on-prem-builder) where you can store and maintain your apps in a secure environment.

--- a/components/docs-chef-io/content/habitat/reusable/md/habitat_builder_overview.md
+++ b/components/docs-chef-io/content/habitat/reusable/md/habitat_builder_overview.md
@@ -1,0 +1,4 @@
+Chef Habitat Builder acts as the core of Chef's Application Delivery Enterprise hub.
+It provides a repository for all available plan files built by Chef and the supporting community, as well as search and an API for clients.
+
+You can store application plans on the Chef Habitat Builder SaaS where the Chef Habitat community can view and access them. You can also deploy the [on-prem version of Chef Habitat Builder](https://github.com/habitat-sh/on-prem-builder) where you can store and maintain your apps in a secure environment.

--- a/components/docs-chef-io/content/habitat/reusable/md/habitat_plans_overview.md
+++ b/components/docs-chef-io/content/habitat/reusable/md/habitat_plans_overview.md
@@ -1,0 +1,3 @@
+A plan is the set of instructions, templates, and configuration files that define how you download, configure, make, install, and manage the lifecycle of the application artifact. The plan is defined in the `habitat` directory at the root of your project repository.
+
+The `habitat` directory includes a plan file (`plan.sh` for Linux systems or `plan.ps1` for Windows), a `default.toml` file, an optional `config` directory for configuration templates, and an optional `hooks` directory for lifecycle hooks. You can create this directory at the root of your application with `hab plan init`.

--- a/components/docs-chef-io/content/habitat/reusable/md/habitat_services_overview.md
+++ b/components/docs-chef-io/content/habitat/reusable/md/habitat_services_overview.md
@@ -1,0 +1,1 @@
+A service is a Chef Habitat package that is run and managed by a Supervisor. Services can be joined together into a [service group]({{< relref "/habitat/service_groups" >}}), which is a collection of services with the same package and topology type that are connected together across a Supervisor network.

--- a/components/docs-chef-io/content/habitat/reusable/md/habitat_studio_overview.md
+++ b/components/docs-chef-io/content/habitat/reusable/md/habitat_studio_overview.md
@@ -1,0 +1,1 @@
+The Chef Habitat Studio is a clean, self-contained, minimal environment in which you can develop, build, and package software that is free from any upstream operating system distribution. All tools and dependencies included in the Studio are installed through Chef Habitat packages, thus preventing any unwanted dependencies from being used by your package.

--- a/components/docs-chef-io/content/habitat/reusable/md/habitat_supervisor_overview.md
+++ b/components/docs-chef-io/content/habitat/reusable/md/habitat_supervisor_overview.md
@@ -1,0 +1,6 @@
+Chef Habitat Supervisor is a process manager that has two primary responsibilities:
+
+- A Supervisor runs your app's services. It starts, stops, updates, and monitors the services according to your plan.
+- Supervisors can talk to each other. You can connect Supervisors together into a network and instruct them to send information to each other and take actions based on that information.
+
+In the Supervisor you can define topologies for you application, such as leader-follower or standalone, or more complex applications that include databases. The supervisor also allows you to inject tunables into your application. Allowing you to defer decisions about how your application behaves until runtime.

--- a/components/docs-chef-io/content/habitat/studio.md
+++ b/components/docs-chef-io/content/habitat/studio.md
@@ -1,7 +1,7 @@
 +++
-title = "Studio"
+title = "Chef Habitat Studio Overview"
 description = "About the Chef Habitat Studio"
-draft = true
+draft = false
 gh_repo = "habitat"
 
 [menu]
@@ -12,17 +12,6 @@ gh_repo = "habitat"
     weight = 80
 
 +++
-## Customizing Studio
-
-When you enter a Studio, Chef Habitat will attempt to locate `/src/.studiorc` and
-source it. Think `~/.bashrc`. This file can be used to export any
-environment variables like the ones in /reference/environment-variables  as well as any other shell
-customizations to help you develop your plans from within the Studio.
-
-To use this feature, place a `.studiorc` in the current working directory
-where you will run `hab studio enter`.
-
-Note that a `.studiorc` will only be source when using `hab studio enter`--it will not be sourced when calling `hab studio run` or `hab studio build` (also `hab pkg build`).
 
 <!-- ## Scotts goals:
 There are two goals I have with this document, the second being a component of the first, but is a major sticking point to selling Habitat right now.
@@ -33,73 +22,90 @@ The desire to build Habitat packages in CI leads to the question of why we requi
 
 In order to explain why that is, so that there is a common starting point, my goal is to break down the studio conceptually, and give a brief overview of the differing implementations before talking about the elevated privileges conundrum. -->
 
-## What is the studio
+{{< readfile file="content/habitat/reusable/md/habitat_studio_overview.md" >}}
 
-The Chef Habitat Studio is a clean, self-contained, minimal environment in which you can develop, build, and package software that is free from any upstream operating system distribution. All tools and dependencies included in the Studio are installed through Chef Habitat packages, thus preventing any unwanted dependencies from being used by your package.
+## Customizing Studio
+
+When you enter a Studio, Chef Habitat will attempt to locate `/src/.studiorc` and
+source it. Think `~/.bashrc`. This file can be used to export any
+environment variables like the ones in `/reference/environment-variables`, as well as any other shell
+customizations to help you develop your plans from within the Studio.
+
+To use this feature, place a `.studiorc` in the current working directory
+where you will run `hab studio enter`.
+
+Note that a `.studiorc` will only be sourced when using `hab studio enter`--it will not be sourced when calling `hab studio run` or `hab studio build` (also `hab pkg build`).
 
 ### Why do we need it (Linux)
 
-The primary purpose of the studio on Linux is to provide environmental and filesystem isolation from the build host during the build process. Many common environmental variables can influence the build process, such as PATH putting user installed tools ahead of the desired tool versions. Filesystem isolation is important as many tools use common system paths to autodiscover libraries, putting them ahead of the desired Habitat libraries. The result is a known, minimal environment that is portable and consistent across hosts (laptop to build farm) and forces the users to be explicit about how they build and package their software
+The primary purpose of the Studio on Linux is to provide environmental and filesystem isolation from the build host during the build process. Many common environmental variables can influence the build process, such as PATH putting user installed tools ahead of the desired tool versions. Filesystem isolation is important as many tools use common system paths to autodiscover libraries, putting them ahead of the desired Habitat libraries. The result is a known, minimal environment that is portable and consistent across hosts (laptop to build farm) and forces the users to be explicit about how they build and package their software
 
 ### Why do we need it (Windows)
-The purpose of the Studio on Windows is fundamentally the same as Linux. However, Windows cannot achieve filesystem isolation with the "native" studio in the same way that linux can, but this is also less important in Windows. It does provide similar environmental isolation, though there are unique constraints imposed by Windows that require certain system paths to be available. For instance, removing the system32 libraries and tools would be unnatural at best and completely break Windows at worst, but the Studio will strip all other PATH entries (your ProgramFiles applications for example) in order to provide a more isolated environment. Registry isolation is also a concern that is different from Linux, but the native studio does not provide this isolation. Note that the Docker Windows Studio mentioned below provides much more thorough isolation.
+
+The purpose of the Studio on Windows is fundamentally the same as Linux. However, Windows cannot achieve filesystem isolation with the "native" studio in the same way that Linux can, but this is also less important in Windows. It does provide similar environmental isolation, though there are unique constraints imposed by Windows that require certain system paths to be available. For instance, removing the system32 libraries and tools would be unnatural at best and completely break Windows at worst, but the Studio will strip all other PATH entries (your ProgramFiles applications for example) in order to provide a more isolated environment. Registry isolation is also a concern that is different from Linux, but the native studio does not provide this isolation. Note that the Docker Windows Studio mentioned below provides much more thorough isolation.
 
 One other purpose of the Studio on Windows is to provide a known and common Powershell environment that the Habitat build program is compatible with. The Windows Studio includes a packaged version of Powershell which is different from the version of Powershell that ships on the OS. Entering an interactive Windows Studio makes it easier to troubleshoot builds because one is placed in the same version of Powershell that builds their packages and also the same version used by the Habitat Supervisor at runtime.
 
 ## What kinds of studios are there?
+
 The Studio as an abstract concept is an environment to provide the required guarantees for builds. The `hab studio` command is our interface to do the requisite setup before handing control over to a studio implementation. `pkg build` uses the same setup but instead of creating an interactive process, it invokes `build` directly in a non-interactive environment.
 
-There are currently 4 implementations of the studio provided by the Habitat team. The studio implementations build upon common utilities, such as chroot or Docker containers, thus constraints on the studio behaviors, where it can run, what kinds of packages it can build, and in many cases what kinds of errors you can expect, are imposed by those tools. In the case of errors, it's often a case of understanding and troubleshooting the underlying tool used to implement the studio rather than troubleshooting the studio itself.
+There are currently four implementations of the studio provided by the Habitat team. The studio implementations build upon common utilities, such as chroot or Docker containers, thus constraints on the studio behaviors, where it can run, what kinds of packages it can build, and in many cases what kinds of errors you can expect, are imposed by those tools. In the case of errors, it's often a case of understanding and troubleshooting the underlying tool used to implement the studio rather than troubleshooting the studio itself.
 
 ### Linux "native" - aka `core/hab-studio`
+
 Built using chroot and bind mounts to provide access to required paths from the host. This is the default studio on Linux, and only functions on Linux based systems.  This requires root privileges to invoke, and the `hab studio` command will attempt to use `sudo` to elevate the users privileges, if they are not already root. In addition, the installation of this package requires root privileges, as `/hab/pkgs` is owned by the root user. Specifically, chroot requires CAP_SYS_CHROOT and mounts require CAP_SYS_ADMIN. In addition to the bind mounts, `/proc` is required to be mounted for builds to function.
 
 ### Linux "Docker Studio" aka `rootless_studio`
-The Linux Docker Studio is a completely separate implementation from the native studio, sharing no code aside from the common `hab studio` entrypoint. This difference in implementation includes available subcommands and help documentation, often leading to confusion.  `hab studio -D` provides the necessary conversion to the required docker cli arguments, such as mounting volumes from the host into the container and setting the image to run. You can invoke this studio using only docker commands,  but requires additional effort in setting all the correct options.
+
+The Linux Docker Studio is a completely separate implementation from the native studio, sharing no code aside from the common `hab studio` entrypoint. This difference in implementation includes available subcommands and help documentation, often leading to confusion.  `hab studio -D` provides the necessary conversion to the required Docker CLI arguments, such as mounting volumes from the host into the container and setting the image to run. You can invoke this studio using only Docker commands,  but requires additional effort in setting all the correct options.
 
 This studio was built to not require elevated permissions to run, to be able to provide studio builds inside CI systems or orchestration engines such as Kubernetes where elevated privileges are typically verboten. However, you still need to be able to communicate with the container engine in order to start the container.
 
 ### Windows "native" - aka `core/hab-studio`
 
-The windows studio uses Junction mounts in order to provide a consistent filesystem view in order to provide a similar experience to the Linux studios. Windows has no concept of "chroot" or jailed filesystems, so it provides no isolation from the host paths, registry and other machine scoped APIs (like windows features, etc.).
+The Windows studio uses Junction mounts in order to provide a consistent filesystem view in order to provide a similar experience to the Linux studios. Windows has no concept of "chroot" or jailed filesystems, so it provides no isolation from the host paths, registry and other machine scoped APIs (like Windows features, etc.).
 
 ### Windows "Docker Studio"
 
-The windows docker studio does not exist as a component like `core/hab-studio` or `rootless_studio` in the Habitat code base. Instead it is created in our release pipeline, using a minimal Windows Container as the base and layering in the windows implementation of `core/hab-studio` to build a Docker image. Like the rootless studio, this can be invoked using only the docker cli with the same additional setup required to set the correct options.
+The Windows Docker studio does not exist as a component like `core/hab-studio` or `rootless_studio` in the Habitat code base. Instead it is created in our release pipeline, using a minimal Windows Container as the base and layering in the Windows implementation of `core/hab-studio` to build a Docker image. Like the rootless studio, this can be invoked using only the Docker CLI with the same additional setup required to set the correct options.
 
+## Studio platform support
 
-## Studio platform support:
-There are 4 implementations of the studio, and 3 primary supported operating systems that the `hab studio` can be invoked from. This matrix shows which studios can be run on the various operating systems.
+There are 4 implementations of the studio, and three primary supported operating systems that the `hab studio` can be invoked from. This matrix shows which studios can be run on the various operating systems.
 
 | Studio | Linux | macOS | Windows |
 |--------|-------|-------|---------|
-Linux Native | Yes | No | No |
-Linux Docker | Yes | Yes | Yes |
-Windows Native | No | No | Yes |
-Windows Docker | No | No | Yes |
+| Linux Native | Yes | No | No |
+| Linux Docker | Yes | Yes | Yes |
+| Windows Native | No | No | Yes |
+| Windows Docker | No | No | Yes |
 
 ### Why do we need privileged containers to build (on Linux)?
+
 Users wishing to build Habitat packages in containers will typically have their CI agent invoke `hab pkg build*`. This agent will be running in a non-privileged container, or possibly create a non-privileged container to invoke `hab pkg build`.
 
-At this point, the hab command will try to create the studio to run the command in. In the case of the native studio, this will fail because the container it is running in does not have the `CAP_SYS_CHROOT` or `CAP_SYS_ADMIN` capabilities.  The Docker studio will also fail, as the environment the build is executing in won't have permissions to run containers,  and also wouldn't have access to the docker socket (or docker in docker).
+At this point, the hab command will try to create the studio to run the command in. In the case of the native studio, this will fail because the container it is running in does not have the `CAP_SYS_CHROOT` or `CAP_SYS_ADMIN` capabilities.  The Docker studio will also fail, as the environment the build is executing in won't have permissions to run containers,  and also wouldn't have access to the Docker socket (or Docker in Docker).
 
-It's possible that if the users are able to provide credentials to access a remote docker host, we would be able to build, though in secured environments this is probably unlikely. I also don't know if volume mapping can work across the network. Even if it is possible, any IO operations, such as reading the source would be slow.
+It's possible that if the users are able to provide credentials to access a remote Docker host, we would be able to build, though in secured environments this is probably unlikely. I also don't know if volume mapping can work across the network. Even if it is possible, any IO operations, such as reading the source would be slow.
 
 We also want to be careful about exposing build functionality directly to CI agents without requiring the studio boundary.  We'd likely start (for example) fielding support questions around our package quality from user software segfaulting, when the underlying issue was the package was built on an Ubuntu host and it linked against the wrong libraries.
 
-Today, users can configure their agents to run the docker studio image directly, but that requires them to perform all the set up `hab pkg build` would normally do for them, creating a point of friction.
+Today, users can configure their agents to run the Docker studio image directly, but that requires them to perform all the set up `hab pkg build` would normally do for them, creating a point of friction.
 
-* `hab studio build` is a synonym for `hab pkg build`
-* Does windows suffer from this same issue?
+- `hab studio build` is a synonym for `hab pkg build`
+- Does Windows suffer from this same issue?
 
-## Other common questions
-Building packages cross platform
-One question often posed is the desire to build windows packages on non-windows systems. This is often spurred by the ability to build Linux packages on Windows or MacOS. However, this is not a capability provided by the Studio, but by Docker. Docker runs a minimal Linux VM (using Hyper-V on Windows and Hyperkit on MacOS) to provide the ability to run Linux containers.
+## Building packages cross platform
+
+One question often posed is the desire to build Windows packages on non-Windows systems. This is often spurred by the ability to build Linux packages on Windows or macOS. However, this is not a capability provided by the Studio, but by Docker. Docker runs a minimal Linux VM (using Hyper-V on Windows and Hyperkit on macOS) to provide the ability to run Linux containers.
 
 ### The "Mac Studio"
-There is no Spoon.  The Studio on MacOS relies on the Docker Desktop creating and running a docker host inside a headless virtual machine. This gives us the capability to develop and build Linux packages on MacOS. MacOS itself provides no os-virtualization primitives beyond chroot. Because `hab studio` manages the set up and execution of the docker cli command, this gives the illusion that we are providing some magic to build Linux packages on Mac.
 
-### How the Studio is used:
+There is no Spoon.  The Studio on macOS relies on the Docker Desktop creating and running a Docker host inside a headless virtual machine. This gives us the capability to develop and build Linux packages on macOS. macOS itself provides no os-virtualization primitives beyond chroot. Because `hab studio` manages the set up and execution of the Docker CLI command, this gives the illusion that we are providing some magic to build Linux packages on Mac.
+
+### How the Studio is used
+
 Studios are used in interactive modes to develop packages, but are often used interactively to also build the resulting packages. While this is fine, any time you are invoking a build from an interactive process that has had additional commands run before the build start, such as creating binlinks or even invoking other builds, you run the risk of creating a "tainted" build. In other words you lose some of the guarantees provided by the studio, leading to scenarios where builds between developers or CI are different.
 
-Studios are also used to develop software, though this is a less than ideal experience today, as it requires additional setup from the user. This is because traditional developer tools have assumptions about the environment they are operating in and have no knowledge of the Habitat package structure.  This is a point of friction to enable developers to develop against the same set of libraries that their software will ultimately be deployed against, allowing us to further "shift left".
+Studios are also used to develop software, though this is a less than ideal experience today as it requires additional setup from the user. This is because traditional developer tools have assumptions about the environment they are operating in and have no knowledge of the Habitat package structure.  This is a point of friction to enable developers to develop against the same set of libraries that their software will ultimately be deployed against, allowing us to further "shift left".

--- a/components/docs-chef-io/content/habitat/studio.md
+++ b/components/docs-chef-io/content/habitat/studio.md
@@ -26,15 +26,18 @@ In order to explain why that is, so that there is a common starting point, my go
 
 ## Customizing Studio
 
-When you enter a Studio, Chef Habitat will attempt to locate `/src/.studiorc` and
-source it. Think `~/.bashrc`. This file can be used to export any
-environment variables like the ones in `/reference/environment-variables`, as well as any other shell
-customizations to help you develop your plans from within the Studio.
+When you enter a Studio, Chef Habitat will attempt to locate `/src/.studiorc` on Linux or `/src/studio_profile.ps1` on Windows and source it.
+Think `~/.bashrc` or `$PROFILE`.
+This file can be used to export any environment variables like the ones in `/reference/environment-variables`, as well as any other shell customizations to help you develop your plans from within the Studio.
 
-To use this feature, place a `.studiorc` in the current working directory
+To use this feature, place a `.studiorc` (Linux) or `studio_profile.ps1` (Windows) in the current working directory
 where you will run `hab studio enter`.
 
-Note that a `.studiorc` will only be sourced when using `hab studio enter`--it will not be sourced when calling `hab studio run` or `hab studio build` (also `hab pkg build`).
+{{< note >}}
+
+Chef Habitat will only source `.studiorc` or `studio_profile.ps1` when you run `hab studio enter`--it will not be sourced when calling `hab studio run`, `hab studio build`, or `hab pkg build`.
+
+{{< /note >}}
 
 ### Why do we need it (Linux)
 
@@ -56,7 +59,7 @@ There are currently four implementations of the studio provided by the Habitat t
 
 Built using chroot and bind mounts to provide access to required paths from the host. This is the default studio on Linux, and only functions on Linux based systems.  This requires root privileges to invoke, and the `hab studio` command will attempt to use `sudo` to elevate the users privileges, if they are not already root. In addition, the installation of this package requires root privileges, as `/hab/pkgs` is owned by the root user. Specifically, chroot requires CAP_SYS_CHROOT and mounts require CAP_SYS_ADMIN. In addition to the bind mounts, `/proc` is required to be mounted for builds to function.
 
-### Linux "Docker Studio" aka `rootless_studio`
+### Linux "Docker Studio"
 
 The Linux Docker Studio is a completely separate implementation from the native studio, sharing no code aside from the common `hab studio` entrypoint. This difference in implementation includes available subcommands and help documentation, often leading to confusion.  `hab studio -D` provides the necessary conversion to the required Docker CLI arguments, such as mounting volumes from the host into the container and setting the image to run. You can invoke this studio using only Docker commands,  but requires additional effort in setting all the correct options.
 
@@ -92,9 +95,6 @@ It's possible that if the users are able to provide credentials to access a remo
 We also want to be careful about exposing build functionality directly to CI agents without requiring the studio boundary.  We'd likely start (for example) fielding support questions around our package quality from user software segfaulting, when the underlying issue was the package was built on an Ubuntu host and it linked against the wrong libraries.
 
 Today, users can configure their agents to run the Docker studio image directly, but that requires them to perform all the set up `hab pkg build` would normally do for them, creating a point of friction.
-
-- `hab studio build` is a synonym for `hab pkg build`
-- Does Windows suffer from this same issue?
 
 ## Building packages cross platform
 


### PR DESCRIPTION
Two things:

- Update the Hab landing page text at docs.chef.io/habitat/
- moves the menu config from chef-web-docs.

Note that the Netlify build will look a little weird since Netlify defaults to using the menu config in chef-web-docs, which I can't delete until this gets merged.

Also see the changes in #8838 
The menu updates for the get_started page in that PR.