### PR TITLE
bump h2 to 0.3.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1174,9 +1174,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
 dependencies = [
  "bytes",
  "fnv",

--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -13,7 +13,7 @@ env = "*"
 futures = "*"
 habitat_core = { path = "../core" }
 habitat_http_client = { path = "../http-client" }
-log = "*"
+log = "0.4"
 pbr = "*"
 percent-encoding = "*"
 rand = "*"
@@ -23,5 +23,5 @@ serde = { version = "*", features = ["derive"] }
 serde_json = { version = "*", features = [ "preserve_order" ] }
 tee = "*"
 tokio = { version = "*", features = ["full"] }
-tokio-util = { version = "*", features = ["compat", "codec"] }
+tokio-util = { version = "0.7", features = ["compat", "codec"] }
 url = "*"

--- a/components/butterfly/Cargo.toml
+++ b/components/butterfly/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "*"
 env_logger = "*"
 habitat_core = { path = "../core" }
 habitat_common = { path = "../common" }
-log = "*"
+log = "0.4"
 lazy_static = "*"
 prometheus = "*"
 parking_lot = "*"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -27,7 +27,7 @@ habitat_core = { path = "../core" }
 handlebars = { version = "= 0.28.3", default-features = false }
 lazy_static = "*"
 libc = "*"
-log = "*"
+log = "0.4"
 native-tls = { version = "*", features = ["vendored"] }
 owning_ref = "*"
 parking_lot = "*"

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -21,7 +21,7 @@ glob = "*"
 hex = "*"
 lazy_static = "*"
 libc = "*"
-log = "*"
+log = "0.4"
 native-tls = { version = "*", features = ["vendored"] }
 os_info = "*"
 paste = "*"

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -33,7 +33,7 @@ habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 handlebars = { version = "0.29.1", default-features = false }
 lazy_static = "*"
 libc = "*"
-log = "*"
+log = "0.4"
 pbr = "*"
 rants = { git = "https://github.com/habitat-sh/rants.git", features = ["native-tls"] }
 reqwest = { version = "*", features = ["blocking", "json", "stream"] }

--- a/components/http-client/Cargo.toml
+++ b/components/http-client/Cargo.toml
@@ -7,7 +7,7 @@ workspace = "../../"
 
 [dependencies]
 base64 = "*"
-log = "*"
+log = "0.4"
 native-tls = { version = "*", features = ["vendored"] }
 pem = "*"
 httparse = "*"

--- a/components/launcher-client/Cargo.toml
+++ b/components/launcher-client/Cargo.toml
@@ -19,7 +19,7 @@ habitat_common = { path = "../common" }
 # The commit that introduced the change can be found here: https://github.com/servo/ipc-channel/commit/eb08381a30bc71a534a0a73ab98c05bca7a12f82
 ipc-channel = { version = "0.15.0" }
 libc = "*"
-log = "*"
+log = "0.4"
 prost = "*"
 serde = "*"
 thiserror = "*"

--- a/components/launcher/Cargo.toml
+++ b/components/launcher/Cargo.toml
@@ -23,7 +23,7 @@ habitat-launcher-protocol = { path = "../launcher-protocol" }
 # The commit that introduced the change can be found here: https://github.com/servo/ipc-channel/commit/eb08381a30bc71a534a0a73ab98c05bca7a12f82
 ipc-channel = { version = "0.15.0" }
 libc = "*"
-log = "*"
+log = "0.4"
 prost = "*"
 semver = "*"
 thiserror = "*"

--- a/components/pkg-export-container/Cargo.toml
+++ b/components/pkg-export-container/Cargo.toml
@@ -25,7 +25,7 @@ habitat_core = { path = "../core" }
 handlebars = { version = "0.29.1", default-features = false }
 lazy_static = "*"
 linked-hash-map = "*"
-log = "*"
+log = "0.4"
 rusoto_core = "*"
 rusoto_credential = "*"
 rusoto_ecr = "*"

--- a/components/pkg-export-tar/Cargo.toml
+++ b/components/pkg-export-tar/Cargo.toml
@@ -21,7 +21,7 @@ habitat_core = { path = "../core" }
 # We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
 handlebars = { version = "0.29.1", default-features = false }
 lazy_static = "*"
-log = "*"
+log = "0.4"
 mktemp = "*"
 serde = { version = "*", features = ["rc"] }
 serde_json = { version = "*", features = [ "preserve_order" ] }

--- a/components/rst-reader/Cargo.toml
+++ b/components/rst-reader/Cargo.toml
@@ -14,4 +14,4 @@ doc = false
 clap = { git = "https://github.com/habitat-sh/clap.git", branch = "v2-master", features = [ "suggestions", "color", "unstable" ] }
 env_logger = "*"
 habitat_butterfly = { path = "../butterfly", default-features = false }
-log = "*"
+log = "0.4"

--- a/components/sup-client/Cargo.toml
+++ b/components/sup-client/Cargo.toml
@@ -10,9 +10,9 @@ futures = { version = "*" }
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 habitat_common = { path = "../common" }
 habitat_core = { path = "../core" }
-log = "*"
+log = "0.4"
 prost = "*"
 rustls = "*"
 termcolor = "*"
 tokio = { version = "*", features = ["full"] }
-tokio-util = { version = "*", features = ["full"] }
+tokio-util = { version = "0.7", features = ["full"] }

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -11,12 +11,12 @@ base64 = "*"
 bytes = "*"
 habitat_core = { path = "../core" }
 lazy_static = "*"
-log = "*"
+log = "0.4"
 prost = { version = "*", features = ["prost-derive"] }
 rand = "*"
 serde = {version = "*", features = ["derive"] }
 tokio = { version = "*", features = ["full"] }
-tokio-util = { version = "*", features = ["full"] }
+tokio-util = { version = "0.7", features = ["full"] }
 
 [build-dependencies]
 prost-build = "*"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -36,7 +36,7 @@ habitat-launcher-client = { path = "../launcher-client" }
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 lazy_static = "*"
 libc = "*"
-log = "*"
+log = "0.4"
 log4rs = "*"
 multimap = "*"
 notify = "*"
@@ -65,7 +65,7 @@ anyhow = { version = "*", features = ["backtrace"] }
 toml = { version = "*", features = ["preserve_order"]}
 tokio = { version = "*", features = ["full"] }
 tokio-rustls = "*"
-tokio-util = { version = "*", features = ["full"] }
+tokio-util = { version = "0.7", features = ["full"] }
 uuid = { version = "*", features = ["v4"] }
 url = "*"
 valico = "*"

--- a/components/win-users/Cargo.toml
+++ b/components/win-users/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 cc = "*"
 
 [dependencies]
-log = "*"
+log = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 widestring = "*"


### PR DESCRIPTION
I had to add some version constraints here. Otherwise the dependabot PR was downgrading some crates.