### PR TITLE
Agadgil/e2e test failure container export

### DIFF
--- a/components/pkg-export-container/src/cli.rs
+++ b/components/pkg-export-container/src/cli.rs
@@ -28,11 +28,12 @@ pub fn cli() -> Command {
                                 .arg(Arg::new("IMAGE_NAME").long("image-name")
                                                            .short('i')
                                                            .value_name("IMAGE_NAME")
-                                                           .help("Image name template: supports: \
-                                                                  {{pkg_origin}}/{{pkg_name}} \
-                                                                  (default), {{pkg_origin}}, \
-                                                                  {{pkg_name}}, {{pkg_version}}, \
-                                                                  {{pkg_release}}, {{channel}})"));
+                                                           .help("Image name template: supports \
+                                                                  {{pkg_origin}}, {{pkg_name}}, \
+                                                                  {{pkg_version}}, \
+                                                                  {{pkg_release}}, {{channel}} \
+                                                                  variables. [default template: \
+                                                                  {{pkg_origin}}/{{pkg_name}}]"));
 
     let cmd = add_base_packages_args(cmd);
     let cmd = add_builder_args(cmd);


### PR DESCRIPTION
Fixes issues in end to end test [failure](https://buildkite.com/chef/habitat-sh-habitat-main-end-to-end/builds/1607#0190dd06-e879-4083-938b-d2aa2550258e) 

1. Fix for `test_cointainer_export` e2e test
2. Fix for `test_external_binaries` e2e test
