### PR TITLE
bump unsafe-libyaml to 0.2.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4127,9 +4127,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
 name = "untrusted"


### PR DESCRIPTION
This should get rid of audit failures.