### PR TITLE
audit.toml maintenance

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,39 +5,148 @@
 # permanently specified in this file.
 
 [advisories]
-# JAH: We are grandfathering the existing warnings so that we can deal
-# JAH: with them over time instead of forcing an immediate reckoning
+# JAH: The warnings below have been grandfathered dating to the start of our use
+# JAH: of cargo audit so that they can be dealt with over time. At the bottom of
+# JAH: this file is is a comment block stating what updating each crate would
+# JAH: require and what parts of habitat are downstream dependents
+#
 # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
 ignore = [
-    "RUSTSEC-2020-0016",    # Unmaintained: net2
-    "RUSTSEC-2020-0071",    # Vulerability, 6.2 Medium: time
-    "RUSTSEC-2021-0137",    # Unmaintained: sodiumoxide
-    "RUSTSEC-2021-0139",    # Unmaintained: ansi_term
-    "RUSTSEC-2021-0145",    # Unsound, Unmaintained: atty
-    "RUSTSEC-2022-0006",    # Vulnerability (???): thread_local
-    "RUSTSEC-2022-0013",    # Vulnerability (7.5 High), regex
-    "RUSTSEC-2022-0040",    # Vulnerability (???): owning_ref
-    "RUSTSEC-2022-0041",    # Unsound: crossbeam-utils
-    "RUSTSEC-2022-0048",    # Unmaintained: xml-rs
-    "RUSTSEC-2022-0071"     # Unmaintained: rusoto
+    "RUSTSEC-2020-0016", # Unmaintained: net2
+    "RUSTSEC-2021-0137", # Unmaintained: sodiumoxide
+    "RUSTSEC-2021-0139", # Unmaintained: ansi_term
+    "RUSTSEC-2021-0145", # Unsound, Unmaintained: atty
+    "RUSTSEC-2022-0006", # Vulnerability (???): thread_local
+    "RUSTSEC-2022-0013", # Vulnerability (7.5 High), regex
+    "RUSTSEC-2022-0040", # Vulnerability (???): owning_ref
+    "RUSTSEC-2022-0041", # Unsound: crossbeam-utils
+    "RUSTSEC-2022-0071", # Unmaintained: rusoto
 ]
-informational_warnings = ["notice", "unmaintained", "unsound"] # warn for categories of informational advisories
+informational_warnings = [
+    "notice",
+    "unmaintained",
+    "unsound",
+] # warn for categories of informational advisories
 severity_threshold = "none" # CVSS severity ("none", "low", "medium", "high", "critical")
 
 # Advisory Database Configuration
 [database]
-path = ".cargo/advisory-db" # Path where advisory git repo will be cloned
+path = ".cargo/advisory-db"                        # Path where advisory git repo will be cloned
 url = "https://github.com/RustSec/advisory-db.git" # URL to git repo
-fetch = true # Perform a `git fetch` before auditing (default: true)
-stale = false # Allow stale advisory DB (i.e. no commits for 90 days, default: false)
+fetch = true                                       # Perform a `git fetch` before auditing (default: true)
+stale = false                                      # Allow stale advisory DB (i.e. no commits for 90 days, default: false)
 
 # Output Configuration
 [output]
-deny = ["warnings", "unmaintained", "unsound", "yanked"] # exit on error if these are found
+deny = [
+    "warnings",
+    "unmaintained",
+    "unsound",
+    "yanked",
+] # exit on error if these are found
 format = "terminal" # "terminal" (human readable report) or "json"
 quiet = false # Only print information on error
 show_tree = true # Show inverse dependency trees along with advisories (default: true)
 
 [yanked]
-enabled = true # Warn for yanked crates in Cargo.lock (default: true)
+enabled = true      # Warn for yanked crates in Cargo.lock (default: true)
 update_index = true # Auto-update the crates.io index (default: true)
+
+#-------------------------------------------------------------------------------
+# "RUSTSEC-2020-0016",    # Unmaintained: net2
+# "RUSTSEC-2022-0041",    # Unsound: crossbeam-utils
+#-------------------------------------------------------------------------------
+#
+# Our Windows 7 support currently requires ipc-channel@0.15.0
+#
+# net2 0.2.37
+# ├── miow 0.2.2
+# │   └── mio 0.6.23
+# │       └── ipc-channel 0.15.0
+# │           ├── habitat-launcher-client 0.0.0
+# │           │   └── habitat_sup 0.0.0
+# │           └── habitat-launcher 0.0.0
+# └── mio 0.6.23
+#
+# crossbeam-utils 0.7.2
+# └── crossbeam-channel 0.4.4
+#     └── ipc-channel 0.15.0
+#         ├── habitat-launcher-client 0.0.0
+#         │   └── habitat_sup 0.0.0
+#         └── habitat-launcher 0.0.0
+#
+#-------------------------------------------------------------------------------
+# "RUSTSEC-2021-0137",    # Unmaintained: sodiumoxide
+#-------------------------------------------------------------------------------
+#
+# Requires selection of replacement cryptography crate
+#
+# sodiumoxide 0.2.7
+# └── habitat_core 0.0.0
+#
+#-------------------------------------------------------------------------------
+# "RUSTSEC-2021-0139",    # Unmaintained: ansi_term
+# "RUSTSEC-2021-0145",    # Unsound, Unmaintained: atty
+#-------------------------------------------------------------------------------
+#
+# Requires that we upgrade clap/structopt/configopt
+#
+# atty 0.2.14
+# ansi_term 0.11.0
+# └── clap 2.33.1
+#     ├── test-probe 0.1.0
+#     ├── structopt 0.3.15
+#     │   ├── habitat_sup 0.0.0
+#     │   ├── hab 0.0.0
+#     │   └── configopt 0.1.0
+#     │       ├── habitat_sup 0.0.0
+#     │       └── hab 0.0.0
+#     ├── habitat_sup 0.0.0
+#     ├── habitat_pkg_export_tar 0.0.0
+#     ├── habitat_pkg_export_container 0.0.0
+#     ├── habitat_common 0.0.0
+#     ├── habitat-rst-reader 0.0.0
+#     └── hab 0.0.0
+#
+#-------------------------------------------------------------------------------
+# "RUSTSEC-2022-0006",    # Vulnerability (???): thread_local
+# "RUSTSEC-2022-0013",    # Vulnerability (7.5 High), regex
+#-------------------------------------------------------------------------------
+#
+# Requires that we upgrade handlebars
+#
+# thread_local 0.3.6
+# └── regex 0.2.11 
+#     ├── handlebars 0.29.1
+#     │   ├── habitat_pkg_export_tar 0.0.0
+#     │   ├── habitat_pkg_export_container 0.0.0
+#     │   └── hab 0.0.0
+#     └── handlebars 0.28.3
+#         └── habitat_common 0.0.0
+#
+#-------------------------------------------------------------------------------
+# "RUSTSEC-2022-0040",    # Vulnerability (???): owning_ref
+#-------------------------------------------------------------------------------
+#
+# Requires that we update rants
+#
+# owning_ref 0.4.1
+# ├── rants 0.6.0
+# │   ├── habitat_sup 0.0.0
+# │   └── hab 0.0.0
+# └── habitat_common 0.0.0
+#
+#-------------------------------------------------------------------------------
+# "RUSTSEC-2022-0071"     # Unmaintained: rusoto
+#-------------------------------------------------------------------------------
+#
+# Requires selection of new "AWS crate" 
+#
+# rusoto_credential 0.48.0
+# ├── rusoto_signature 0.48.0
+# │   └── rusoto_core 0.48.0
+# │       ├── rusoto_ecr 0.48.0
+# │       │   └── habitat_pkg_export_container 0.0.0
+# │       └── habitat_pkg_export_container 0.0.0
+# ├── rusoto_core 0.48.0
+# └── habitat_pkg_export_container 0.0.0


### PR DESCRIPTION
Was able to eliminate RUSTSEC-2020-0071 (Vulerability, 6.2 Medium: time) and RUSTSEC-2022-0048 (Unmaintained: xml-rs). A recent updated by the chrono crate removed the time crate dependency that was triggering RUSTSEC-2020-0071. Advisory RUSTSEC-2022-0048 was rescinded as the xml-rs crate has a new maintainer.  Also added a comment block to the end which concisely discusses all of the remaining vulnerabilities.