### PR TITLE
Fix Release Pipeline

### DIFF
--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -340,7 +340,7 @@ fastly_token() {
 
 latest_release_tag() {
   local repo="${1?repo argument required}"
-  tag=$(curl --silent "https://api.github.com/repos/${repo}/releases/latest" | jq -r .tag_name)
+  tag=$(curl --silent -L -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${repo}/releases/latest" | jq -r .tag_name)
   echo "${tag}"
 }
 


### PR DESCRIPTION
- Adds the `-L` option ensuring curl follows any redirects which can happen when the API changes
- Adds the `-H "X-GitHub-Api-Version: 2022-11-28"` option based on github's recommendation for using their versioned APIs https://docs.github.com/en/rest/overview/api-versions?apiVersion=2022-11-28