### PR TITLE
use rustls-webpki instead of webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "reqwest",
  "retry",
  "rustls",
+ "rustls-webpki",
  "same-file",
  "serde",
  "serde_json",
@@ -1289,7 +1290,6 @@ dependencies = [
  "url",
  "uuid 1.2.2",
  "walkdir",
- "webpki",
  "widestring 1.0.2",
  "winapi 0.3.9",
  "winreg 0.51.0",
@@ -1510,6 +1510,7 @@ dependencies = [
  "reqwest",
  "rustls",
  "rustls-pemfile",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_test",
@@ -1522,7 +1523,6 @@ dependencies = [
  "tokio-rustls",
  "toml 0.7.6",
  "url",
- "webpki",
  "widestring 1.0.2",
  "winapi 0.3.9",
  "windows-acl",
@@ -3299,6 +3299,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { version = "*", features = ["full"] }
 tokio-rustls = "*"
 toml = { version = "*", features = [ "preserve_order" ] }
 url = "*"
-webpki = "*"
+rustls-webpki = "*"
 xz2 = "*"
 
 [target.'cfg(not(windows))'.dependencies]

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -53,7 +53,7 @@ tokio = { version = "*", features = ["full"] }
 toml = { version = "*", features = [ "preserve_order" ] }
 url = { version = "*", features = ["serde"] }
 walkdir = "*"
-webpki = { version = "*", features = ["alloc"] }
+rustls-webpki = { version = "*", features = ["alloc"] }
 tempfile = "*"
 
 [dependencies.uuid]


### PR DESCRIPTION
This PR changes direct dependencies on webpki to rustls-webpki due to RUSTSEC-2023-0052. It does not completely address RUSTSEC-2023-0052 as of yet.  I believe for that to happen that actix-web will have to address their dependency and that their work to do so is starting with [this pull request](https://github.com/actix/actix-web/pull/3112).  See 
[webpki-reverse-dependencies.txt](https://github.com/habitat-sh/habitat/files/12429497/webpki-reverse-dependencies.txt) to review remaining indirect depending on webpki.