### PR TITLE
use CreateEnvironmentBlock from windows-sys instead of winapi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,6 +1525,7 @@ dependencies = [
  "widestring 1.1.0",
  "winapi",
  "windows-acl",
+ "windows-sys 0.52.0",
  "xz2",
 ]
 

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -60,13 +60,16 @@ winapi = { version = "^0.3", features = [
   "ioapiset",
   "namedpipeapi",
   "synchapi",
-  "userenv",
   "winbase",
   "wincrypt",
   "winerror",
   "ws2def",
 ] }
 windows-acl = "*"
+windows-sys = { version = "^0.52.0", features = [
+  "Win32_Foundation",
+  "Win32_System_Environment",
+] }
 
 [dev-dependencies]
 num_cpus = "*"                                       # For doc tests

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -61,7 +61,6 @@ use winapi::{shared::{minwindef::{BOOL,
                                       PROCESS_INFORMATION,
                                       STARTUPINFOW},
                   synchapi,
-                  userenv,
                   winbase::{CREATE_NEW_PROCESS_GROUP,
                             CREATE_UNICODE_ENVIRONMENT,
                             FILE_FLAG_FIRST_PIPE_INSTANCE,
@@ -95,7 +94,7 @@ use winapi::{shared::{minwindef::{BOOL,
                           PHANDLE,
                           READ_CONTROL,
                           WRITE_DAC}}};
-
+use windows_sys::Win32::System::Environment;
 lazy_static::lazy_static! {
     static ref CREATE_PROCESS_LOCK: Mutex<()> = Mutex::new(());
 }
@@ -993,8 +992,8 @@ fn create_user_environment(token: HANDLE,
                            -> io::Result<Vec<u16>> {
     unsafe {
         let mut new_env: Vec<u16> = Vec::new();
-        let mut block: LPVOID = ptr::null_mut();
-        cvt(userenv::CreateEnvironmentBlock(&mut block, token, FALSE))?;
+        let mut block = ptr::null_mut();
+        cvt(Environment::CreateEnvironmentBlock(&mut block, token as isize, FALSE))?;
         let mut tail: u32 = MAXDWORD;
         let mut offset = 0;
         let mut part = ParsePart::Key;
@@ -1037,7 +1036,7 @@ fn create_user_environment(token: HANDLE,
                 }
             }
         }
-        cvt(userenv::DestroyEnvironmentBlock(block))?;
+        cvt(Environment::DestroyEnvironmentBlock(block))?;
 
         let len = new_env.len();
         new_env.truncate(len - 1);

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -993,7 +993,9 @@ fn create_user_environment(token: HANDLE,
     unsafe {
         let mut new_env: Vec<u16> = Vec::new();
         let mut block = ptr::null_mut();
-        cvt(Environment::CreateEnvironmentBlock(&mut block, token as isize, FALSE))?;
+        cvt(Environment::CreateEnvironmentBlock(&mut block,
+                                                token as isize,
+                                                FALSE))?;
         let mut tail: u32 = MAXDWORD;
         let mut offset = 0;
         let mut part = ParsePart::Key;


### PR DESCRIPTION
For some reason, a recent crate bump of winapi-utils was causing confusion in the types used for `CreateEnvironmentBlock`. We have always used this ffi call and most other win32 api calls via the winapi crate. The environment block returned by `CreateEnvironmentBlock` was filled with only a single character repeated seemingly endlessly. This caused the loop that processes the block to never exit.

I swapped that function wit the one provided by the `windows-sys` crate and that fixed the behavior.

This should fix a couple of the broken e2e tests.