### PR TITLE
bump mac release build to macos 11

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -69,7 +69,7 @@ steps:
     expeditor:
       executor:
         macos:
-          os-version: "10.15"
+          os-version: "11"
           inherit-environment-vars: true
     timeout_in_minutes: 60
     retry:


### PR DESCRIPTION
Mac 10 is no longer on Anka and release pipeline is failing.