### PR TITLE
toToml helper fix

### DIFF
--- a/components/common/src/templating/helpers/to_toml.rs
+++ b/components/common/src/templating/helpers/to_toml.rs
@@ -17,13 +17,27 @@ impl HelperDef for ToTomlHelper {
         // `serde_json` has been compiled with the `preserve_order`
         // feature, since order *is* important for TOML (values must
         // be emitted before tables).
-        let toml = toml::ser::to_string(&param).map_err(|e| {
-                                                   RenderError::new(format!("Can't serialize \
-                                                                             parameter to TOML: \
-                                                                             {}",
-                                                                            e))
-                                               })?;
-        rc.writer.write_all(toml.into_bytes().as_ref())?;
+        if param.is_object() {
+            let toml = toml::ser::to_string(&param).map_err(|e| {
+                                                       RenderError::new(format!("Can't serialize \
+                                                                                 parameter to \
+                                                                                 TOML: {}",
+                                                                                e))
+                                                   })?;
+            rc.writer.write_all(toml.into_bytes().as_ref())?;
+        } else {
+            let mut value = String::new();
+            serde::Serialize::serialize(
+                &param,
+                toml::ser::ValueSerializer::new(&mut value)
+            ).map_err(|e| {
+                                RenderError::new(format!("Can't serialize \
+                                                         parameter to TOML: \
+                                                         {}",
+                                                        e))
+                            })?;
+            rc.writer.write_all(value.into_bytes().as_ref())?;
+        }
         Ok(())
     }
 }
@@ -82,6 +96,91 @@ mod tests {
         renderer.register_template_string("t", "{{ toToml cfg }}")
                 .expect("Couldn't register template!");
 
+        assert!(renderer.render("t", &cfg).is_ok());
+    }
+
+    #[test]
+    fn toml_tables_are_serialized_for_str_array() {
+        let mut config = Table::new();
+        config.insert("build_targets".to_string(),
+                      Value::Array(vec![Value::String("x86_64-linux".to_string())]));
+        let mut cfg = Table::new();
+        cfg.insert("cfg".to_string(), Value::Table(config));
+
+        assert!(toml::to_string(&cfg).is_ok(),
+                "Should be able to render a Table directly as TOML");
+
+        // We should also be able to render the same thing through handlebars
+        let mut renderer = TemplateRenderer::new();
+        let tmpl = "build_targets = {{toToml cfg.build_targets}}";
+        renderer.register_template_string("t", tmpl)
+                .expect("Couldn't register template!");
+        let result = renderer.render("t", &cfg);
+        assert!(result.is_ok());
+        let generated_cfg = result.unwrap();
+        assert_eq!(generated_cfg, "build_targets = [\"x86_64-linux\"]");
+    }
+
+    #[test]
+    fn toml_tables_are_serialized_for_values() {
+        let mut config = Table::new();
+        config.insert("log_level".to_string(), Value::String("info".to_string()));
+        config.insert("log_path".to_string(), Value::String("/tmp".to_string()));
+        config.insert("job_timeout".to_string(), Value::Integer(60));
+        config.insert("build_targets".to_string(),
+                      Value::Array(vec![Value::String("x86_64-linux".to_string())]));
+        config.insert("features_enabled".to_string(),
+                      Value::String("".to_string()));
+
+        let mut cfg = Table::new();
+        cfg.insert("cfg".to_string(), Value::Table(config));
+
+        assert!(toml::to_string(&cfg).is_ok(),
+                "Should be able to render a Table directly as TOML");
+
+        // We should also be able to render the same thing through handlebars
+        let mut renderer = TemplateRenderer::new();
+        let tmpl = r#"log_path = {{toToml cfg.log_path}}
+job_timeout = {{cfg.job_timeout}}
+build_targets = {{toToml cfg.build_targets}}
+features_enabled = "{{cfg.features_enabled}}""#;
+        renderer.register_template_string("t", tmpl)
+                .expect("Couldn't register template!");
+        assert!(renderer.render("t", &cfg).is_ok());
+    }
+
+    #[test]
+    fn toml_tables_are_serialized_for_values_and_partial_toml() {
+        let mut config = Table::new();
+        config.insert("log_level".to_string(), Value::String("info".to_string()));
+        config.insert("log_path".to_string(), Value::String("/tmp".to_string()));
+        config.insert("job_timeout".to_string(), Value::Integer(60));
+        config.insert("build_targets".to_string(),
+                      Value::Array(vec![Value::String("x86_64-linux".to_string())]));
+        config.insert("features_enabled".to_string(),
+                      Value::String("".to_string()));
+
+        let mut backend = Table::new();
+        backend.insert("backend".to_string(), Value::String("local".to_string()));
+        config.insert("archive".to_string(), Value::Table(backend));
+
+        let mut cfg = Table::new();
+        cfg.insert("cfg".to_string(), Value::Table(config));
+
+        assert!(toml::to_string(&cfg).is_ok(),
+                "Should be able to render a Table directly as TOML");
+
+        // We should also be able to render the same thing through handlebars
+        let mut renderer = TemplateRenderer::new();
+        let tmpl = r#"log_path = "{{cfg.log_path}}"
+job_timeout = {{cfg.job_timeout}}
+build_targets = {{toToml cfg.build_targets}}
+features_enabled = "{{cfg.features_enabled}}"
+
+[archive]
+{{toToml cfg.archive}}"#;
+        renderer.register_template_string("t", tmpl)
+                .expect("Couldn't register template!");
         assert!(renderer.render("t", &cfg).is_ok());
     }
 }


### PR DESCRIPTION
The issue has been observed during the local setup of the builder.

The issue is failing with the following scenarios:
[default,toml] 
my_values = ["a", "b", "c"]
[config,toml]
my_values = {{toToml cfg.my_values}}

If we configure it as:
build_targets = {{cfg.my_values}}
It writes as:
my_values = [a, b, c,]

**Here are the simple instructions to reproduce it using builder source:**

1. Enter the Habitat Studio: hab studio enter
2. Start the builder: start-builder

The error is particularly occurring on the line `build_targets = {{toToml cfg.build_targets}}` in the `config.toml` file of the builder-jobsrv component.

The reason seems to be the updating toml crate (https://github.com/habitat-sh/habitat/commit/4c8b5fbef186ac5db04236226c15742b56238393), particularly replacing `to_vec` with `to_string`.

According to the change log (https://github.com/toml-rs/toml/blob/main/crates/toml/CHANGELOG.md#compatibility-2), `to_string` should be used for TOML documents, not values.

I've also added a few test cases to cover these scenarios. However, I'm not sure if this is the only case where we need this.
