### PR TITLE
use mac os 12 in release pipeline to fix broken mac builds

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -69,7 +69,7 @@ steps:
     expeditor:
       executor:
         macos:
-          os-version: "11"
+          os-version: "12"
           inherit-environment-vars: true
     timeout_in_minutes: 60
     retry:


### PR DESCRIPTION
Anka no longer supports 11.