### PR TITLE
Studio can build against downgraded channels

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -13,7 +13,8 @@ expeditor:
         HAB_ORIGIN: "core"
         PIPELINE_HAB_BLDR_URL: "https://bldr.habitat.sh"
         # Necessary to prevent old studios from poisoning builds after core plans refreshes
-        HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL: "true"
+        HAB_STUDIO_SECRET_HAB_PREFER_LOCAL_CHEF_DEPS: "true"
+        HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: "stable"
 
 steps:
 #######################################################################

--- a/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
+++ b/.expeditor/scripts/end_to_end/run_e2e_test_core.ps1
@@ -267,8 +267,12 @@ function Get-Leader($Remote, $ServiceGroup) {
     }
 }
 
-function Invoke-Build($PackageName) {
-    hab pkg build test/fixtures/$PackageName --reuse
+function Invoke-Build($PackageName, $RefreshChannel) {
+    $commandArgs = @("--reuse")
+    if($RefreshChannel) {
+        $commandArgs += @("--refresh-channel", $RefreshChannel)
+    }
+    hab pkg build test/fixtures/$PackageName $commandArgs
     if ($IsLinux) {
         # This changes the format of last_build from `var=value` to `$var='value'`
         # so that powershell can parse and source the script
@@ -277,8 +281,8 @@ function Invoke-Build($PackageName) {
     }
 }
 
-Function Invoke-BuildAndInstall($PackageName) {
-    Invoke-Build $PackageName
+Function Invoke-BuildAndInstall($PackageName, $RefreshChannel) {
+    Invoke-Build @PSBoundParameters
     . ./results/last_build.ps1
     hab pkg install ./results/$pkg_artifact
     hab studio run "rm /hab/pkgs/$pkg_ident/hooks"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -631,7 +631,6 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux"
       HAB_BLDR_CHANNEL: "acceptance"
       HAB_INTERNAL_BLDR_CHANNEL: "acceptance"
-      HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL: "true"
     command:
       - .expeditor/scripts/verify/build_package.sh components/backline
     expeditor:
@@ -676,7 +675,6 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux"
       HAB_BLDR_CHANNEL: "acceptance"
       HAB_INTERNAL_BLDR_CHANNEL: "acceptance"
-      HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL: "true"
     command:
       - .expeditor/scripts/verify/build_package.sh components/pkg-cfize
     expeditor:
@@ -806,7 +804,6 @@ steps:
       BUILD_PKG_TARGET: "x86_64-linux-kernel2"
       HAB_BLDR_CHANNEL: "acceptance"
       HAB_INTERNAL_BLDR_CHANNEL: "acceptance"
-      HAB_STUDIO_SECRET_HAB_FEAT_IGNORE_LOCAL: "true"
     expeditor:
       executor:
         docker:

--- a/components/common/src/command/package/install.rs
+++ b/components/common/src/command/package/install.rs
@@ -251,10 +251,6 @@ pub enum InstallHookMode {
 /// package to satisfy a dependency, or if we should ignore it, thus
 /// giving the user the opportunity to try installing from another
 /// channel.
-///
-/// Usage of this is currently hidden behind the IGNORE_LOCAL feature
-/// flag, as there is still some question as to the best way to solve
-/// this.
 #[derive(Debug, Eq, PartialEq)]
 pub enum LocalPackageUsage {
     /// Use locally-installed packages if they satisfy the desired
@@ -531,7 +527,7 @@ impl<'a> InstallTask<'a> {
 
             match (latest_local, latest_remote) {
                 (Ok(local), Some(remote)) => {
-                    if local > remote {
+                    if local > remote && !self.ignore_locally_installed_packages() {
                         // Return the latest identifier reported by
                         // the Builder API *unless* there is a newer
                         // version found installed locally.
@@ -546,8 +542,6 @@ impl<'a> InstallTask<'a> {
                 }
                 (Ok(local), None) => {
                     if self.ignore_locally_installed_packages() {
-                        // This is the behavior that is currently
-                        // governed by the IGNORE_LOCAL feature-flag
                         self.recommend_channels(ui, (&ident, target), token).await?;
                         ui.warn(format!("Locally-installed package '{}' would satisfy '{}', \
                                          but we are ignoring that as directed",

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -75,7 +75,6 @@ bitflags::bitflags! {
         #[cfg(target_family = "unix")]
         const NATIVE_PACKAGE_SUPPORT     = 0b0000_0010_0000;
         const OFFLINE_INSTALL            = 0b0000_0100_0000;
-        const IGNORE_LOCAL               = 0b0000_1000_0000;
         const TRIGGER_ELECTION           = 0b0010_0000_0000;
         const STRUCTOPT_CLI              = 0b0100_0000_0000;
         const NO_NAMED_PIPE_HEALTH_CHECK = 0b1000_0000_0000;
@@ -90,7 +89,6 @@ lazy_static! {
                  (FeatureFlag::TEST_BOOT_FAIL, "HAB_FEAT_BOOT_FAIL"),
                  (FeatureFlag::REDACT_HTTP, "HAB_FEAT_REDACT_HTTP"),
                  (FeatureFlag::OFFLINE_INSTALL, "HAB_FEAT_OFFLINE_INSTALL"),
-                 (FeatureFlag::IGNORE_LOCAL, "HAB_FEAT_IGNORE_LOCAL"),
                  (FeatureFlag::TRIGGER_ELECTION, "HAB_FEAT_TRIGGER_ELECTION"),
                  (FeatureFlag::STRUCTOPT_CLI, "HAB_FEAT_STRUCTOPT_CLI"),
                  (FeatureFlag::NO_NAMED_PIPE_HEALTH_CHECK, "HAB_FEAT_NO_NAMED_PIPE_HEALTH_CHECK"),

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -354,7 +354,7 @@ pub struct PkgBuild {
                 long = "refresh-channel",
                 env = "HAB_REFRESH_CHANNEL",
                 default_value = "LTS-2024")]
-    refresh_channel:          Option<String>,
+    refresh_channel: Option<String>,
 }
 
 /// Bulk Uploads Habitat Artifacts to a Depot from a local directory

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -348,7 +348,7 @@ pub struct PkgBuild {
     /// Uses a Dockerized Studio for the build
     #[structopt(name = "DOCKER", short = "D", long = "docker")]
     docker:          bool,
-    /// Channel used to retrieve plan dpendencies for Chef supported origins
+    /// Channel used to retrieve plan dependencies for Chef supported origins
     #[structopt(name = "REFRESH_CHANNEL",
                 short = "f",
                 long = "refresh-channel",

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -353,7 +353,7 @@ pub struct PkgBuild {
                 short = "f",
                 long = "refresh-channel",
                 env = "HAB_REFRESH_CHANNEL",
-                default_value = "LTS-2024")]
+                default_value = "stable")]
     refresh_channel: Option<String>,
 }
 

--- a/components/hab/src/cli/hab/pkg.rs
+++ b/components/hab/src/cli/hab/pkg.rs
@@ -348,6 +348,13 @@ pub struct PkgBuild {
     /// Uses a Dockerized Studio for the build
     #[structopt(name = "DOCKER", short = "D", long = "docker")]
     docker:          bool,
+    /// Channel used to retrieve plan dpendencies for Chef supported origins
+    #[structopt(name = "REFRESH_CHANNEL",
+                short = "f",
+                long = "refresh-channel",
+                env = "HAB_REFRESH_CHANNEL",
+                default_value = "LTS-2024")]
+    refresh_channel:          Option<String>,
 }
 
 /// Bulk Uploads Habitat Artifacts to a Depot from a local directory
@@ -523,8 +530,7 @@ pub struct PkgInstall {
     offline:               bool,
     /// Do not use locally-installed packages when a corresponding package cannot be installed
     /// from Builder
-    #[structopt(long = "ignore-local",
-                hidden = !FEATURE_FLAGS.contains(FeatureFlag::IGNORE_LOCAL))]
+    #[structopt(long = "ignore-local")]
     ignore_local:          bool,
 }
 

--- a/components/hab/src/command/pkg/build.rs
+++ b/components/hab/src/command/pkg/build.rs
@@ -14,7 +14,8 @@ pub async fn start(ui: &mut UI,
                    origins: &[Origin],
                    native_package: bool,
                    reuse: bool,
-                   docker: bool)
+                   docker: bool,
+                   refresh_channel: Option<&str>)
                    -> Result<()> {
     let mut args: Vec<OsString> = Vec::new();
     if let Some(root) = root {
@@ -24,6 +25,10 @@ pub async fn start(ui: &mut UI,
     if let Some(src) = src {
         args.push("-s".into());
         args.push(src.into());
+    }
+    if let Some(refresh_channel) = refresh_channel {
+        args.push("-f".into());
+        args.push(refresh_channel.into());
     }
 
     if !origins.is_empty() {

--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -809,6 +809,7 @@ async fn sub_pkg_build(ui: &mut UI, m: &ArgMatches<'_>, feature_flags: FeatureFl
     let plan_context = required_value_of(m, "PLAN_CONTEXT");
     let root = m.value_of("HAB_STUDIO_ROOT");
     let src = m.value_of("SRC_PATH");
+    let refresh_channel = m.value_of("REFRESH_CHANNEL");
 
     let origins = hab_key_origins(m)?;
     if !origins.is_empty() {
@@ -846,7 +847,8 @@ async fn sub_pkg_build(ui: &mut UI, m: &ArgMatches<'_>, feature_flags: FeatureFl
                                &origins,
                                native_package,
                                reuse,
-                               docker).await
+                               docker,
+                               refresh_channel).await
 }
 
 fn sub_pkg_config(m: &ArgMatches<'_>) -> Result<()> {
@@ -1104,12 +1106,11 @@ async fn sub_pkg_install(ui: &mut UI,
             InstallMode::default()
         };
 
-    let local_package_usage =
-        if feature_flags.contains(FeatureFlag::IGNORE_LOCAL) && m.is_present("IGNORE_LOCAL") {
-            LocalPackageUsage::Ignore
-        } else {
-            LocalPackageUsage::default()
-        };
+    let local_package_usage = if m.is_present("IGNORE_LOCAL") {
+        LocalPackageUsage::Ignore
+    } else {
+        LocalPackageUsage::default()
+    };
 
     let install_hook_mode = if m.is_present("IGNORE_INSTALL_HOOK") {
         InstallHookMode::Ignore

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -87,7 +87,7 @@ if (!(Test-Path Env:\HAB_FALLBACK_CHANNEL)) {
 }
 # Use the refresh channel for dependencies in the core/chef/chef-platform origins
 if (!(Test-Path Env:\HAB_REFRESH_CHANNEL)) {
-    $env:HAB_REFRESH_CHANNEL = "LTS-2024"
+    $env:HAB_REFRESH_CHANNEL = "stable"
 }
 # The value of `$env:Path` on initial start of this program
 $script:INITIAL_PATH = "$env:Path"

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -366,7 +366,7 @@ export HAB_BLDR_CHANNEL
 # has been set to something different.
 : "${HAB_FALLBACK_CHANNEL=stable}"
 # Use the refresh channel for dependencies in the core/chef/chef-platform origins
-: "${HAB_REFRESH_CHANNEL:=LTS-2024}"
+: "${HAB_REFRESH_CHANNEL:=stable}"
 # If we prefer to use local core/chef/chef-platform deps then a locally installed
 # package in one of these origins will be used in preference to what is in the refresh
 : "${HAB_PREFER_LOCAL_CHEF_DEPS:=false}"

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -365,6 +365,11 @@ export HAB_BLDR_CHANNEL
 # Also note that this only really comes into play if HAB_BLDR_CHANNEL
 # has been set to something different.
 : "${HAB_FALLBACK_CHANNEL=stable}"
+# Use the refresh channel for dependencies in the core/chef/chef-platform origins
+: "${HAB_REFRESH_CHANNEL:=LTS-2024}"
+# If we prefer to use local core/chef/chef-platform deps then a locally installed
+# package in one of these origins will be used in preference to what is in the refresh
+: "${HAB_PREFER_LOCAL_CHEF_DEPS:=false}"
 # The value of `$PATH` on initial start of this program
 INITIAL_PATH="$PATH"
 # The value of `pwd` on initial start of this program
@@ -670,64 +675,6 @@ _find_system_commands() {
   fi
 }
 
-# **Internal** Return the path to the latest release of a package on stdout.
-#
-# ```
-# _latest_installed_package acme/nginx
-# # /hab/pkgs/acme/nginx/1.8.0/20150911120000
-# _latest_installed_package acme/nginx/1.8.0
-# # /hab/pkgs/acme/nginx/1.8.0/20150911120000
-# _latest_installed_package acme/nginx/1.8.0/20150911120000
-# # /hab/pkgs/acme/nginx/1.8.0/20150911120000
-# ```
-#
-# Will return 0 if a package was found on disk, and 1 if a package cannot be
-# found. A message will be printed to stderr explaining that no package was
-# found.
-_latest_installed_package() {
-  local result
-  if result="$($HAB_BIN pkg path "$1" 2> /dev/null)"; then
-    echo "$result"
-    return 0
-  else
-    warn "Could not find a suitable installed package for '$1'"
-    return 1
-  fi
-}
-
-# **Internal** Returns the path to the desired package on stdout, using the
-# constraints specified in `$pkg_deps` or `$pkg_build_deps`. If a package
-# cannot be found locally on disk, and the `hab` CLI package is present,
-# this program will attempt to install the package from a remote repository.
-#
-# ```
-# _resolve_dependency acme/zlib
-# # /hab/pkgs/acme/zlib/1.2.8/20151216221001
-# _resolve_dependency acme/zlib/1.2.8
-# # /hab/pkgs/acme/zlib/1.2.8/20151216221001
-# _resolve_dependency acme/zlib/1.2.8/20151216221001
-# # /hab/pkgs/acme/zlib/1.2.8/20151216221001
-# ```
-#
-# Will return 0 if a package was found or installed on disk, and 1 if a package
-# cannot be found or remotely installed. A message will be printed to stderr to
-# provide context.
-_resolve_dependency() {
-  local dep="$1"
-  local dep_path
-  if ! echo "$dep" | grep -q '\/' > /dev/null; then
-    warn "Origin required for '$dep' in plan '$pkg_origin/$pkg_name' (example: acme/$dep)"
-    return 1
-  fi
-
-  if dep_path=$(_latest_installed_package "$dep"); then
-    echo "${dep_path}"
-    return 0
-  else
-    return 1
-  fi
-}
-
 # **Internal** Attempts to download a package dependency. If the value of the
 # `$NO_INSTALL_DEPS` variable is set, then no package installation will occur.
 # If an installation is attempted but there is an error, this function will
@@ -740,17 +687,19 @@ _resolve_dependency() {
 # ```
 _install_dependency() {
     local dep="${1}"
+    local origin="$(echo "$dep" | cut -d "/" -f 1)"
+    local channel="$HAB_BLDR_CHANNEL"
     if [[ -z "${NO_INSTALL_DEPS:-}" ]]; then
 
-    # Enable --ignore-local if invoked with HAB_FEAT_IGNORE_LOCAL in
-    # the environment, set to either "true" or "TRUE" (features are
-    # not currently enabled by the mere presence of an environment variable)
-    if [[ "${HAB_FEAT_IGNORE_LOCAL:-}" = "true" ||
-              "${HAB_FEAT_IGNORE_LOCAL:-}" = "TRUE" ]]; then
+    if [[ $origin == "core" || $origin == "chef" || $origin == "chef-platform" ]]; then
+      channel="$HAB_REFRESH_CHANNEL"
+      if [[ $HAB_PREFER_LOCAL_CHEF_DEPS == "false" ]]; then
         IGNORE_LOCAL="--ignore-local"
+      fi
     fi
-    $HAB_BIN pkg install -u $HAB_BLDR_URL --channel $HAB_BLDR_CHANNEL ${IGNORE_LOCAL:-} "$@" || {
-      if [[ "$HAB_BLDR_CHANNEL" != "$HAB_FALLBACK_CHANNEL" ]]; then
+
+    $HAB_BIN pkg install -u $HAB_BLDR_URL --channel $channel ${IGNORE_LOCAL:-} "$@" || {
+      if [[ "$channel" != "$HAB_FALLBACK_CHANNEL" ]]; then
         build_line "Trying to install '$dep' from '$HAB_FALLBACK_CHANNEL'"
         $HAB_BIN pkg install -u $HAB_BLDR_URL --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
       fi
@@ -1030,10 +979,12 @@ _resolve_scaffolding_dependencies() {
   scaff_build_deps=()
   scaff_build_deps_resolved=()
 
-  _install_dependency "$pkg_scaffolding"
+  res=$(_install_dependency "$pkg_scaffolding")
+  echo "$res"
+  resolved=$(echo "$res" | tail -n 1 | grep -Eo "\S+/\S+")
   # Add scaffolding package to the list of scaffolding build deps
   scaff_build_deps+=("$pkg_scaffolding")
-  if resolved="$(_resolve_dependency "$pkg_scaffolding")"; then
+  if [[ $resolved != "" ]]; then
     build_line "Resolved scaffolding dependency '$pkg_scaffolding' to $resolved"
     scaff_build_deps_resolved+=("$resolved")
     # Add each (fully qualified) direct run dependency of the scaffolding
@@ -1087,10 +1038,12 @@ _resolve_build_dependencies() {
   # Append to `${pkg_build_deps_resolved[@]}` all resolved direct build
   # dependencies.
   for dep in "${pkg_build_deps[@]}"; do
-    _install_dependency "$dep"
-    if resolved="$(_resolve_dependency "$dep")"; then
+    res=$(_install_dependency "$dep")
+    echo "$res"
+    resolved=$(echo "$res" | tail -n 1 | grep -Eo "\S+/\S+")
+    if [[ $resolved != "" ]]; then
       build_line "Resolved build dependency '$dep' to $resolved"
-      pkg_build_deps_resolved+=("$resolved")
+      pkg_build_deps_resolved+=("/hab/pkgs/$resolved")
     else
       exit_with "Resolving '$dep' failed, should this be built first?" 1
     fi
@@ -1162,10 +1115,12 @@ _resolve_run_dependencies() {
 
   # Append to `${pkg_deps_resolved[@]}` all resolved direct run dependencies.
   for dep in "${pkg_deps[@]}"; do
-    _install_dependency "$dep" "--ignore-install-hook"
-    if resolved="$(_resolve_dependency "$dep")"; then
+    res=$(_install_dependency "$dep" "--ignore-install-hook")
+    echo "$res"
+    resolved=$(echo "$res" | tail -n 1 | grep -Eo "\S+/\S+")
+    if [[ $resolved != "" ]]; then
       build_line "Resolved dependency '$dep' to $resolved"
-      pkg_deps_resolved+=("$resolved")
+      pkg_deps_resolved+=("/hab/pkgs/$resolved")
     else
       exit_with "Resolving '$dep' failed, should this be built first?" 1
     fi

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -687,10 +687,10 @@ _find_system_commands() {
 # ```
 _install_dependency() {
     local dep="${1}"
-    local origin="$(echo "$dep" | cut -d "/" -f 1)"
+    local origin
     local channel="$HAB_BLDR_CHANNEL"
     if [[ -z "${NO_INSTALL_DEPS:-}" ]]; then
-
+    origin="$(echo "$dep" | cut -d "/" -f 1)"
     if [[ $origin == "core" || $origin == "chef" || $origin == "chef-platform" ]]; then
       channel="$HAB_REFRESH_CHANNEL"
       if [[ $HAB_PREFER_LOCAL_CHEF_DEPS == "false" ]]; then

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -19,6 +19,7 @@ param (
     [switch]$R,
     [string]$command,
     [string]$commandVal,
+    [string]$f,
     [string]$k,
     [string]$o,
     [string]$s
@@ -48,6 +49,8 @@ COMMON FLAGS:
     -D  Use a Docker Studio instead of a native Studio
 
 COMMON OPTIONS:
+    -f <REFRESH_CHANNEL>  Sets the channel used to retrieve plan dpendencies for Chef
+                          supported origins (default: LTS-2024)
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )
     -o <HAB_STUDIO_ROOT>  Sets a Studio root (default: /hab/studios/<DIR_NAME>)
     -s <SRC_PATH>         Sets the source path (default: \$PWD)
@@ -62,17 +65,18 @@ SUBCOMMANDS:
     version   Prints version information
 
 ENVIRONMENT VARIABLES:
-    HAB_LICENSE           Set to 'accept' or 'accept-no-persist' to accept the Habitat license
-    HAB_ORIGIN            Propagates this variable into any studios
-    HAB_ORIGIN_KEYS       Installs secret keys (\`-k' option overrides)
-    HAB_STUDIOS_HOME      Sets a home path for all Studios (default: /hab/studios)
-    HAB_STUDIO_NOPROFILE  Disables sourcing a \`.studio_profile.ps1' in \`studio enter'
-    HAB_STUDIO_ROOT       Sets a Studio root (\`-r' option overrides)
-    NO_ARTIFACT_PATH      If set, do not mount the source artifact cache path
-    NO_SRC_PATH           If set, do not mount source path (\`-n' flag overrides)
-    QUIET                 Prints less output (\`-q' flag overrides)
-    SRC_PATH              Sets the source path (\`-s' option overrides)
-    VERBOSE               Prints more verbose output (\`-v' flag overrides)
+    HAB_LICENSE                 Set to 'accept' or 'accept-no-persist' to accept the Habitat license
+    HAB_ORIGIN                  Propagates this variable into any studios
+    HAB_ORIGIN_KEYS             Installs secret keys (\`-k' option overrides)
+    HAB_PREFER_LOCAL_CHEF_DEPS  Use locally installed Chef supported dependencies if available
+    HAB_STUDIOS_HOME            Sets a home path for all Studios (default: /hab/studios)
+    HAB_STUDIO_NOPROFILE        Disables sourcing a \`.studio_profile.ps1' in \`studio enter'
+    HAB_STUDIO_ROOT             Sets a Studio root (\`-r' option overrides)
+    NO_ARTIFACT_PATH            If set, do not mount the source artifact cache path
+    NO_SRC_PATH                 If set, do not mount source path (\`-n' flag overrides)
+    QUIET                       Prints less output (\`-q' flag overrides)
+    SRC_PATH                    Sets the source path (\`-s' option overrides)
+    VERBOSE                     Prints more verbose output (\`-v' flag overrides)
 
 SUBCOMMAND HELP:
     $program <SUBCOMMAND> -h
@@ -601,6 +605,7 @@ if ((Test-Path "$env:USERPROFILE\.hab\accepted-licenses\habitat") -or (Test-Path
     $env:HAB_LICENSE = "accept-no-persist"
 }
 
+if($f) { $env:HAB_REFRESH_CHANNEL = $f }
 if($h) { $script:printHelp = $true }
 if($n) { $env:NO_SRC_PATH = $true }
 if($q) { $script:quiet = $true }

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -50,7 +50,7 @@ COMMON FLAGS:
 
 COMMON OPTIONS:
     -f <REFRESH_CHANNEL>  Sets the channel used to retrieve plan dpendencies for Chef
-                          supported origins (default: LTS-2024)
+                          supported origins (default: stable)
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )
     -o <HAB_STUDIO_ROOT>  Sets a Studio root (default: /hab/studios/<DIR_NAME>)
     -s <SRC_PATH>         Sets the source path (default: \$PWD)

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -70,6 +70,8 @@ COMMON FLAGS:
 COMMON OPTIONS:
     -a <ARTIFACT_PATH>    Sets the source artifact cache path (default: /hab/cache/artifacts)
     -c <CERT_PATH>        Sets the SSL certs cache path (default: /hab/cache/ssl)
+    -f <REFRESH_CHANNEL>  Sets the channel used to retrieve plan dpendencies for Chef
+                          supported origins (default: LTS-2024)
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )
     -r <HAB_STUDIO_ROOT>  Sets a Studio root (default: /hab/studios/<DIR_NAME>)
     -s <SRC_PATH>         Sets the source path (default: \$PWD)
@@ -86,27 +88,28 @@ SUBCOMMANDS:
     version   Prints version information
 
 ENVIRONMENT VARIABLES:
-    ARTIFACT_PATH          Sets the source artifact cache path (\`-a' option overrides)
-    CERT_PATH              Sets the SSL cert cache path (\`-c' option overrides)
-    HAB_NOCOLORING         Disables text coloring mode despite TERM capabilities
-    HAB_NONINTERACTIVE     Disables interactive progress bars despite tty
-    HAB_LICENSE            Set to 'accept' or 'accept-no-persist' to accept the Habitat license
-    HAB_ORIGIN             Propagates this variable into any studios
-    HAB_ORIGIN_KEYS        Installs secret keys (\`-k' option overrides)
-    HAB_STUDIOS_HOME       Sets a home path for all Studios (default: /hab/studios)
-    HAB_STUDIO_NOSTUDIORC  Disables sourcing a \`.studiorc' in \`studio enter'
-    HAB_STUDIO_ROOT        Sets a Studio root (\`-r' option overrides)
-    HAB_STUDIO_SUP         Sets args for a Supervisor in \`studio enter'
-    NO_ARTIFACT_PATH       If set, do not mount the source artifact cache path (\`-N' flag overrides)
-    NO_CERT_PATH           If set, do not mount the SSL cert cache path (\`-M' flag overrides)
-    NO_SRC_PATH            If set, do not mount the source path (\`-n' flag overrides)
-    QUIET                  Prints less output (\`-q' flag overrides)
-    SRC_PATH               Sets the source path (\`-s' option overrides)
-    STUDIO_TYPE            Sets a Studio type when creating (\`-t' option overrides)
-    VERBOSE                Prints more verbose output (\`-v' flag overrides)
-    http_proxy             Sets an http_proxy environment variable inside the Studio
-    https_proxy            Sets an https_proxy environment variable inside the Studio
-    no_proxy               Sets a no_proxy environment variable inside the Studio
+    ARTIFACT_PATH               Sets the source artifact cache path (\`-a' option overrides)
+    CERT_PATH                   Sets the SSL cert cache path (\`-c' option overrides)
+    HAB_NOCOLORING              Disables text coloring mode despite TERM capabilities
+    HAB_NONINTERACTIVE          Disables interactive progress bars despite tty
+    HAB_LICENSE                 Set to 'accept' or 'accept-no-persist' to accept the Habitat license
+    HAB_ORIGIN                  Propagates this variable into any studios
+    HAB_ORIGIN_KEYS             Installs secret keys (\`-k' option overrides)
+    HAB_PREFER_LOCAL_CHEF_DEPS  Use locally installed Chef supported dependencies if available
+    HAB_STUDIOS_HOME            Sets a home path for all Studios (default: /hab/studios)
+    HAB_STUDIO_NOSTUDIORC       Disables sourcing a \`.studiorc' in \`studio enter'
+    HAB_STUDIO_ROOT             Sets a Studio root (\`-r' option overrides)
+    HAB_STUDIO_SUP              Sets args for a Supervisor in \`studio enter'
+    NO_ARTIFACT_PATH            If set, do not mount the source artifact cache path (\`-N' flag overrides)
+    NO_CERT_PATH                If set, do not mount the SSL cert cache path (\`-M' flag overrides)
+    NO_SRC_PATH                 If set, do not mount the source path (\`-n' flag overrides)
+    QUIET                       Prints less output (\`-q' flag overrides)
+    SRC_PATH                    Sets the source path (\`-s' option overrides)
+    STUDIO_TYPE                 Sets a Studio type when creating (\`-t' option overrides)
+    VERBOSE                     Prints more verbose output (\`-v' flag overrides)
+    http_proxy                  Sets an http_proxy environment variable inside the Studio
+    https_proxy                 Sets an https_proxy environment variable inside the Studio
+    no_proxy                    Sets a no_proxy environment variable inside the Studio
 
 SUBCOMMAND HELP:
     $program <SUBCOMMAND> -h
@@ -854,6 +857,11 @@ chroot_env() {
   if [ -n "${HAB_BLDR_CHANNEL:-}" ]; then
     env="$env HAB_BLDR_CHANNEL=$HAB_BLDR_CHANNEL"
   fi
+  # If a Habitat refresh Channel is set, then propagate it into the Studio's
+  # environment.
+  if [ -n "${HAB_REFRESH_CHANNEL:-}" ]; then
+    env="$env HAB_REFRESH_CHANNEL=$HAB_REFRESH_CHANNEL"
+  fi
   # If a no coloring environment variable is set, then propagate it into the Studio's
   # environment.
   if [ -n "${HAB_NOCOLORING:-}" ]; then
@@ -971,7 +979,9 @@ report_env_vars() {
   if [ -n "${no_proxy:-}" ]; then
     info "Exported: no_proxy=$no_proxy"
   fi
-
+  if [ -n "${HAB_REFRESH_CHANNEL:-}" ]; then
+    info "Exported: HAB_REFRESH_CHANNEL=$HAB_REFRESH_CHANNEL"
+  fi
   for secret_name in $(load_secrets | $bb cut -d = -f 1); do
     info "Exported: $secret_name=[redacted]"
   done
@@ -1267,13 +1277,16 @@ ensure_root
 # ## CLI Argument Parsing
 
 # Parse command line flags and options.
-while getopts ":nNMa:c:k:r:s:t:D:vqVh" opt; do
+while getopts ":nNMa:c:f:k:r:s:t:D:vqVh" opt; do
   case $opt in
     a)
       ARTIFACT_PATH=$OPTARG
       ;;
     c)
       CERT_PATH=$OPTARG
+      ;;
+    f)
+      export HAB_REFRESH_CHANNEL="$OPTARG"
       ;;
     n)
       NO_SRC_PATH=true

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -71,7 +71,7 @@ COMMON OPTIONS:
     -a <ARTIFACT_PATH>    Sets the source artifact cache path (default: /hab/cache/artifacts)
     -c <CERT_PATH>        Sets the SSL certs cache path (default: /hab/cache/ssl)
     -f <REFRESH_CHANNEL>  Sets the channel used to retrieve plan dpendencies for Chef
-                          supported origins (default: LTS-2024)
+                          supported origins (default: stable)
     -k <HAB_ORIGIN_KEYS>  Installs secret origin keys (default:\$HAB_ORIGIN )
     -r <HAB_STUDIO_ROOT>  Sets a Studio root (default: /hab/studios/<DIR_NAME>)
     -s <SRC_PATH>         Sets the source path (default: \$PWD)

--- a/test/end-to-end/test_studio_can_build_packages.ps1
+++ b/test/end-to-end/test_studio_can_build_packages.ps1
@@ -145,3 +145,35 @@ Describe "Consuming runtime variables of build dependency" {
         $LASTEXITCODE | Should -Be 0
     }
 }
+
+Describe "Targeting different refresh channels" {
+    if($IsLinux) {
+        It "Can target a downgraded channel" {
+            Invoke-BuildAndInstall -PackageName breakable-refresh-downgrade -RefreshChannel refresh2022q2
+            . ./results/last_build.ps1
+            "/hab/pkgs/$pkg_ident/TDEPS" | Should -FileContentMatch "core/glibc/2.34"
+        }
+
+        It "Can target default LTS-2024" {
+            Invoke-BuildAndInstall -PackageName breakable-refresh-downgrade
+            . ./results/last_build.ps1
+            "/hab/pkgs/$pkg_ident/TDEPS" | Should -FileContentMatch "core/glibc/2.36"
+        }
+    }
+
+    if($IsWindows) {
+        hab studio run "hab pkg install core/libarchive"
+
+        It "Can target a downgraded channel" {
+            Invoke-BuildAndInstall -PackageName breakable-refresh-downgrade -RefreshChannel refresh2022q2
+            . ./results/last_build.ps1
+            "/hab/pkgs/$pkg_ident/TDEPS" | Should -FileContentMatch "core/zlib/1.2.12"
+        }
+
+        It "Can target latest stable" {
+            Invoke-BuildAndInstall -PackageName breakable-refresh-downgrade -RefreshChannel stable
+            . ./results/last_build.ps1
+            "/hab/pkgs/$pkg_ident/TDEPS" | Should -FileContentMatch "core/zlib/1.3"
+        }
+    }
+}

--- a/test/end-to-end/test_studio_can_build_packages.ps1
+++ b/test/end-to-end/test_studio_can_build_packages.ps1
@@ -155,7 +155,7 @@ Describe "Targeting different refresh channels" {
         }
 
         It "Can target default LTS-2024" {
-            Invoke-BuildAndInstall -PackageName breakable-refresh-downgrade
+            Invoke-BuildAndInstall -PackageName breakable-refresh-downgrade -RefreshChannel LTS-2024
             . ./results/last_build.ps1
             "/hab/pkgs/$pkg_ident/TDEPS" | Should -FileContentMatch "core/glibc/2.36"
         }

--- a/test/fixtures/breakable-refresh-downgrade/plan.ps1
+++ b/test/fixtures/breakable-refresh-downgrade/plan.ps1
@@ -1,0 +1,6 @@
+$pkg_name="breakable-refresh-downgrade"
+$pkg_origin="habitat-testing"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_version="0.0.0"
+
+$pkg_deps=@("core/protobuf", "core/libarchive")

--- a/test/fixtures/breakable-refresh-downgrade/plan.sh
+++ b/test/fixtures/breakable-refresh-downgrade/plan.sh
@@ -1,0 +1,12 @@
+pkg_name="breakable-refresh-downgrade"
+pkg_origin="habitat-testing"
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_version="0.0.0"
+
+pkg_deps=(
+  core/glibc
+  core/gcc
+)
+
+do_build() { :; }
+do_install() { :; }


### PR DESCRIPTION
This introduces two new environment variables to the hab-plan-build script (linux and windows):
* `HAB_REFRESH_CHANNEL` specifies the channel used to pull dependencies for `core`, `chef` and `chef-platform` origins. The default is `LTS-2024` which falls back to `stable` if they cannot be found there.
* `HAB_PREFER_LOCAL_CHEF_DEPS` is a boolean flag which defaults to false/unset. If set, this informs the build to choose a locally installed core/chef/chef-platform dependency over the one in the remote bldr channel. This would likely be used by the packages team when building a new set of refreshed packages where they need to build many deps locally in a particular order. It would also be used in our own release pipeline when we need to pull a locally built component (like a new new studio).

The `hab pkg build` command has a new `--refresh-channel` arg that is a convenience for feeding the `HAB_REFRESH_CHANNEL` environment variable for a build. There is no convenience arg for `HAB_PREFER_LOCAL_CHEF_DEPS` because that will likely only be used internally.

One key thing to note here is that now, unless `HAB_PREFER_LOCAL_CHEF_DEPS` is set, core/chef/chef-platform deps will only ever come the remote refresh channel and they will not come from the latest locally installed package.

I have removed the `IGNORE_LOCAL` feature flag since this now removes the need for that flag. We only ever needed/used this for `core` deps and now we essentially use it by default. It was also never publicly documented so I don't think we need to worry about it breaking anyone.