### PR TITLE
Refactor Supervisor HTTP Gateway to eliminate service data inconsistencies

### DIFF
--- a/components/sup/src/http_gateway.rs
+++ b/components/sup/src/http_gateway.rs
@@ -41,8 +41,6 @@ use prometheus::{self,
                  TextEncoder};
 use rustls::ServerConfig;
 use serde::Serialize;
-use serde_json::{self,
-                 Value as Json};
 use std::{self,
           cell::Cell,
           fs::File,
@@ -227,7 +225,6 @@ struct Services {}
 
 impl Services {
     // Route registration
-    //
     pub fn register(cfg: &mut ServiceConfig) {
         cfg.route("/services", web::get().to(services_gsr))
            .route("/services/{svc}/{group}",
@@ -249,7 +246,6 @@ struct Butterfly {}
 
 impl Butterfly {
     // Route registration
-    //
     pub fn register(cfg: &mut ServiceConfig) {
         cfg.service(web::resource("/butterfly").route(web::get().to(butterfly_gsr))
                                                .wrap_fn(redact_http_middleware));
@@ -260,7 +256,6 @@ struct Census {}
 
 impl Census {
     // Route registration
-    //
     pub fn register(cfg: &mut ServiceConfig) {
         cfg.service(web::resource("/census").route(web::get().to(census_gsr))
                                             .wrap_fn(redact_http_middleware));
@@ -360,8 +355,7 @@ async fn census_gsr(state: Data<AppState>) -> HttpResponse {
 /// * `GatewayState::inner` (read)
 #[allow(clippy::needless_pass_by_value)]
 async fn services_gsr(state: Data<AppState>) -> HttpResponse {
-    let data = state.gateway_state.lock_gsr().services_data().to_string();
-    json_response(data)
+    HttpResponse::Ok().json(state.gateway_state.lock_gsr().services_data())
 }
 
 /// # Locking (see locking.md)
@@ -394,10 +388,13 @@ fn config_gsr(svc: String, group: String, org: Option<&str>, state: &AppState) -
         Err(_) => return HttpResponse::BadRequest().finish(),
     };
 
-    match service_from_services(&service_group,
-                                state.gateway_state.lock_gsr().services_data())
+    match state.gateway_state
+               .lock_gsr()
+               .services_data()
+               .iter()
+               .find(|service| service.service_group == service_group)
     {
-        Some(mut s) => HttpResponse::Ok().json(s["cfg"].take()),
+        Some(service) => HttpResponse::Ok().json(&service.cfg),
         None => HttpResponse::NotFound().finish(),
     }
 }
@@ -430,7 +427,14 @@ fn health_gsr(svc: String, group: String, org: Option<&str>, state: &AppState) -
         Err(_) => return HttpResponse::BadRequest().finish(),
     };
 
-    if let Some(health_check) = state.gateway_state.lock_gsr().health_of(&service_group) {
+    let service_health_check = state.gateway_state
+                                    .lock_gsr()
+                                    .services_data()
+                                    .iter()
+                                    .find(|service| service.service_group == service_group)
+                                    .map(|service| service.health_check);
+
+    if let Some(health_check) = service_health_check {
         let mut body = HealthCheckBody::default();
         let stdout_path = hooks::stdout_log_path::<HealthCheckHook>(service_group.service());
         let stderr_path = hooks::stderr_log_path::<HealthCheckHook>(service_group.service());
@@ -480,10 +484,13 @@ fn service_gsr(svc: String, group: String, org: Option<&str>, state: &AppState) 
         Err(_) => return HttpResponse::BadRequest().finish(),
     };
 
-    match service_from_services(&service_group,
-                                state.gateway_state.lock_gsr().services_data())
+    match state.gateway_state
+               .lock_gsr()
+               .services_data()
+               .iter()
+               .find(|service| service.service_group == service_group)
     {
-        Some(s) => HttpResponse::Ok().json(s),
+        Some(service) => HttpResponse::Ok().json(service),
         None => HttpResponse::NotFound().finish(),
     }
 }
@@ -511,16 +518,6 @@ async fn metrics() -> HttpResponse {
 
 async fn doc() -> HttpResponse { HttpResponse::Ok().content_type("text/html").body(APIDOCS) }
 // End route handlers
-
-fn service_from_services(service_group: &ServiceGroup, services_json: &str) -> Option<Json> {
-    match serde_json::from_str(services_json) {
-        Ok(Json::Array(services)) => {
-            services.into_iter()
-                    .find(|s| s["service_group"] == service_group.as_ref())
-        }
-        _ => None,
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -20,10 +20,9 @@ use self::{action::{ShutdownInput,
                             ServiceOperation},
                      ConfigRendering,
                      DesiredState,
-                     HealthCheckResult,
                      PersistentServiceWrapper,
                      Service,
-                     ServiceProxy,
+                     ServiceQueryModel,
                      ServiceRunState,
                      ServiceSpec,
                      Topology},
@@ -450,11 +449,7 @@ pub(crate) mod sync {
 
         pub fn census_data(&self) -> &str { &self.0.census_data }
 
-        pub fn services_data(&self) -> &str { &self.0.services_data }
-
-        pub fn health_of(&self, service_group: &ServiceGroup) -> Option<HealthCheckResult> {
-            self.0.health_check_data.get(service_group).copied()
-        }
+        pub fn services_data(&self) -> &[ServiceQueryModel] { &self.0.services_data.as_slice() }
     }
 
     pub struct GatewayStateWriteGuard<'a>(WriteGuard<'a, GatewayStateInner>);
@@ -466,14 +461,12 @@ pub(crate) mod sync {
 
         pub fn set_butterfly_data(&mut self, new_data: String) { self.0.butterfly_data = new_data }
 
-        pub fn set_services_data(&mut self, new_data: String) { self.0.services_data = new_data }
-
-        pub fn remove(&mut self, service_group: &ServiceGroup) {
-            self.0.health_check_data.remove(service_group);
+        pub fn set_services_data(&mut self, new_data: Vec<ServiceQueryModel>) {
+            self.0.services_data = new_data
         }
 
-        pub fn set_health_of(&mut self, service_group: ServiceGroup, value: HealthCheckResult) {
-            self.0.health_check_data.insert(service_group, value);
+        pub fn get_services_data_mut(&mut self) -> &mut Vec<ServiceQueryModel> {
+            self.0.services_data.as_mut()
         }
     }
 
@@ -497,14 +490,11 @@ pub(crate) mod sync {
     #[derive(Debug, Default)]
     struct GatewayStateInner {
         /// JSON returned by the /census endpoint
-        census_data:       String,
+        census_data:    String,
         /// JSON returned by the /butterfly endpoint
-        butterfly_data:    String,
+        butterfly_data: String,
         /// JSON returned by the /services endpoint
-        services_data:     String,
-        /// Data returned by /services/<SERVICE_NAME>/<GROUP_NAME>/health
-        /// endpoint
-        health_check_data: HashMap<ServiceGroup, HealthCheckResult>,
+        services_data:  Vec<ServiceQueryModel>,
     }
 
     type ManagerServicesInner = HashMap<PackageIdent, PersistentServiceWrapper>;
@@ -1648,29 +1638,30 @@ impl Manager {
                 };
             }
         }
-        let watched_service_proxies: Vec<ServiceProxy<'_>> =
+        let watched_service_proxies: Vec<ServiceQueryModel> =
             watched_services.iter()
                             .map(|(service, service_run_state)| {
-                                ServiceProxy::new(service, service_run_state, config_rendering)
+                                ServiceQueryModel::new(service, service_run_state, config_rendering)
                             })
                             .collect();
-        let mut services_to_render: Vec<ServiceProxy<'_>> =
+        let mut services_data: Vec<ServiceQueryModel> =
             service_map.iter()
                        .filter_map(|(_, svc_state)| {
                            if let Some(service) = svc_state.service() {
-                               return Some(ServiceProxy::new(service,
-                                                             svc_state.service_run_state(),
-                                                             config_rendering));
+                               return Some(ServiceQueryModel::new(service,
+                                                                  svc_state.service_run_state(),
+                                                                  config_rendering));
                            }
                            None
                        })
                        .collect();
 
-        services_to_render.extend(watched_service_proxies);
+        services_data.extend(watched_service_proxies);
 
-        let json =
-            serde_json::to_string(&services_to_render).expect("ServiceProxy::serialize failure");
-        self.state.gateway_state.lock_gsw().set_services_data(json);
+        self.state
+            .gateway_state
+            .lock_gsw()
+            .set_services_data(services_data);
     }
 
     /// Check if any elections need restarting.

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -449,7 +449,7 @@ pub(crate) mod sync {
 
         pub fn census_data(&self) -> &str { &self.0.census_data }
 
-        pub fn services_data(&self) -> &[ServiceQueryModel] { &self.0.services_data.as_slice() }
+        pub fn services_data(&self) -> &[ServiceQueryModel] { self.0.services_data.as_slice() }
     }
 
     pub struct GatewayStateWriteGuard<'a>(WriteGuard<'a, GatewayStateInner>);

--- a/components/sup/src/manager/commands.rs
+++ b/components/sup/src/manager/commands.rs
@@ -5,14 +5,12 @@ use crate::{ctl_gateway::CtlRequest,
             manager::{action::{ActionSender,
                                SupervisorAction},
                       service::{spec::ServiceSpec,
-                                DesiredState,
-                                ProcessState},
+                                DesiredState},
                       ManagerState},
             util};
 use habitat_butterfly as butterfly;
 use habitat_common::{command::package::install::InstallSource,
                      outputln,
-                     templating::package::Pkg,
                      ui::UIWriter};
 use habitat_core::{package::{Identifiable,
                              PackageIdent,
@@ -22,14 +20,9 @@ use habitat_sup_protocol::{self as protocol,
                            net::{self,
                                  ErrCode,
                                  NetResult}};
-use serde::Deserialize;
 use std::{convert::TryFrom,
-          fmt,
-          result,
           str,
-          sync::atomic::Ordering,
-          time::{Duration,
-                 SystemTime}};
+          sync::atomic::Ordering};
 
 static LOGKEY: &str = "CMD";
 
@@ -349,119 +342,54 @@ pub fn service_status_gsr(mgr: &ManagerState,
                           req: &mut CtlRequest,
                           opts: protocol::ctl::SvcStatus)
                           -> NetResult<()> {
-    let statuses: Vec<ServiceStatus> =
-        serde_json::from_str(mgr.gateway_state.lock_gsr().services_data()).map_err(Error::ServiceDeserializationError)?;
-
     if let Some(ident) = opts.ident {
-        for status in statuses {
-            if status.pkg.ident.satisfies(&ident) {
-                let msg: protocol::types::ServiceStatus = status.into();
-                req.reply_complete(msg);
-                return Ok(());
+        let service_status = mgr.gateway_state
+                                .lock_gsr()
+                                .services_data()
+                                .iter()
+                                .find_map(|service| {
+                                    if service.pkg.ident.satisfies(&ident) {
+                                        Some(protocol::types::ServiceStatus::from(service))
+                                    } else {
+                                        None
+                                    }
+                                });
+        match service_status {
+            Some(service_status) => {
+                req.reply_complete(service_status);
+                Ok(())
             }
+            None => Err(net::err(ErrCode::NotFound, format!("Service not loaded, {}", ident))),
         }
-        return Err(net::err(ErrCode::NotFound, format!("Service not loaded, {}", ident)));
-    }
-
-    // We're not dealing with a single service, but with all of them.
-    if statuses.is_empty() {
-        req.reply_complete(net::ok());
     } else {
-        let mut list = statuses.into_iter().peekable();
-        while let Some(status) = list.next() {
-            let msg: protocol::types::ServiceStatus = status.into();
-            if list.peek().is_some() {
-                req.reply_partial(msg);
-            } else {
-                req.reply_complete(msg);
+        // We're not dealing with a single service, but with all of them.
+        // We serialize service data into messages completely before sending them over the network
+        // to minimize locking of the gateway state.
+        let service_statuses: Vec<_> = mgr.gateway_state
+                                          .lock_gsr()
+                                          .services_data()
+                                          .iter()
+                                          .map(protocol::types::ServiceStatus::from)
+                                          .collect();
+        if service_statuses.is_empty() {
+            req.reply_complete(net::ok());
+        } else {
+            let mut list = service_statuses.into_iter().peekable();
+            while let Some(service_status) = list.next() {
+                if list.peek().is_some() {
+                    req.reply_partial(service_status);
+                } else {
+                    req.reply_complete(service_status);
+                }
             }
         }
+        Ok(())
     }
-    Ok(())
 }
 
 ////////////////////////////////////////////////////////////////////////
 // Private helper functions
 fn err_update_client() -> net::NetErr { net::err(ErrCode::UpdateClient, "client out of date") }
-
-#[derive(Deserialize)]
-struct ServiceStatus {
-    pkg:           Pkg,
-    process:       ProcessStatus,
-    service_group: ServiceGroup,
-    desired_state: DesiredState,
-}
-
-impl From<ServiceStatus> for protocol::types::ServiceStatus {
-    fn from(other: ServiceStatus) -> Self {
-        protocol::types::ServiceStatus { ident:         PackageIdent::from(other.pkg.ident).into(),
-                                         process:       Some(other.process.into()),
-                                         service_group: other.service_group.into(),
-                                         desired_state: Some(other.desired_state.into()), }
-    }
-}
-
-// NOTE: This effectively the inverse of
-// habitat_sup::manager::service::supervisor::Supervisor's `Serialize`
-// implementation. When you trace the code, we're basically
-// rehydrating this struct from the JSON that results when we
-// serialize `Supervisor` for the HTTP gateway.
-//
-// That's very Rube Goldberg, of course, and should be made a bit more
-// sane in the future, but hopefully this trail of bread crumbs is
-// useful to you, Dear Reader.
-#[derive(Deserialize)]
-struct ProcessStatus {
-    #[serde(deserialize_with = "duration_from_epoch_offset",
-            rename = "state_entered")]
-    elapsed: Duration,
-    pid:     Option<u32>,
-    state:   ProcessState,
-}
-
-impl From<ProcessStatus> for protocol::types::ProcessStatus {
-    fn from(other: ProcessStatus) -> Self {
-        let mut proto = protocol::types::ProcessStatus { elapsed: Some(other.elapsed.as_secs()),
-                                                         state: other.state.into(),
-                                                         ..Default::default() };
-        if let Some(pid) = other.pid {
-            proto.pid = Some(pid);
-        }
-        proto
-    }
-}
-
-fn duration_from_epoch_offset<'de, D>(d: D) -> result::Result<Duration, D::Error>
-    where D: serde::Deserializer<'de>
-{
-    struct FromEpochOffset;
-
-    impl<'de> serde::de::Visitor<'de> for FromEpochOffset {
-        type Value = Duration;
-
-        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("a u64 integer")
-        }
-
-        fn visit_u64<R>(self, value: u64) -> result::Result<Duration, R>
-            where R: serde::de::Error
-        {
-            // The incoming value is the seconds since the UNIX
-            // Epoch... therefore, we need to figure out what time
-            // that was. Then, we figure out far in the past that
-            // point in time was.
-            if let Some(start_time) = SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(value))
-            {
-                Ok(SystemTime::now().duration_since(start_time)
-                                    .map_err(serde::de::Error::custom)?)
-            } else {
-                Err(serde::de::Error::custom("invalid epoch offset given"))
-            }
-        }
-    }
-
-    d.deserialize_u64(FromEpochOffset)
-}
 
 /// Helper function to ensure that all errors in sending are handled identically.
 fn send_action(action: SupervisorAction, sender: &ActionSender) -> NetResult<()> {

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -1634,7 +1634,7 @@ impl ServiceQueryModel {
                                 (*service.health_check_result
                                          .lock()
                                          .expect("Couldn't lock health check result for \
-                                                  serialization")).clone(),
+                                                  serialization")),
                             hooks:                  HookTableQueryModel::new(&service.hooks),
                             initialized:            service.initialized(),
                             last_election_status:   service.last_election_status,
@@ -1664,7 +1664,7 @@ impl ServiceQueryModel {
                             spec_ident:             service.spec.ident.clone(),
                             spec_identifier:        service.spec.ident.to_string(),
                             svc_encrypted_password: service.spec.svc_encrypted_password.clone(),
-                            health_check_interval:  service.spec.health_check_interval.clone(),
+                            health_check_interval:  service.spec.health_check_interval,
                             sys:                    service.sys.clone(),
                             topology:               service.spec.topology,
                             update_strategy:        service.spec.update_strategy,
@@ -1747,9 +1747,9 @@ mod tests {
         let service_wrapper = initialize_test_service().await;
 
         // With config
-        let proxy_with_config = ServiceProxy::new(service_wrapper.service().unwrap(),
-                                                  service_wrapper.service_run_state(),
-                                                  ConfigRendering::Full);
+        let proxy_with_config = ServiceQueryModel::new(service_wrapper.service().unwrap(),
+                                                       service_wrapper.service_run_state(),
+                                                       ConfigRendering::Full);
         let proxies_with_config = vec![proxy_with_config];
         let json_with_config =
             serde_json::to_string(&proxies_with_config).expect("Expected to convert \
@@ -1758,9 +1758,9 @@ mod tests {
         assert_valid(&json_with_config, "http_gateway_services_schema.json");
 
         // Without config
-        let proxy_without_config = ServiceProxy::new(service_wrapper.service().unwrap(),
-                                                     service_wrapper.service_run_state(),
-                                                     ConfigRendering::Redacted);
+        let proxy_without_config = ServiceQueryModel::new(service_wrapper.service().unwrap(),
+                                                          service_wrapper.service_run_state(),
+                                                          ConfigRendering::Redacted);
         let proxies_without_config = vec![proxy_without_config];
         let json_without_config =
             serde_json::to_string(&proxies_without_config).expect("Expected  to convert \

--- a/components/sup/src/manager/service.rs
+++ b/components/sup/src/manager/service.rs
@@ -21,8 +21,10 @@ mod terminator;
 use self::{context::RenderContext,
            hook_runner::HookRunner,
            hooks::{HookCompileTable,
-                   HookTable},
+                   HookTable,
+                   HookTableQueryModel},
            supervisor::{PidUpdate,
+                        SupervisedProcessQueryModel,
                         Supervisor}};
 pub use self::{health::{HealthCheckBundle,
                         HealthCheckHookStatus,
@@ -52,11 +54,11 @@ use habitat_common::templating::package::DEFAULT_USER;
 pub use habitat_common::templating::{config::{Cfg,
                                               UserConfigPath},
                                      package::{Env,
-                                               Pkg,
-                                               PkgProxy}};
+                                               Pkg}};
 use habitat_common::{outputln,
                      templating::{config::CfgRenderer,
-                                  hooks::Hook},
+                                  hooks::Hook,
+                                  package::PkgQueryModel},
                      FeatureFlag};
 #[cfg(windows)]
 use habitat_core::os::users;
@@ -71,7 +73,8 @@ use habitat_core::{crypto::Blake2bHash,
                    package::{metadata::Bind,
                              PackageIdent,
                              PackageInstall},
-                   service::{ServiceBind,
+                   service::{HealthCheckInterval,
+                             ServiceBind,
                              ServiceGroup},
                    ChannelIdent};
 use habitat_launcher_client::LauncherCli;
@@ -93,6 +96,7 @@ use serde::{ser::{Error as _,
             Serializer};
 use std::{self,
           collections::HashSet,
+          convert::TryFrom,
           fmt,
           fs,
           ops::Deref,
@@ -704,9 +708,6 @@ impl Service {
         let service_event_metadata = self.to_service_metadata();
         let service_health_result = Arc::clone(&self.health_check_result);
         let gateway_state = Arc::clone(&self.gateway_state);
-        // Initialize the gateway_state for this service to Unknown.
-        gateway_state.lock_gsw()
-                     .set_health_of(service_group.clone(), HealthCheckResult::Unknown);
         let f = async move {
             while let Some(HealthCheckBundle { status,
                                                result,
@@ -718,7 +719,13 @@ impl Service {
                                       .expect("Could not unlock service_health_result") = result;
 
                 gateway_state.lock_gsw()
-                             .set_health_of(service_group.clone(), result);
+                             .get_services_data_mut()
+                             .iter_mut()
+                             .for_each(|service| {
+                                 if service.service_group == service_group {
+                                     service.health_check = result;
+                                 }
+                             });
 
                 event::health_check(service_event_metadata.clone(), result, status, interval);
             }
@@ -789,13 +796,11 @@ impl Service {
         self.detach();
 
         let service_group = self.service_group.clone();
-        let gs = Arc::clone(&self.gateway_state);
 
         self.supervisor
             .lock()
             .expect("Couldn't lock supervisor")
             .stop(shutdown_config);
-        gs.lock_gsw().remove(&service_group);
 
         if let Some(hook) = self.post_stop() {
             if let Err(e) = hook.into_future().await {
@@ -1559,91 +1564,121 @@ pub enum ConfigRendering {
     Redacted,
 }
 
-/// This is a proxy struct to represent what information we're writing to the dat file, and
-/// therefore what information gets sent out via the HTTP API. Right now, we're just wrapping the
-/// actual Service struct, but this will give us something we can refactor against without
-/// worrying about breaking the data returned to users.
-pub struct ServiceProxy<'a> {
-    service:           &'a Service,
-    service_run_state: &'a ServiceRunState,
-    config_rendering:  ConfigRendering,
-}
+#[derive(Debug, Clone, Serialize)]
+pub struct UnixTimestamp(u64);
 
-impl<'a> ServiceProxy<'a> {
-    pub fn new(service: &'a Service,
-               service_run_state: &'a ServiceRunState,
-               config_rendering: ConfigRendering)
-               -> Self {
-        ServiceProxy { service,
-                       service_run_state,
-                       config_rendering }
+impl TryFrom<SystemTime> for UnixTimestamp {
+    type Error = std::time::SystemTimeError;
+
+    fn try_from(timestamp: SystemTime) -> result::Result<Self, Self::Error> {
+        Ok(UnixTimestamp(timestamp.duration_since(SystemTime::UNIX_EPOCH)?.as_secs()))
     }
 }
 
-impl<'a> Serialize for ServiceProxy<'a> {
-    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
-        where S: Serializer
-    {
-        let num_fields: usize = if self.config_rendering == ConfigRendering::Full {
-            31
-        } else {
-            30
-        };
+/// This is a queryable representation of a service. It allows us to separate the
+/// structure of the data returned through APIs from the actual internal representation.
+/// Importantly this allows us to refactor the API and internal models without
+/// worrying about breaking the data returned to users.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServiceQueryModel {
+    pub all_pkg_binds:          Vec<Bind>,
+    pub binding_mode:           BindingMode,
+    pub binds:                  Vec<ServiceBind>,
+    pub bldr_url:               String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cfg:                    Option<Cfg>,
+    pub channel:                ChannelIdent,
+    pub config_from:            Option<PathBuf>,
+    pub desired_state:          DesiredState,
+    pub health_check:           HealthCheckResult,
+    pub hooks:                  HookTableQueryModel,
+    pub initialized:            bool,
+    pub last_election_status:   ElectionStatus,
+    pub manager_fs_cfg:         Arc<FsCfg>,
+    pub pkg:                    PkgQueryModel,
+    pub process:                SupervisedProcessQueryModel,
+    pub last_process_state:     Option<LastProcessState>,
+    pub next_restart_at:        Option<UnixTimestamp>,
+    pub restart_count:          u64,
+    pub restart_config:         ServiceRestartConfig,
+    pub service_group:          ServiceGroup,
+    pub spec_file:              PathBuf,
+    pub spec_ident:             PackageIdent,
+    pub spec_identifier:        String,
+    pub svc_encrypted_password: Option<String>,
+    pub health_check_interval:  HealthCheckInterval,
+    pub sys:                    Arc<Sys>,
+    pub topology:               Topology,
+    pub update_strategy:        UpdateStrategy,
+    pub update_condition:       UpdateCondition,
+    pub user_config_updated:    bool,
+}
 
-        let s = &self.service;
-        let mut strukt = serializer.serialize_struct("service", num_fields)?;
-        strukt.serialize_field("all_pkg_binds", &s.all_pkg_binds)?;
-        strukt.serialize_field("binding_mode", &s.spec.binding_mode)?;
-        strukt.serialize_field("binds", &s.spec.binds)?;
-        strukt.serialize_field("bldr_url", &s.spec.bldr_url)?;
+impl ServiceQueryModel {
+    pub fn new(service: &Service,
+               service_run_state: &ServiceRunState,
+               config_rendering: ConfigRendering)
+               -> Self {
+        ServiceQueryModel { all_pkg_binds:          service.all_pkg_binds.clone(),
+                            binding_mode:           service.spec.binding_mode,
+                            binds:                  service.spec.binds.clone(),
+                            bldr_url:               service.spec.bldr_url.clone(),
+                            cfg:                    match config_rendering {
+                                ConfigRendering::Full => Some(service.cfg.clone()),
+                                ConfigRendering::Redacted => None,
+                            },
+                            channel:                service.spec.channel.clone(),
+                            config_from:            service.spec.config_from.clone(),
+                            desired_state:          service.spec.desired_state,
+                            health_check:
+                                (*service.health_check_result
+                                         .lock()
+                                         .expect("Couldn't lock health check result for \
+                                                  serialization")).clone(),
+                            hooks:                  HookTableQueryModel::new(&service.hooks),
+                            initialized:            service.initialized(),
+                            last_election_status:   service.last_election_status,
+                            manager_fs_cfg:         service.manager_fs_cfg.clone(),
+                            pkg:                    PkgQueryModel::new(&service.pkg),
+                            process:
+                                SupervisedProcessQueryModel::new(service.supervisor
+                                                                        .lock()
+                                                                        .expect("Couldn't lock \
+                                                                                 supervisor for \
+                                                                                 serialization")
+                                                                        .deref()),
+                            last_process_state:     service_run_state.last_process_state.clone(),
+                            next_restart_at:
+                                service_run_state.restart_backoff
+                                                 .duration_until_next_attempt_start()
+                                                 .and_then(|duration| {
+                                                     SystemTime::now().checked_add(duration)
+                                                 })
+                                                 .and_then(|timestamp| {
+                                                     UnixTimestamp::try_from(timestamp).ok()
+                                                 }),
+                            restart_count:          service_run_state.restart_count,
+                            restart_config:         service_run_state.restart_config.clone(),
+                            service_group:          service.service_group.clone(),
+                            spec_file:              service.spec_file.clone(),
+                            spec_ident:             service.spec.ident.clone(),
+                            spec_identifier:        service.spec.ident.to_string(),
+                            svc_encrypted_password: service.spec.svc_encrypted_password.clone(),
+                            health_check_interval:  service.spec.health_check_interval.clone(),
+                            sys:                    service.sys.clone(),
+                            topology:               service.spec.topology,
+                            update_strategy:        service.spec.update_strategy,
+                            update_condition:       service.spec.update_condition,
+                            user_config_updated:    service.user_config_updated, }
+    }
+}
 
-        if self.config_rendering == ConfigRendering::Full {
-            strukt.serialize_field("cfg", &s.cfg)?;
-        }
-
-        strukt.serialize_field("channel", &s.spec.channel)?;
-        strukt.serialize_field("config_from", &s.spec.config_from)?;
-        strukt.serialize_field("desired_state", &s.spec.desired_state)?;
-        strukt.serialize_field("health_check", &s.health_check_result)?;
-        strukt.serialize_field("hooks", &s.hooks)?;
-        strukt.serialize_field("initialized", &s.initialized())?;
-        strukt.serialize_field("last_election_status", &s.last_election_status)?;
-        strukt.serialize_field("manager_fs_cfg", &s.manager_fs_cfg)?;
-
-        let pkg_proxy = PkgProxy::new(&s.pkg);
-        strukt.serialize_field("pkg", &pkg_proxy)?;
-
-        strukt.serialize_field("process",
-                               s.supervisor
-                                .lock()
-                                .expect("Couldn't lock supervisor")
-                                .deref())?;
-        strukt.serialize_field("last_process_state",
-                               &self.service_run_state.last_process_state)?;
-        strukt.serialize_field("next_restart_at",
-                               &self.service_run_state
-                                    .restart_backoff
-                                    .duration_until_next_attempt_start()
-                                    .and_then(|duration| SystemTime::now().checked_add(duration))
-                                    .and_then(|timestamp| {
-                                        timestamp.duration_since(SystemTime::UNIX_EPOCH).ok()
-                                    })
-                                    .map(|duration| duration.as_secs()))?;
-        strukt.serialize_field("restart_count", &self.service_run_state.restart_count)?;
-        strukt.serialize_field("restart_config", &self.service_run_state.restart_config)?;
-        strukt.serialize_field("service_group", &s.service_group)?;
-        strukt.serialize_field("spec_file", &s.spec_file)?;
-        // Deprecated field; use spec_identifier instead
-        strukt.serialize_field("spec_ident", &s.spec.ident)?;
-        strukt.serialize_field("spec_identifier", &s.spec.ident.to_string())?;
-        strukt.serialize_field("svc_encrypted_password", &s.spec.svc_encrypted_password)?;
-        strukt.serialize_field("health_check_interval", &s.spec.health_check_interval)?;
-        strukt.serialize_field("sys", &s.sys)?;
-        strukt.serialize_field("topology", &s.spec.topology)?;
-        strukt.serialize_field("update_strategy", &s.spec.update_strategy)?;
-        strukt.serialize_field("update_condition", &s.spec.update_condition)?;
-        strukt.serialize_field("user_config_updated", &s.user_config_updated)?;
-        strukt.end()
+impl From<&ServiceQueryModel> for habitat_sup_protocol::types::ServiceStatus {
+    fn from(service: &ServiceQueryModel) -> Self {
+        Self { ident:         (*service.pkg.ident.as_ref()).clone().into(),
+               process:       Some((&service.process).into()),
+               service_group: service.service_group.clone().into(),
+               desired_state: Some(service.desired_state.into()), }
     }
 }
 

--- a/components/sup/src/manager/service/hooks.rs
+++ b/components/sup/src/manager/service/hooks.rs
@@ -563,6 +563,44 @@ impl HookCompileTable {
     }
 }
 
+// Queryable representation of a hook
+#[derive(Debug, Clone, Serialize)]
+pub struct HookQueryModel {
+    pub render_pair:     PathBuf,
+    pub stdout_log_path: PathBuf,
+    pub stderr_log_path: PathBuf,
+}
+
+// Queryable representation of all hooks of a service
+#[derive(Debug, Clone, Serialize)]
+pub struct HookTableQueryModel {
+    pub health_check: Option<HookQueryModel>,
+    pub init:         Option<HookQueryModel>,
+    pub file_updated: Option<HookQueryModel>,
+    pub reload:       Option<HookQueryModel>,
+    pub reconfigure:  Option<HookQueryModel>,
+    pub suitability:  Option<HookQueryModel>,
+    pub run:          Option<HookQueryModel>,
+    pub post_run:     Option<HookQueryModel>,
+    pub post_stop:    Option<HookQueryModel>,
+}
+
+impl HookTableQueryModel {
+    pub fn new(hook_table: &HookTable) -> HookTableQueryModel {
+        HookTableQueryModel {
+            health_check: hook_table.health_check.as_ref().map(|hook| HookQueryModel { render_pair: hook.render_pair.path.clone(), stdout_log_path: hook.stdout_log_path.clone(), stderr_log_path: hook.stderr_log_path.clone() }),
+            init: hook_table.init.as_ref().map(|hook| HookQueryModel { render_pair: hook.render_pair.path.clone(), stdout_log_path: hook.stdout_log_path.clone(), stderr_log_path: hook.stderr_log_path.clone() }),
+            file_updated: hook_table.file_updated.as_ref().map(|hook| HookQueryModel { render_pair: hook.render_pair.path.clone(), stdout_log_path: hook.stdout_log_path.clone(), stderr_log_path: hook.stderr_log_path.clone() }),
+            reload: hook_table.reload.as_ref().map(|hook| HookQueryModel { render_pair: hook.render_pair.path.clone(), stdout_log_path: hook.stdout_log_path.clone(), stderr_log_path: hook.stderr_log_path.clone() }),
+            reconfigure: hook_table.reconfigure.as_ref().map(|hook| HookQueryModel { render_pair: hook.render_pair.path.clone(), stdout_log_path: hook.stdout_log_path.clone(), stderr_log_path: hook.stderr_log_path.clone() }),
+            suitability: hook_table.suitability.as_ref().map(|hook| HookQueryModel { render_pair: hook.render_pair.path.clone(), stdout_log_path: hook.stdout_log_path.clone(), stderr_log_path: hook.stderr_log_path.clone() }),
+            run: hook_table.run.as_ref().map(|hook| HookQueryModel { render_pair: hook.render_pair.path.clone(), stdout_log_path: hook.stdout_log_path.clone(), stderr_log_path: hook.stderr_log_path.clone() }),
+            post_run: hook_table.post_run.as_ref().map(|hook| HookQueryModel { render_pair: hook.render_pair.path.clone(), stdout_log_path: hook.stdout_log_path.clone(), stderr_log_path: hook.stderr_log_path.clone() }),
+            post_stop: hook_table.post_stop.as_ref().map(|hook| HookQueryModel { render_pair: hook.render_pair.path.clone(), stdout_log_path: hook.stdout_log_path.clone(), stderr_log_path: hook.stderr_log_path.clone() })
+        }
+    }
+}
+
 // Hooks wrapped in Arcs represent a possibly-temporary state while we
 // refactor hooks to be able to run asynchronously.
 #[derive(Debug, Default, Serialize)]

--- a/components/sup/src/manager/service/supervisor.rs
+++ b/components/sup/src/manager/service/supervisor.rs
@@ -90,7 +90,7 @@ impl From<&SupervisedProcessQueryModel> for habitat_sup_protocol::types::Process
     fn from(process: &SupervisedProcessQueryModel) -> Self {
         // The process id is already u32 on windows, but that is not the case for other platforms
         #[cfg(target_os = "windows")]
-        let pid: Option<u32> = process.pid.map(|value| value);
+        let pid: Option<u32> = process.pid;
         #[cfg(not(target_os = "windows"))]
         let pid: Option<u32> = process.pid.map(|value| value as u32);
 


### PR DESCRIPTION
This PR refactors the HTTP Gateway code to use in memory structs as the source of truth instead of serialized JSON data. This also allows us to directly update these structs on service changes and prevent any data inconsistencies.
Namely the health check data between the `/services` and `/services/{svc}/{group}/{org}/health` endpoints should be identical.

This also addresses #8470.