### PR TITLE
Removed dependency on crate `env`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,12 +904,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env"
-version = "0.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876927d21ef1ae98001c8c35a1d8dfd682136914b23ef04276820fa6d43c3630"
-
-[[package]]
 name = "env_filter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,7 +1393,6 @@ dependencies = [
  "broadcast",
  "bytes",
  "chrono",
- "env",
  "futures",
  "habitat_core",
  "habitat_http_client",

--- a/components/builder-api-client/Cargo.toml
+++ b/components/builder-api-client/Cargo.toml
@@ -9,7 +9,6 @@ workspace = "../../"
 broadcast = "*"
 bytes = "*"
 chrono = "*"
-env = "*"
 futures = "*"
 habitat_core = { path = "../core" }
 habitat_http_client = { path = "../http-client" }


### PR DESCRIPTION
`components/builder-api-client` had a dependency on crate `env` and this crate is possibly yanked from `crates.io`, this resulted in builds starting to fail.

Removed this dependency as this is an old dependency lying around and not used anywhere in the package.

Did a very basic `cargo build` and `cargo test`