### PR TITLE
fix regression breaking pathing of scaffolding dependencies and add test for linux

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,6 +18,7 @@ ignore = [
     "RUSTSEC-2022-0006", # Vulnerability (???): thread_local
     "RUSTSEC-2022-0013", # Vulnerability (7.5 High), regex
     "RUSTSEC-2022-0071", # Unmaintained: rusoto
+    "RUSTSEC-2024-0370", # Unmaintained: proc-macro-error (used by structopt)
 ]
 informational_warnings = [
     "notice",

--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -575,6 +575,18 @@ steps:
       automatic:
         limit: 1
 
+  - label: "[:linux: test_studio_can_build_scaffolded_package]"
+    command:
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_can_build_scaffolded_package
+    artifact_paths:
+      - "*.log"
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+
   - label: "[:linux: test_studio_unmount_with_long_filesystem]"
     command:
       - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_studio_unmount_with_long_filesystem

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -641,7 +641,7 @@ function Resolve-ScaffoldingDependencyList {
         $scaff_build_deps += $pkg_scaffolding
         if($resolved) {
             Write-BuildLine "Resolved scaffolding dependency '$pkg_scaffolding' to $resolved"
-            $scaff_build_deps_resolved+=($resolved)
+            $scaff_build_deps_resolved+=(Resolve-Path "$HAB_PKG_PATH/$resolved").Path
             $sdeps=(@(Get-DepsFor $resolved) + @(Get-BuildDepsFor $resolved))
             foreach($sdep in $sdeps) {
                 $scaff_build_deps += $sdep

--- a/components/plan-build/bin/hab-plan-build.sh
+++ b/components/plan-build/bin/hab-plan-build.sh
@@ -986,7 +986,7 @@ _resolve_scaffolding_dependencies() {
   scaff_build_deps+=("$pkg_scaffolding")
   if [[ $resolved != "" ]]; then
     build_line "Resolved scaffolding dependency '$pkg_scaffolding' to $resolved"
-    scaff_build_deps_resolved+=("$resolved")
+    scaff_build_deps_resolved+=("$HAB_PKG_PATH/$resolved")
     # Add each (fully qualified) direct run dependency of the scaffolding
     # package.
     mapfile -t sdeps < <(_get_deps_for "$resolved") # See syntax note @ _get_deps_for
@@ -1043,7 +1043,7 @@ _resolve_build_dependencies() {
     resolved=$(echo "$res" | tail -n 1 | grep -Eo "\S+/\S+")
     if [[ $resolved != "" ]]; then
       build_line "Resolved build dependency '$dep' to $resolved"
-      pkg_build_deps_resolved+=("/hab/pkgs/$resolved")
+      pkg_build_deps_resolved+=("$HAB_PKG_PATH/$resolved")
     else
       exit_with "Resolving '$dep' failed, should this be built first?" 1
     fi
@@ -1120,7 +1120,7 @@ _resolve_run_dependencies() {
     resolved=$(echo "$res" | tail -n 1 | grep -Eo "\S+/\S+")
     if [[ $resolved != "" ]]; then
       build_line "Resolved dependency '$dep' to $resolved"
-      pkg_deps_resolved+=("/hab/pkgs/$resolved")
+      pkg_deps_resolved+=("$HAB_PKG_PATH/$resolved")
     else
       exit_with "Resolving '$dep' failed, should this be built first?" 1
     fi

--- a/test/end-to-end/test_studio_can_build_scaffolded_package.ps1
+++ b/test/end-to-end/test_studio_can_build_scaffolded_package.ps1
@@ -1,24 +1,30 @@
 hab origin key generate $env:HAB_ORIGIN
 
-Function Invoke-WindowsPlanBuild($package) {
-    Invoke-NativeCommand hab pkg build test/fixtures/windows_plans/$package -R | Out-Null
+Function Invoke-PlanBuild($package) {
+    hab pkg build test/fixtures/$package -R | Out-Null
+    if ($IsLinux) {
+        # This changes the format of last_build from `var=value` to `$var='value'`
+        # so that powershell can parse and source the script
+        Set-Content -Path "results/last_build.ps1" -Value ""
+        Get-Content "results/last_build.env" | ForEach-Object { Add-Content "results/last_build.ps1" -Value "`$$($_.Replace("=", '="'))`"" }
+    }
     . results/last_build.ps1
     @{ Artifact = $pkg_artifact; Ident = $pkg_ident }
 }
 
 Describe "package using scaffolding" {
-    $dummy = Invoke-WindowsPlanBuild dummy
-    $dummyHabSvcUser = Invoke-WindowsPlanBuild dummy_hab_svc_user
-    $scaffolding = Invoke-WindowsPlanBuild scaffolding
-    $consumer = Invoke-WindowsPlanBuild use_scaffolding
+    $minimal = Invoke-PlanBuild minimal-package
+    $depPkg = Invoke-PlanBuild dep-pkg-1
+    $scaffolding = Invoke-PlanBuild scaffolding
+    $consumer = Invoke-PlanBuild use_scaffolding
     It "inherits scaffolding dependencies" {
-        hab pkg install "results/$($dummy.Artifact)"
-        hab pkg install "results/$($dummyHabSvcUser.Artifact)"
+        hab pkg install "results/$($minimal.Artifact)"
+        hab pkg install "results/$($depPkg.Artifact)"
         hab pkg install "results/$($scaffolding.Artifact)"
         hab pkg install "results/$($consumer.Artifact)"
-        # scaffolding has dummy as runtime and dummy_hab_svc_user as build time deps
+        # scaffolding has minimal_package as runtime and dep-pkg-1 as build time deps
 
-        "/hab/pkgs/$($consumer.Ident)/DEPS" | Should -FileContentMatch "habitat-testing/dummy"
-        "/hab/pkgs/$($consumer.Ident)/BUILD_DEPS" | Should -FileContentMatch "habitat-testing/dummy-hab-user"
+        "/hab/pkgs/$($consumer.Ident)/DEPS" | Should -FileContentMatch "$env:HAB_ORIGIN/minimal_package"
+        "/hab/pkgs/$($consumer.Ident)/BUILD_DEPS" | Should -FileContentMatch "$env:HAB_ORIGIN/dep-pkg-1"
     }
 }

--- a/test/fixtures/scaffolding/lib/scaffolding.ps1
+++ b/test/fixtures/scaffolding/lib/scaffolding.ps1
@@ -1,6 +1,6 @@
 [Diagnostics.CodeAnalysis.SuppressMessage("PSUseApprovedVerbs", '', Scope="function")]
 param()
 function Load-Scaffolding {
-    $pkg_deps += @("habitat-testing/dummy")
-    $pkg_build_deps += @("habitat-testing/dummy-hab-user")
+    $pkg_deps += @("$env:HAB_ORIGIN/minimal_package")
+    $pkg_build_deps += @("$env:HAB_ORIGIN/dep-pkg-1")
 }

--- a/test/fixtures/scaffolding/lib/scaffolding.sh
+++ b/test/fixtures/scaffolding/lib/scaffolding.sh
@@ -1,0 +1,4 @@
+scaffolding_load() {
+    pkg_deps=("$HAB_ORIGIN/minimal_package" "${pkg_deps[@]}")
+    pkg_build_deps=("$HAB_ORIGIN/dep-pkg-1" "${pkg_build_deps[@]}")
+}

--- a/test/fixtures/scaffolding/plan.ps1
+++ b/test/fixtures/scaffolding/plan.ps1
@@ -1,5 +1,5 @@
 $pkg_name="dummy-scaffolding"
-$pkg_origin="habitat-testing"
+$pkg_origin=$env:HAB_ORIGIN
 $pkg_version="0.1.0"
 
 function Invoke-Install {

--- a/test/fixtures/scaffolding/plan.sh
+++ b/test/fixtures/scaffolding/plan.sh
@@ -1,3 +1,4 @@
+# shellcheck disable=2154
 pkg_name="dummy-scaffolding"
 pkg_origin=$HAB_ORIGIN
 pkg_version="0.1.0"

--- a/test/fixtures/scaffolding/plan.sh
+++ b/test/fixtures/scaffolding/plan.sh
@@ -1,0 +1,8 @@
+pkg_name="dummy-scaffolding"
+pkg_origin=$HAB_ORIGIN
+pkg_version="0.1.0"
+
+do_build() { :; }
+do_install() {
+  install -D -m 0644 "$PLAN_CONTEXT/lib/scaffolding.sh" "$pkg_prefix/lib/scaffolding.sh"
+}

--- a/test/fixtures/use_scaffolding/plan.ps1
+++ b/test/fixtures/use_scaffolding/plan.ps1
@@ -1,0 +1,4 @@
+$pkg_name="use-scaffolding"
+$pkg_origin=$env:HAB_ORIGIN
+$pkg_version="0.1.0"
+$pkg_scaffolding="$env:HAB_ORIGIN/dummy-scaffolding"

--- a/test/fixtures/use_scaffolding/plan.sh
+++ b/test/fixtures/use_scaffolding/plan.sh
@@ -1,0 +1,7 @@
+pkg_name="use-scaffolding"
+pkg_origin=$HAB_ORIGIN
+pkg_version="0.1.0"
+pkg_scaffolding="$HAB_ORIGIN/dummy-scaffolding"
+
+do_build() { :; }
+do_install() { :; }

--- a/test/fixtures/windows_plans/use_scaffolding/plan.ps1
+++ b/test/fixtures/windows_plans/use_scaffolding/plan.ps1
@@ -1,4 +1,0 @@
-$pkg_name="use-scaffolding"
-$pkg_origin="habitat-testing"
-$pkg_version="0.1.0"
-$pkg_scaffolding="habitat-testing/dummy-scaffolding"


### PR DESCRIPTION
This fixes the scaffolding e2e test broken by recent PR merge and it also ensures we test scaffolding loading on linux too. I have validated the both windows and linux tests pass now.