### PR TITLE
update yanked hermit-abi crate and fix e2e test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -1933,7 +1933,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1978,7 +1978,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "io-lifetimes",
  "rustix 0.36.8",
  "windows-sys 0.45.0",
@@ -2463,7 +2463,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
 ]
 

--- a/test/end-to-end/test_health_check_output_of_http_gateway.ps1
+++ b/test/end-to-end/test_health_check_output_of_http_gateway.ps1
@@ -11,8 +11,9 @@ Describe "HTTP gateway" {
     }
 
     $supLog = New-SupervisorLogFile("test_health_check_output_of_http_gateway")
-    $env:health_check_interval = 10
-    Start-Supervisor -LogFile $supLog -Timeout 45
+    Start-Supervisor -LogFile $supLog -Timeout 45 -SupArgs @( `
+            "--health-check-interval=10"
+    ) | Out-Null
     Load-SupervisorService $test_probe_release
     Wait-Release -Ident $test_probe_release
 
@@ -39,7 +40,7 @@ Describe "HTTP gateway" {
 
     Context "with a service that changes status" {
         Set-Content -Path "/hab/pkgs/$test_probe_release/health_exit" -Value 1
-        Start-Sleep 15
+        Start-Sleep 30
 
         It "returns status of the hook when queried" {
             $status = (Invoke-WebRequest "http://localhost:9631/services/test-probe/default/health" | ConvertFrom-Json).status


### PR DESCRIPTION
hermit-abi 0.3.1 was yanked and this updates to 0.3.2. This also hopefully fixes a intermittently broken e2e test.