### PR TITLE
fix verify pipeline

### DIFF
--- a/.expeditor/scripts/release_habitat/create_manifest.rb
+++ b/.expeditor/scripts/release_habitat/create_manifest.rb
@@ -18,7 +18,7 @@ class ManifestUtil
 
     input_lines = []
 
-    f = File.open(filename, { mode: 'r', encoding: 'UTF-8' })
+    f = File.open(filename, "r:UTF-8")
     f.each_line do | line |
       input_lines << line.chomp
     end
@@ -71,4 +71,4 @@ version = ARGV[1]
 sha = ARGV[2]
 
 manifest = ManifestUtil.new.generate(version, sha, filename, log)
-File.write("manifest.json", JSON.pretty_generate(manifest), { mode: 'w', encoding: 'UTF-8' })
+File.write("manifest.json", JSON.pretty_generate(manifest), mode: 'w', encoding: 'UTF-8')

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -629,6 +629,9 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
       BUILD_PKG_TARGET: "x86_64-linux"
+      HAB_BLDR_CHANNEL: "acceptance"
+      HAB_INTERNAL_BLDR_CHANNEL: "acceptance"
+      HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL: "true"
     command:
       - .expeditor/scripts/verify/build_package.sh components/backline
     expeditor:
@@ -671,6 +674,9 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
       BUILD_PKG_TARGET: "x86_64-linux"
+      HAB_BLDR_CHANNEL: "acceptance"
+      HAB_INTERNAL_BLDR_CHANNEL: "acceptance"
+      HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL: "true"
     command:
       - .expeditor/scripts/verify/build_package.sh components/pkg-cfize
     expeditor:
@@ -798,6 +804,9 @@ steps:
     env:
       HAB_LICENSE: "accept-no-persist"
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
+      HAB_BLDR_CHANNEL: "acceptance"
+      HAB_INTERNAL_BLDR_CHANNEL: "acceptance"
+      HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL: "true"
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
Our CI image bumped its version of ruby and the core package refresh is breaking the backline and cfize builds. This makes small tweaks to the ruby based manifest generator to work with a more modern ruby. This also tells the backline and cfize builds to consume from acceptance so that it will get versions of plan-build built against the core package refresh.