### PR TITLE
CHEF-9418: Fixes peer file watching behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.8.1"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbb46d5d01695d7a1fb8be5f0d1968bd2b2b8ba1d1b3e7062ce2a0593e57af1"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
 dependencies = [
  "log 0.4.21",
  "serde",

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -49,7 +49,7 @@ impl PeerWatcher {
     }
 
     fn setup_watcher(path: PathBuf) -> Result<Arc<AtomicBool>> {
-        let have_events = Arc::new(AtomicBool::new(false));
+        let have_events = Arc::new(AtomicBool::new(true));
         let have_events_for_thread = Arc::clone(&have_events);
 
         ThreadBuilder::new().name(format!("peer-watcher-[{}]", path.display()))

--- a/components/sup/src/manager/peer_watcher.rs
+++ b/components/sup/src/manager/peer_watcher.rs
@@ -171,8 +171,12 @@ mod tests {
         lock.unset();
         let watcher = PeerWatcher::run(path).unwrap();
 
-        assert!(!watcher.has_fs_events());
+        // The watcher always has events initially
+        assert!(watcher.has_fs_events());
+        // We verify that the watcher finds no peers, since the file doesn't exist
         assert_eq!(watcher.get_members().unwrap(), vec![]);
+        // The watcher now has no more events
+        assert!(!watcher.has_fs_events());
     }
 
     #[test]


### PR DESCRIPTION
Modifies the peer file watcher to always perform atleast one initial read attempt on the peer file. We do this by initializing the initial value of the `have_events` flag to `true` instead of `false`.