### PR TITLE
`pkg-export-container`: Remove `pub` visibilty

### DIFF
--- a/components/common/src/cfg_macros.rs
+++ b/components/common/src/cfg_macros.rs
@@ -1,0 +1,31 @@
+//! Common config macros
+//!
+//! There is quite a bit of functionality that is dependent upon the platform/os that we are
+//! running on, the following config macros are used to conditionally compile such code. This is
+//! inspired by `cfg_*` macros in `tokio`.
+
+// Enable windows specific code
+#[macro_export]
+macro_rules! cfg_windows {
+
+    ($($item:item)*) => {
+
+        $(
+            #[cfg(windows)]
+            $item
+        )*
+    }
+}
+
+// Enable unix specific code
+#[macro_export]
+macro_rules! cfg_unix {
+
+    ($($item:item)*) => {
+
+        $(
+            #[cfg(unix)]
+            $item
+        )*
+    }
+}

--- a/components/common/src/lib.rs
+++ b/components/common/src/lib.rs
@@ -23,6 +23,8 @@ pub mod types;
 pub mod ui;
 pub mod util;
 
+pub mod cfg_macros;
+
 use log::error;
 
 lazy_static::lazy_static! {

--- a/components/pkg-export-container/Cargo.toml
+++ b/components/pkg-export-container/Cargo.toml
@@ -26,6 +26,7 @@ handlebars = { version = "0.29.1", default-features = false }
 lazy_static = "*"
 linked-hash-map = "*"
 log = "0.4"
+# TODO: Move this to `aws-sdk-rust`
 rusoto_core = "*"
 rusoto_credential = "*"
 rusoto_ecr = "*"

--- a/components/pkg-export-container/src/accounts.rs
+++ b/components/pkg-export-container/src/accounts.rs
@@ -7,15 +7,17 @@ use std::fmt;
 
 /// Represents an entry for a user in `/etc/passwd`
 #[derive(Debug)]
-pub struct EtcPasswdEntry {
-    pub name: String,
-    pub uid:  u32,
+pub(crate) struct EtcPasswdEntry {
+    pub(crate) name: String,
+
+    uid: u32,
+
     // Primary GID
-    pub gid:  u32,
+    gid: u32,
 }
 
 impl EtcPasswdEntry {
-    pub fn new(name: &str, uid: u32, gid: u32) -> Self {
+    pub(crate) fn new(name: &str, uid: u32, gid: u32) -> Self {
         Self { name: name.to_string(),
                uid,
                gid }
@@ -34,19 +36,19 @@ impl fmt::Display for EtcPasswdEntry {
 
 /// Represents an entry for a group in `/etc/group`
 #[derive(Debug)]
-pub struct EtcGroupEntry {
-    pub name:  String,
-    pub gid:   u32,
-    pub users: Vec<String>,
+pub(crate) struct EtcGroupEntry {
+    pub(crate) name: String,
+    gid:             u32,
+    users:           Vec<String>,
 }
 
 impl EtcGroupEntry {
-    pub fn empty_group(name: &str, gid: u32) -> Self {
+    pub(crate) fn empty_group(name: &str, gid: u32) -> Self {
         let users: Vec<String> = vec![];
         Self::group_with_users(name, gid, &users)
     }
 
-    pub fn group_with_users<U>(name: &str, gid: u32, users: &[U]) -> Self
+    pub(crate) fn group_with_users<U>(name: &str, gid: u32, users: &[U]) -> Self
         where U: ToString
     {
         Self { name: name.to_string(),

--- a/components/pkg-export-container/src/cli.rs
+++ b/components/pkg-export-container/src/cli.rs
@@ -1,7 +1,8 @@
 use crate::{engine,
             HabHartIdParser,
             RegistryType,
-            UrlValueParser};
+            UrlValueParser,
+            VERSION};
 use clap::{builder::Str,
            value_parser,
            Arg,
@@ -10,11 +11,8 @@ use clap::{builder::Str,
 use habitat_common::PROGRAM_NAME;
 use habitat_core::url::default_bldr_url;
 
-/// The version of this library and program when built.
-const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/VERSION"));
-
 /// Create the Clap CLI for the container exporter
-pub fn cli() -> Command {
+pub(crate) fn cli() -> Command {
     let name: &str = &PROGRAM_NAME;
     let about = "Creates a container image from a set of Habitat packages (and optionally pushes \
                  to a remote repository)";

--- a/components/pkg-export-container/src/container.rs
+++ b/components/pkg-export-container/src/container.rs
@@ -36,7 +36,7 @@ const BUILD_REPORT_FILE_NAME: &str = "last_container_export.env";
 const OLD_BUILD_REPORT_FILE_NAME: &str = "last_docker_export.env";
 
 /// A built container image which exists locally.
-pub struct ContainerImage {
+pub(crate) struct ContainerImage {
     /// The image ID for this image.
     id:      String,
     /// The name of this image.
@@ -52,13 +52,13 @@ pub struct ContainerImage {
 
 impl ContainerImage {
     // TODO (CM): temporary; we shouldn't use this at all
-    pub fn workdir(&self) -> &Path { self.workdir.as_path() }
+    pub(crate) fn workdir(&self) -> &Path { self.workdir.as_path() }
 
-    pub fn expanded_identifiers(&self) -> &[String] { &self.expanded_identifiers }
+    pub(crate) fn expanded_identifiers(&self) -> &[String] { &self.expanded_identifiers }
 
-    pub fn name(&self) -> String { self.name.clone() }
+    pub(crate) fn name(&self) -> String { self.name.clone() }
 
-    pub fn tags(&self) -> Vec<String> { self.tags.clone() }
+    pub(crate) fn tags(&self) -> Vec<String> { self.tags.clone() }
 
     /// Create a build report with image metadata in the given path.
     ///
@@ -66,7 +66,7 @@ impl ContainerImage {
     ///
     /// * If the destination directory cannot be created
     /// * If the report file cannot be written
-    pub fn create_report<P: AsRef<Path>>(&self, ui: &mut UI, dst: P) -> Result<()> {
+    pub(crate) fn create_report<P: AsRef<Path>>(&self, ui: &mut UI, dst: P) -> Result<()> {
         let report = Self::report_path(&dst);
         ui.status(Status::Creating,
                   format!("build report {}", report.display()))?;
@@ -131,7 +131,7 @@ impl ContainerImage {
 /// A build context for building a container
 ///
 /// (i.e. the `.` in `docker build -t foo .`)
-pub struct BuildContext(BuildRoot);
+pub(crate) struct BuildContext(BuildRoot);
 
 impl BuildContext {
     /// Builds a completed build root from a `BuildRoot`, performing any final tasks on the
@@ -141,7 +141,7 @@ impl BuildContext {
     ///
     /// * If any remaining tasks cannot be performed in the build root
     #[cfg(unix)]
-    pub fn from_build_root(build_root: BuildRoot, ui: &mut UI) -> Result<Self> {
+    pub(crate) fn from_build_root(build_root: BuildRoot, ui: &mut UI) -> Result<Self> {
         let context = BuildContext(build_root);
         context.add_users_and_groups(ui)?;
         context.create_entrypoint(ui)?;
@@ -151,7 +151,7 @@ impl BuildContext {
     }
 
     #[cfg(windows)]
-    pub fn from_build_root(build_root: BuildRoot, ui: &mut UI) -> Result<Self> {
+    pub(crate) fn from_build_root(build_root: BuildRoot, ui: &mut UI) -> Result<Self> {
         let context = BuildContext(build_root);
         context.create_dockerfile(ui)?;
 
@@ -168,7 +168,7 @@ impl BuildContext {
     /// # Errors
     ///
     /// * If the temporary work directory cannot be removed
-    pub fn destroy(self, ui: &mut UI) -> Result<()> { self.0.destroy(ui) }
+    pub(crate) fn destroy(self, ui: &mut UI) -> Result<()> { self.0.destroy(ui) }
 
     #[cfg(unix)]
     fn add_users_and_groups(&self, ui: &mut UI) -> Result<()> {
@@ -253,12 +253,12 @@ impl BuildContext {
     }
 
     /// Build the image locally using the provided naming policy.
-    pub fn export(&self,
-                  ui: &mut UI,
-                  naming: &Naming,
-                  memory: Option<&str>,
-                  engine: &dyn Engine)
-                  -> Result<ContainerImage> {
+    pub(crate) fn export(&self,
+                         ui: &mut UI,
+                         naming: &Naming,
+                         memory: Option<&str>,
+                         engine: &dyn Engine)
+                         -> Result<ContainerImage> {
         ui.status(Status::Creating, "image")?;
         let ident = self.0.ctx().installed_primary_svc_ident()?;
         let channel = self.0.ctx().channel();

--- a/components/pkg-export-container/src/engine.rs
+++ b/components/pkg-export-container/src/engine.rs
@@ -59,7 +59,7 @@ enum EngineError {
 /// When https://github.com/containers/buildah/issues/2215 is fixed,
 /// we can update our Buildah dependency and remove this check.
 #[cfg(not(windows))]
-pub fn fail_if_buildah_and_multilayer(matches: &ArgMatches) -> Result<()> {
+pub(crate) fn fail_if_buildah_and_multilayer(matches: &ArgMatches) -> Result<()> {
     if matches.get_one::<EngineKind>("ENGINE") == Some(&EngineKind::Buildah)
        && matches.get_flag("MULTI_LAYER")
     {
@@ -106,7 +106,7 @@ impl std::fmt::Display for EngineKind {
 /// Define the CLAP CLI argument for specifying a container build
 /// engine to use.
 #[rustfmt::skip] // otherwise the long_help formatting goes crazy
-pub fn cli_arg() -> Arg {
+pub(crate) fn cli_arg() -> Arg {
     let arg =
         Arg::new("ENGINE").value_name("ENGINE")
         .value_parser(value_parser!(EngineKind))
@@ -152,7 +152,7 @@ impl TryFrom<&ArgMatches> for Box<dyn Engine> {
     }
 }
 
-pub trait Engine {
+pub(crate) trait Engine {
     /// A command that takes a container image reference and returns
     /// the ID of that image on the first line of standard output.
     fn image_id_command(&self, image_reference: &str) -> Command;

--- a/components/pkg-export-container/src/engine/buildah.rs
+++ b/components/pkg-export-container/src/engine/buildah.rs
@@ -20,7 +20,7 @@ const SIGNATURE_POLICY: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"),
                                                     "/defaults/containers-policy.json"));
 
 #[derive(Debug)]
-pub(super) struct BuildahEngine {
+pub(crate) struct BuildahEngine {
     binary: PathBuf,
 
     /// Path to a signature policy file that we control, not
@@ -41,7 +41,7 @@ impl From<BuildahError> for EngineError {
 }
 
 impl BuildahEngine {
-    pub fn new() -> Result<Self, EngineError> {
+    pub(crate) fn new() -> Result<Self, EngineError> {
         let binary = resolve_engine_binary("buildah")?;
         let policy = Self::signature_policy()?;
         Ok(BuildahEngine { binary, policy })

--- a/components/pkg-export-container/src/engine/docker.rs
+++ b/components/pkg-export-container/src/engine/docker.rs
@@ -7,12 +7,12 @@ use std::{path::{Path,
           result::Result};
 
 #[derive(Debug)]
-pub(super) struct DockerEngine {
+pub(crate) struct DockerEngine {
     binary: PathBuf,
 }
 
 impl DockerEngine {
-    pub fn new() -> Result<Self, EngineError> {
+    pub(crate) fn new() -> Result<Self, EngineError> {
         let binary = resolve_engine_binary("docker")?;
         Ok(DockerEngine { binary })
     }

--- a/components/pkg-export-container/src/error.rs
+++ b/components/pkg-export-container/src/error.rs
@@ -1,12 +1,9 @@
-use base64::DecodeError;
 use rusoto_core::RusotoError;
 use rusoto_ecr::GetAuthorizationTokenError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-pub enum Error {
-    #[error(transparent)]
-    Base64DecodeError(DecodeError),
+pub(crate) enum Error {
     #[error("Invalid registry type: {0}")]
     InvalidRegistryType(String),
     #[error("No ECR Tokens returned")]

--- a/components/pkg-export-container/src/graph.rs
+++ b/components/pkg-export-container/src/graph.rs
@@ -6,17 +6,17 @@ use habitat_core::package::{FullyQualifiedPackageIdent,
 use linked_hash_map::LinkedHashMap;
 use std::path::Path;
 
-pub struct Graph {
+pub(crate) struct Graph {
     g:    PackageGraph,
     base: BasePkgIdents,
     user: Vec<FullyQualifiedPackageIdent>,
 }
 
 impl Graph {
-    pub fn from_packages(base: BasePkgIdents,
-                         user: Vec<FullyQualifiedPackageIdent>,
-                         rootfs: &Path)
-                         -> Result<Graph> {
+    pub(crate) fn from_packages(base: BasePkgIdents,
+                                user: Vec<FullyQualifiedPackageIdent>,
+                                rootfs: &Path)
+                                -> Result<Graph> {
         let g = PackageGraph::from_root_path(rootfs)?;
         Ok(Graph { g, base, user })
     }
@@ -65,7 +65,7 @@ impl Graph {
     /// User packages will be last. Ideally, as users are iterating on
     /// their packages and creating images, this should mean that all
     /// the dependencies are already available as cached layers.
-    pub fn reverse_topological_sort(&self) -> Vec<PackageIdent> {
+    pub(crate) fn reverse_topological_sort(&self) -> Vec<PackageIdent> {
         self.idents_from_base()
             .into_iter()
             .chain(self.user_idents())

--- a/components/pkg-export-container/src/main.rs
+++ b/components/pkg-export-container/src/main.rs
@@ -1,23 +1,13 @@
-use anyhow::Result;
 use habitat_common::ui::{UIWriter,
                          UI};
-use habitat_pkg_export_container::{cli,
-                                   export_for_cli_matches};
-use log::debug;
+use habitat_pkg_export_container::cli_driver;
 
 #[tokio::main]
 async fn main() {
     env_logger::init();
     let mut ui = UI::default_with_env();
-    if let Err(e) = start(&mut ui).await {
+    if let Err(e) = cli_driver(&mut ui).await {
         ui.fatal(e).unwrap();
         std::process::exit(1)
     }
-}
-
-async fn start(ui: &mut UI) -> Result<()> {
-    let cli = cli();
-    let m = cli.get_matches();
-    debug!("clap cli args: {:?}", m);
-    export_for_cli_matches(ui, &m).await.map(|_| ())
 }

--- a/components/pkg-export-container/src/naming.rs
+++ b/components/pkg-export-container/src/naming.rs
@@ -26,7 +26,7 @@ macro_rules! safe {
 ///
 /// This is a value struct which captures the naming and tagging intentions for an image.
 #[derive(Debug, Default)]
-pub struct Naming {
+pub(crate) struct Naming {
     /// An optional custom image name which would override a computed default value.
     custom_image_name_template:  Option<String>,
     /// Whether or not to tag the image with a latest value.
@@ -47,9 +47,9 @@ pub struct Naming {
     // single new type.
     /// A URL to a custom Docker registry to publish to. This will be used as part of every tag
     /// before pushing.
-    pub registry_url:  Option<String>, // TODO (CM): Option<Url>
+    pub(crate) registry_url:  Option<String>, // TODO (CM): Option<Url>
     /// The type of registry we're publishing to. Ex: Amazon, Docker, Google, Azure.
-    pub registry_type: RegistryType,
+    pub(crate) registry_type: RegistryType,
 }
 
 impl From<&ArgMatches> for Naming {
@@ -98,17 +98,17 @@ impl From<&ArgMatches> for Naming {
 ///
 /// With future refactorings, this hopefully goes away, but for now
 /// we'll err on the side of explicitness.
-pub struct ImageIdentifiers {
+pub(crate) struct ImageIdentifiers {
     /// The bare name of an image, like "core/redis"
-    pub name:                 String,
+    pub(crate) name:                 String,
     /// A possibly empty `Vec` of bare tags, like "latest"
-    pub tags:                 Vec<String>,
+    pub(crate) tags:                 Vec<String>,
     /// A `Vec` containing the bare name concatenated with each bare
     /// tag (or just the bare name, if no tags), like
     /// "core/redis:latest".
     ///
     /// Guaranteed to have at least one member.
-    pub expanded_identifiers: Vec<String>,
+    pub(crate) expanded_identifiers: Vec<String>,
 }
 
 impl Naming {
@@ -119,10 +119,10 @@ impl Naming {
     /// Return the image name, along with a (possibly empty) vector of
     /// additional bare tags, and a vector containing "name:tag"
     /// identifiers (or just "name" if there are no tags).
-    pub fn image_identifiers(&self,
-                             ident: &FullyQualifiedPackageIdent,
-                             channel: &ChannelIdent)
-                             -> Result<ImageIdentifiers> {
+    pub(crate) fn image_identifiers(&self,
+                                    ident: &FullyQualifiedPackageIdent,
+                                    channel: &ChannelIdent)
+                                    -> Result<ImageIdentifiers> {
         let context = Self::rendering_context(ident, channel);
 
         let name = self.image_name(&context)?;

--- a/components/pkg-export-container/src/os/check.rs
+++ b/components/pkg-export-container/src/os/check.rs
@@ -10,5 +10,6 @@ pub(crate) fn ensure_proper_docker_platform() -> Result<()> { Ok(()) }
 // On Windows, however, we have a bit more work to do.
 #[cfg(windows)]
 mod windows;
+
 #[cfg(windows)]
 pub(crate) use windows::ensure_proper_docker_platform;

--- a/components/pkg-export-container/src/os/check/windows.rs
+++ b/components/pkg-export-container/src/os/check/windows.rs
@@ -23,7 +23,7 @@ pub(crate) fn ensure_proper_docker_platform() -> Result<(), Error> {
 }
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub(crate) enum Error {
     #[error("Only Windows container export is supported; please set your Docker daemon to \
              Windows container mode.\n\nThe Docker daemon is currently set for: {0:?}")]
     DockerNotInWindowsMode(DockerOS),
@@ -32,7 +32,7 @@ pub enum Error {
 /// Describes the OS of the containers the Docker daemon is currently
 /// configured to manage.
 #[derive(Clone, Debug)]
-pub enum DockerOS {
+enum DockerOS {
     /// Docker daemon is managing Linux containers
     Linux,
     /// Docker daemon is managing Windows containers

--- a/components/pkg-export-container/src/os/check/windows.rs
+++ b/components/pkg-export-container/src/os/check/windows.rs
@@ -32,7 +32,7 @@ pub(crate) enum Error {
 /// Describes the OS of the containers the Docker daemon is currently
 /// configured to manage.
 #[derive(Clone, Debug)]
-enum DockerOS {
+pub(crate) enum DockerOS {
     /// Docker daemon is managing Linux containers
     Linux,
     /// Docker daemon is managing Windows containers

--- a/components/pkg-export-container/src/rootfs.rs
+++ b/components/pkg-export-container/src/rootfs.rs
@@ -19,7 +19,7 @@ const ETC_NSSWITCH_CONF: &str = include_str!("../defaults/etc/nsswitch.conf");
 /// * If files and/or directories cannot be created
 /// * If permissions for files and/or directories cannot be set
 #[cfg(unix)]
-pub fn create<T>(root: T) -> Result<()>
+pub(crate) fn create<T>(root: T) -> Result<()>
     where T: AsRef<Path>
 {
     let root = root.as_ref();

--- a/components/pkg-export-container/src/util.rs
+++ b/components/pkg-export-container/src/util.rs
@@ -9,11 +9,11 @@ use std::{fs::{self,
 const BIN_PATH: &str = "/bin";
 
 /// Returns the `bin` path used for symlinking programs.
-pub fn bin_path() -> &'static Path { Path::new(BIN_PATH) }
+pub(crate) fn bin_path() -> &'static Path { Path::new(BIN_PATH) }
 
 /// Returns the Package Identifier for a Busybox package.
 #[cfg(unix)]
-pub fn busybox_ident() -> Result<PackageIdent> {
+pub(crate) fn busybox_ident() -> Result<PackageIdent> {
     use super::BUSYBOX_IDENT;
     use std::str::FromStr;
 
@@ -25,7 +25,7 @@ pub fn busybox_ident() -> Result<PackageIdent> {
 /// # Errors
 ///
 /// * If a package cannot be loaded from in the root file system
-pub fn pkg_path_for<P: AsRef<Path>>(ident: &PackageIdent, rootfs: P) -> Result<PathBuf> {
+pub(crate) fn pkg_path_for<P: AsRef<Path>>(ident: &PackageIdent, rootfs: P) -> Result<PathBuf> {
     let pkg_install = PackageInstall::load(ident, Some(rootfs.as_ref()))?;
     Ok(Path::new("/").join(pkg_install.installed_path()
                                       .strip_prefix(rootfs.as_ref())
@@ -37,7 +37,7 @@ pub fn pkg_path_for<P: AsRef<Path>>(ident: &PackageIdent, rootfs: P) -> Result<P
 /// # Errors
 ///
 /// * If an `IO` error occurs while creating, tuncating, writing, or closing the file
-pub fn write_file<T>(file: T, content: &str) -> Result<()>
+pub(crate) fn write_file<T>(file: T, content: &str) -> Result<()>
     where T: AsRef<Path>
 {
     fs::create_dir_all(file.as_ref().parent().expect("Parent directory exists"))?;


### PR DESCRIPTION
A number of `struct`s , `enum`s and functions inside different modules were having a `pub` visibility. A lot of these are implementation details that need not be exposed to the caller (thus allowing us to refactor the code without affecting the user expected behavior),

Made a single `cli_driver` public API for the `pkg_export_container`  `lib` crate  which will be called by the binary.

There is possible opportunity for refactoring further, but we will keep the changes small for now.