### PR TITLE
defaulting open-pull-requests-limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 20
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule: 
       interval: daily
-    open-pull-requests-limit: 20


### PR DESCRIPTION
I bumped dependabot's configuration to set open-pull-requests-limit to 20. This removes that configuration returning it back the default value of 5 because that was done while working through several interdependent crates triggering a RUSTSEC advisory.