### PR TITLE
add a rust-toolchain.toml to appease dependabot

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.68.2"


### PR DESCRIPTION
Noticed that dpendabot has not been running because it now expects rust-toolchain to be in toml format. Changing `/rust-toolchain` to toml is a larger change because we need to retrofit our automation to read toml. However, it looks like you can also have a `/rust-toolchain.toml` file. The question is will the .toml file take precedence for dependabot? If not then we need to update the automation (not a huge task) sooner than later.