### PR TITLE
replace plain test rust-toolchain with toml

### DIFF
--- a/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
+++ b/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
@@ -41,7 +41,7 @@ if [ "$BUILD_PKG_TARGET" == "aarch64-darwin" ]; then
 fi
 
 # set the rust toolchain
-rust_toolchain="$(cat rust-toolchain)"
+rust_toolchain="$(tail -n 1 rust-toolchain  | cut -d'"' -f 2)"
 echo "--- :rust: Using Rust toolchain ${rust_toolchain}"
 rustc --version # just 'cause I'm paranoid and I want to double check
 

--- a/.expeditor/scripts/shared.ps1
+++ b/.expeditor/scripts/shared.ps1
@@ -52,7 +52,7 @@ function Install-Habitat {
 }
 
 function Get-Toolchain {
-    "$((ConvertFrom-StringData (Get-Content $PSScriptRoot\..\..\rust-toolchain)[1]).channel.Replace("`"", ""))-x86_64-pc-windows-msvc"
+    "$((ConvertFrom-StringData (Get-Content $PSScriptRoot\..\..\rust-toolchain)[1]).channel.Replace('"', ''))-x86_64-pc-windows-msvc"
 }
 
 function New-PathString([string]$StartingPath, [string]$Path) {

--- a/.expeditor/scripts/shared.ps1
+++ b/.expeditor/scripts/shared.ps1
@@ -52,7 +52,7 @@ function Install-Habitat {
 }
 
 function Get-Toolchain {
-    "$(Get-Content $PSScriptRoot\..\..\rust-toolchain)-x86_64-pc-windows-msvc"
+    "$((ConvertFrom-StringData (Get-Content $PSScriptRoot\..\..\rust-toolchain)[1]).channel.Replace("`"", ""))-x86_64-pc-windows-msvc"
 }
 
 function New-PathString([string]$StartingPath, [string]$Path) {

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -49,7 +49,7 @@ install_rustup() {
 
 get_toolchain() {
     dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-    cat "$dir/../../rust-toolchain"
+    tail -n 1 "$dir/../../rust-toolchain" | cut -d'"' -f 2
 }
 
 # Chef's GPG key for generating signatures. See `import_gpg_keys`

--- a/.expeditor/scripts/verify/build_mac_package.sh
+++ b/.expeditor/scripts/verify/build_mac_package.sh
@@ -35,7 +35,7 @@ if [ "$BUILD_PKG_TARGET" == "aarch64-darwin" ]; then
     rustup target add aarch64-apple-darwin
 fi
 
-rust_toolchain="$(cat rust-toolchain)"
+rust_toolchain="$(tail -n 1 rust-toolchain  | cut -d'"' -f 2)"
 echo "--- :rust: Using Rust toolchain ${rust_toolchain}"
 rustc --version # just 'cause I'm paranoid and I want to double check
 

--- a/components/hab/habitat/plan.ps1
+++ b/components/hab/habitat/plan.ps1
@@ -8,7 +8,7 @@ $pkg_deps=@(
 $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace('"', ''))",
     "core/cacerts",
     "core/protobuf"
 )

--- a/components/hab/habitat/plan.ps1
+++ b/components/hab/habitat/plan.ps1
@@ -8,7 +8,7 @@ $pkg_deps=@(
 $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
     "core/cacerts",
     "core/protobuf"
 )

--- a/components/hab/habitat/plan.sh
+++ b/components/hab/habitat/plan.sh
@@ -9,7 +9,7 @@ pkg_deps=()
 pkg_build_deps=(core/musl
                 core/perl # Needed for vendored openssl-sys
                 core/coreutils
-                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
+                core/rust/"$(tail -n 1 "$SRC_PATH/../../rust-toolchain"  | cut -d'"' -f 2)"
                 core/gcc
                 core/protobuf)
 pkg_bin_dirs=(bin)

--- a/components/launcher/habitat/plan.ps1
+++ b/components/launcher/habitat/plan.ps1
@@ -7,7 +7,7 @@ $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @(
     "core/visual-cpp-redist-2015",
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
     "core/cacerts",
     "core/git",
     "core/protobuf"

--- a/components/launcher/habitat/plan.ps1
+++ b/components/launcher/habitat/plan.ps1
@@ -7,7 +7,7 @@ $pkg_bin_dirs = @("bin")
 $pkg_build_deps = @(
     "core/visual-cpp-redist-2015",
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace('"', ''))",
     "core/cacerts",
     "core/git",
     "core/protobuf"

--- a/components/launcher/habitat/plan.sh
+++ b/components/launcher/habitat/plan.sh
@@ -6,7 +6,7 @@ pkg_license=('Apache-2.0')
 pkg_deps=(core/glibc
           core/gcc-libs)
 pkg_build_deps=(core/coreutils
-                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
+                core/rust/"$(tail -n 1 "$SRC_PATH/../../rust-toolchain"  | cut -d'"' -f 2)"
                 core/gcc
                 core/git
                 core/protobuf)

--- a/components/pkg-export-container/habitat/plan.ps1
+++ b/components/pkg-export-container/habitat/plan.ps1
@@ -9,7 +9,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
     "core/cacerts",
     "core/protobuf"
 )

--- a/components/pkg-export-container/habitat/plan.ps1
+++ b/components/pkg-export-container/habitat/plan.ps1
@@ -9,7 +9,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace('"', '')))",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace('"', ''))",
     "core/cacerts",
     "core/protobuf"
 )

--- a/components/pkg-export-container/habitat/plan.ps1
+++ b/components/pkg-export-container/habitat/plan.ps1
@@ -9,7 +9,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace('"', '')))",
     "core/cacerts",
     "core/protobuf"
 )

--- a/components/pkg-export-container/habitat/plan.sh
+++ b/components/pkg-export-container/habitat/plan.sh
@@ -12,7 +12,7 @@ pkg_build_deps=(
     core/musl
     core/perl # Needed for vendored openssl-sys
     core/coreutils
-    core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
+    core/rust/"$(tail -n 1 "$SRC_PATH/../../rust-toolchain"  | cut -d'"' -f 2)"
     core/gcc
     core/make
     core/protobuf

--- a/components/pkg-export-tar/habitat/plan.ps1
+++ b/components/pkg-export-tar/habitat/plan.ps1
@@ -9,7 +9,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
     "core/cacerts"
 )
 

--- a/components/pkg-export-tar/habitat/plan.ps1
+++ b/components/pkg-export-tar/habitat/plan.ps1
@@ -9,7 +9,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace('"', ''))",
     "core/cacerts"
 )
 

--- a/components/pkg-export-tar/habitat/plan.sh
+++ b/components/pkg-export-tar/habitat/plan.sh
@@ -8,7 +8,7 @@ pkg_deps=()
 pkg_build_deps=(core/musl
                 core/perl # Needed for vendored openssl-sys
                 core/coreutils
-                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
+                core/rust/"$(tail -n 1 "$SRC_PATH/../../rust-toolchain"  | cut -d'"' -f 2)"
                 core/gcc
                 core/make)
 pkg_bin_dirs=(bin)

--- a/components/sup/habitat/plan.ps1
+++ b/components/sup/habitat/plan.ps1
@@ -10,7 +10,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$(Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
     "core/cacerts",
     "core/raml2html",
     "core/protobuf"

--- a/components/sup/habitat/plan.ps1
+++ b/components/sup/habitat/plan.ps1
@@ -10,7 +10,7 @@ $pkg_deps=@(
 )
 $pkg_build_deps = @(
     "core/visual-cpp-build-tools-2015",
-    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace("`"", ""))",
+    "core/rust/$((ConvertFrom-StringData (Get-Content "$PLAN_CONTEXT/../../../rust-toolchain")[1]).channel.Replace('"', ''))",
     "core/cacerts",
     "core/raml2html",
     "core/protobuf"

--- a/components/sup/habitat/plan.sh
+++ b/components/sup/habitat/plan.sh
@@ -12,7 +12,7 @@ pkg_build_deps=(core/coreutils
                 core/cacerts
                 core/make
                 core/perl # Needed for vendored openssl-sys
-                core/rust/"$(cat "$SRC_PATH/../../rust-toolchain")"
+                core/rust/"$(tail -n 1 "$SRC_PATH/../../rust-toolchain"  | cut -d'"' -f 2)"
                 core/gcc
                 core/raml2html
                 core/protobuf)

--- a/components/sup/static/plan.sh
+++ b/components/sup/static/plan.sh
@@ -5,7 +5,7 @@ pkg_name=hab-sup-static
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_deps=(core/busybox-static)
 pkg_build_deps=(
-  core/coreutils core/cacerts core/rust/"$(cat "$SRC_PATH/../../../rust-toolchain")" core/gcc
+  core/coreutils core/cacerts core/rust/"$(tail -n 1 "$SRC_PATH/../../rust-toolchain"  | cut -d'"' -f 2)" core/gcc
 )
 
 do_begin() {

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,2 @@
-1.68.2
+[toolchain]
+channel = "1.68.2"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.68.2"


### PR DESCRIPTION
Well it looks like we really need to convert `/rust-toolchain` to toml to get dependabot working again.