### PR TITLE
Fixes license check for hab in studio setup code

### DIFF
--- a/components/studio/libexec/hab-studio-type-bare.sh
+++ b/components/studio/libexec/hab-studio-type-bare.sh
@@ -119,7 +119,8 @@ EOT
 _hab() (
     unset HAB_CACHE_KEY_PATH
     # shellcheck disable=2154
-    $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
+    # Set the HAB_LICENSE because the license accepted files don't yet exist on the chroot filesystem
+    $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_LICENSE="$HAB_LICENSE" "$hab" "$@"
 )
 
 _pkgpath_for() {
@@ -127,5 +128,5 @@ _pkgpath_for() {
 }
 
 _outside_pkgpath_for() {
-  $hab pkg path "$1"
+  HAB_LICENSE="$HAB_LICENSE" $hab pkg path "$1"
 }

--- a/components/studio/libexec/hab-studio-type-baseimage.sh
+++ b/components/studio/libexec/hab-studio-type-baseimage.sh
@@ -146,7 +146,8 @@ EOT
 _hab() (
     unset HAB_CACHE_KEY_PATH
     # shellcheck disable=2154
-    $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
+    # Set the HAB_LICENSE because the license accepted files don't yet exist on the chroot filesystem
+    $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_LICENSE="$HAB_LICENSE" "$hab" "$@"
 )
 
 _pkgpath_for() {
@@ -154,5 +155,5 @@ _pkgpath_for() {
 }
 
 _outside_pkgpath_for() {
-  $hab pkg path "$1"
+  HAB_LICENSE="$HAB_LICENSE" $hab pkg path "$1"
 }

--- a/components/studio/libexec/hab-studio-type-bootstrap.sh
+++ b/components/studio/libexec/hab-studio-type-bootstrap.sh
@@ -26,7 +26,7 @@ finish_setup() {
       # Import the secret origin key, required for signing packages
       info "Importing '$key' secret origin key"
       # shellcheck disable=2154
-      if key_text=$($hab origin key export --type secret "$key"); then
+      if key_text=$(HAB_LICENSE="$HAB_LICENSE" $hab origin key export --type secret "$key"); then
         printf -- "%s" "${key_text}" | _hab origin key import
       else
         echo "Error exporting $key key"
@@ -52,7 +52,7 @@ finish_setup() {
       fi
       # Attempt to import the public origin key, which can be used for local
       # package installations where the key may not yet be uploaded.
-      if key_text=$($hab origin key export --type public "$key" 2>/dev/null); then
+      if key_text=$(HAB_LICENSE="$HAB_LICENSE" $hab origin key export --type public "$key" 2>/dev/null); then
         info "Importing '$key' public origin key"
         printf -- "%s" "${key_text}" | _hab origin key import
       else
@@ -172,7 +172,8 @@ _hab() (
   # We remove a couple of env vars we do not want for this instance of the studio
   unset HAB_CACHE_KEY_PATH
   unset HAB_BLDR_CHANNEL
-  $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
+  # Set the HAB_LICENSE because the license accepted files don't yet exist on the chroot filesystem
+  $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_LICENSE="$HAB_LICENSE" "$hab" "$@"
 )
 
 _pkgpath_for() {

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -28,7 +28,7 @@ finish_setup() {
       # Import the secret origin key, required for signing packages
       info "Importing '$key' secret origin key"
       # shellcheck disable=2154
-      if key_text=$($hab origin key export --type secret "$key"); then
+      if key_text=$(HAB_LICENSE="$HAB_LICENSE" $hab origin key export --type secret "$key"); then
         printf -- "%s" "${key_text}" | _hab origin key import
       else
         echo "Error exporting $key key"
@@ -54,7 +54,7 @@ finish_setup() {
       fi
       # Attempt to import the public origin key, which can be used for local
       # package installations where the key may not yet be uploaded.
-      if key_text=$($hab origin key export --type public "$key" 2> /dev/null); then
+      if key_text=$(HAB_LICENSE="$HAB_LICENSE" $hab origin key export --type public "$key" 2> /dev/null); then
         info "Importing '$key' public origin key"
         printf -- "%s" "${key_text}" | _hab origin key import
       else
@@ -238,7 +238,8 @@ _hab() (
     # We remove a couple of env vars we do not want for this instance of the studio
     unset HAB_CACHE_KEY_PATH
     unset HAB_BLDR_CHANNEL
-    $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
+    # Set the HAB_LICENSE because the license accepted files don't yet exist on the chroot filesystem
+    $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_LICENSE="$HAB_LICENSE" "$hab" "$@"
 )
 
 _pkgpath_for() {

--- a/components/studio/libexec/hab-studio-type-stage1.sh
+++ b/components/studio/libexec/hab-studio-type-stage1.sh
@@ -23,7 +23,7 @@ finish_setup() {
       local key_text
       # Import the secret origin key, required for signing packages
       info "Importing '$key' secret origin key"
-      if key_text=$($hab origin key export --type secret "$key"); then
+      if key_text=$(HAB_LICENSE="$HAB_LICENSE" $hab origin key export --type secret "$key"); then
         printf -- "%s" "${key_text}" | _hab origin key import
       else
         echo "Error exporting $key key"
@@ -49,7 +49,7 @@ finish_setup() {
       fi
       # Attempt to import the public origin key, which can be used for local
       # package installations where the key may not yet be uploaded.
-      if key_text=$($hab origin key export --type public "$key" 2> /dev/null); then
+      if key_text=$(HAB_LICENSE="$HAB_LICENSE" $hab origin key export --type public "$key" 2> /dev/null); then
         info "Importing '$key' public origin key"
         printf -- "%s" "${key_text}" | _hab origin key import
       else
@@ -119,5 +119,6 @@ PROFILE
 # caller's environment.
 _hab() (
     unset HAB_CACHE_KEY_PATH
-    $bb env FS_ROOT="$HAB_STUDIO_ROOT" "$hab" "$@"
+    # Set the HAB_LICENSE because the license accepted files don't yet exist on the chroot filesystem
+    $bb env FS_ROOT="$HAB_STUDIO_ROOT" HAB_LICENSE="$HAB_LICENSE" "$hab" "$@"
 )


### PR DESCRIPTION
This resolves a long standing issue with license checking and the habitat studio which is explained in #7846.

We resolve this issue by explicitly evaluating the value of `HAB_LICENSE` early in the studio code. We also use this value in every invocation of the host system's hab command which will prevent the hab binary from prompting the user interactively for license acceptance.

Closes #7846, #7738