### PR TITLE
CHEF-12227: vulnerable owning_ref crate

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,7 +18,6 @@ ignore = [
     "RUSTSEC-2021-0145", # Unsound, Unmaintained: atty
     "RUSTSEC-2022-0006", # Vulnerability (???): thread_local
     "RUSTSEC-2022-0013", # Vulnerability (7.5 High), regex
-    "RUSTSEC-2022-0040", # Vulnerability (???): owning_ref
     "RUSTSEC-2022-0041", # Unsound: crossbeam-utils
     "RUSTSEC-2022-0071", # Unmaintained: rusoto
 ]
@@ -116,7 +115,7 @@ update_index = true # Auto-update the crates.io index (default: true)
 # Requires that we upgrade handlebars
 #
 # thread_local 0.3.6
-# └── regex 0.2.11 
+# └── regex 0.2.11
 #     ├── handlebars 0.29.1
 #     │   ├── habitat_pkg_export_tar 0.0.0
 #     │   ├── habitat_pkg_export_container 0.0.0
@@ -124,23 +123,12 @@ update_index = true # Auto-update the crates.io index (default: true)
 #     └── handlebars 0.28.3
 #         └── habitat_common 0.0.0
 #
-#-------------------------------------------------------------------------------
-# "RUSTSEC-2022-0040",    # Vulnerability (???): owning_ref
-#-------------------------------------------------------------------------------
-#
-# Requires that we update rants
-#
-# owning_ref 0.4.1
-# ├── rants 0.6.0
-# │   ├── habitat_sup 0.0.0
-# │   └── hab 0.0.0
-# └── habitat_common 0.0.0
 #
 #-------------------------------------------------------------------------------
 # "RUSTSEC-2022-0071"     # Unmaintained: rusoto
 #-------------------------------------------------------------------------------
 #
-# Requires selection of new "AWS crate" 
+# Requires selection of new "AWS crate"
 #
 # rusoto_credential 0.48.0
 # ├── rusoto_signature 0.48.0

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.sig.key
 *.sym.key
 .cargo/advisory-db/
+.cargo/advisory-db..lock
 .DS_Store
 .envrc
 .secrets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1508,7 +1508,6 @@ dependencies = [
  "log 0.4.21",
  "native-tls",
  "nix 0.29.0",
- "owning_ref",
  "parking_lot",
  "pbr",
  "petgraph",
@@ -1516,6 +1515,7 @@ dependencies = [
  "reqwest",
  "retry",
  "rustls",
+ "safer_owning_ref",
  "serde",
  "serde-transcode",
  "serde_json",
@@ -2613,15 +2613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,17 +3009,17 @@ dependencies = [
 
 [[package]]
 name = "rants"
-version = "0.6.0"
-source = "git+https://github.com/habitat-sh/rants.git#7fd1434ecaaf9af743ccab1840034f5d71329935"
+version = "0.6.1"
+source = "git+https://github.com/habitat-sh/rants.git#9f268782e17c93d35e24ca433f6a1297e23e22fe"
 dependencies = [
  "bytes",
  "futures",
  "log 0.4.21",
  "native-tls",
  "nom",
- "owning_ref",
  "pin-project",
  "rand 0.8.5",
+ "safer_owning_ref",
  "serde",
  "serde_json",
  "tokio",
@@ -3391,6 +3382,15 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "safer_owning_ref"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af21b9de2df966f61c07b5b541c81c98225b86e48ababd43366a642654de30ef"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "same-file"

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -33,7 +33,7 @@ lazy_static = "*"
 libc = "*"
 log = "0.4"
 native-tls = { version = "*", features = ["vendored"] }
-owning_ref = "*"
+safer_owning_ref = "*"
 parking_lot = "*"
 pbr = "*"
 petgraph = "*"

--- a/components/common/src/owning_refs.rs
+++ b/components/common/src/owning_refs.rs
@@ -63,19 +63,19 @@ impl<'a, T> From<RwLockWriteGuard<'a, T>> for StableRwLockWriteGuard<'a, T> {
 }
 
 /// Typedef of a owning reference that uses a `MutexGuard` as the owner.
-pub type MutexGuardRef<'a, T, U = T> = OwningRef<StableMutexGuard<'a, T>, U>;
+pub type MutexGuardRef<'a, T, U = T> = OwningRef<'a, StableMutexGuard<'a, T>, U>;
 
 /// Typedef of a mutable owning reference that uses a `MutexGuard` as the owner.
-pub type MutexGuardRefMut<'a, T, U = T> = OwningRefMut<StableMutexGuard<'a, T>, U>;
+pub type MutexGuardRefMut<'a, T, U = T> = OwningRefMut<'a, StableMutexGuard<'a, T>, U>;
 
 /// Typedef of a owning reference that uses a `RwLockReadGuard` as the owner.
-pub type RwLockReadGuardRef<'a, T, U = T> = OwningRef<StableRwLockReadGuard<'a, T>, U>;
+pub type RwLockReadGuardRef<'a, T, U = T> = OwningRef<'a, StableRwLockReadGuard<'a, T>, U>;
 
 /// Typedef of a owning reference that uses a `RwLockWriteGuard` as the owner.
-pub type RwLockWriteGuardRef<'a, T, U = T> = OwningRef<StableRwLockWriteGuard<'a, T>, U>;
+pub type RwLockWriteGuardRef<'a, T, U = T> = OwningRef<'a, StableRwLockWriteGuard<'a, T>, U>;
 
 /// Typedef of a mutable owning reference that uses a `RwLockWriteGuard` as the owner.
-pub type RwLockWriteGuardRefMut<'a, T, U = T> = OwningRefMut<StableRwLockWriteGuard<'a, T>, U>;
+pub type RwLockWriteGuardRefMut<'a, T, U = T> = OwningRefMut<'a, StableRwLockWriteGuard<'a, T>, U>;
 
 #[test]
 fn raii_locks() {

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = "*"
 libc = "*"
 log = "0.4"
 pbr = "*"
-rants = { git = "https://github.com/habitat-sh/rants.git", features = ["native-tls"] }
+rants = { version = "0.6.1", git = "https://github.com/habitat-sh/rants.git", features = ["native-tls"] }
 reqwest = { version = "*", features = ["blocking", "json", "stream"] }
 retry = { git = "https://github.com/habitat-sh/retry", features = ["asynchronous"] }
 rustls = "*"

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -53,7 +53,7 @@ prometheus = "*"
 prost = { version = "*", features = ["prost-derive"] }
 prost-types = "*"
 rand = "*"
-rants = { git = "https://github.com/habitat-sh/rants.git", features = [
+rants = { version = "0.6.1", git = "https://github.com/habitat-sh/rants.git", features = [
   "native-tls",
 ] }
 regex = "*"


### PR DESCRIPTION
- change owning_ref crate to safer_owning_ref crate
- use habitat.sh/rants 6.1 which uses safer_owning_ref crate
- added .cargo/advisory-db..lock to .gitignore