### PR TITLE
Fix the verify pipeline to get macOS building again

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -335,9 +335,9 @@ steps:
     expeditor:
       executor:
         macos:
-          os-version: "11"
+          os-version: "12"
           inherit-environment-vars: true
-    timeout_in_minutes: 10
+    timeout_in_minutes: 60
     retry:
       automatic:
         limit: 10 # Addressing current Anka system timeouts due to oversubscription
@@ -998,7 +998,7 @@ steps:
     expeditor:
       executor:
         macos:
-          os-version: "10.15"
+          os-version: "12"
           inherit-environment-vars: true
     timeout_in_minutes: 60
     retry:
@@ -1018,7 +1018,7 @@ steps:
     expeditor:
       executor:
         macos:
-          os-version: "11"
+          os-version: "12"
           inherit-environment-vars: true
     timeout_in_minutes: 60
     retry:


### PR DESCRIPTION
### Problem

Our buildkit pipelines are failing because the macOS install script step is timing out.

### Root Cause

- [p11-kit releases 0.25.1 stable](https://github.com/p11-glue/p11-kit/releases)
- [Homebrew rolls out a 0.25.1 forumlae requiring meson and updates the 0.25.0 bottle dropping macOS 11 (Big Sur)](https://github.com/Homebrew/homebrew-core/commits/d75d5dde165275005185aee61c10b6dc1c597c6d/Formula/p/p11-kit.rb)
- Our gnupgp dependency is now using the updated p11-kit which brings in meson, ninja, and python as new dependencies and the install step is timing out.

### Solution

- Change the timeout for the step to 60m matching the timeout for other macOS steps

### While we're here...

- Since macOS 11 (Big Sur) has apparently gone EOL as of Sept 26, 2023, change macOS version to 12 (Monterey) as that's [the last approved version in expeditor](https://github.com/chef/expeditor/blob/5e8f0b19519b9abe40dea19c433f4443ddaa259e/expeditor-ruby/lib/expeditor/cli/buildkite/executor/macos.rb#L54).