### PR TITLE
clap-v4 support for RST Reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 name = "habitat-rst-reader"
 version = "0.0.0"
 dependencies = [
- "clap 2.33.1",
+ "clap 4.5.9",
  "env_logger",
  "habitat_butterfly",
  "log 0.4.22",

--- a/components/rst-reader/Cargo.toml
+++ b/components/rst-reader/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 doc = false
 
 [dependencies]
-clap = { git = "https://github.com/habitat-sh/clap.git", branch = "v2-master", features = [ "suggestions", "color", "unstable" ] }
+clap = { version = "4" , features = ["env", "derive", "string", "wrap_help"]}
 env_logger = "*"
 habitat_butterfly = { path = "../butterfly", default-features = false }
 log = "0.4"

--- a/components/rst-reader/src/error.rs
+++ b/components/rst-reader/src/error.rs
@@ -3,11 +3,11 @@ use std::{error,
           result};
 
 #[derive(Debug)]
-pub enum Error {
+pub(crate) enum Error {
     Butterfly(habitat_butterfly::error::Error),
 }
 
-pub type Result<T> = result::Result<T, Error>;
+pub(crate) type Result<T> = result::Result<T, Error>;
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
Moved `rst-reader` binary to Clap V4. (CHEF-14728) 