### PR TITLE
Possible fixes: Leader Election Issue (CHEF-15608)

### DIFF
--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -523,16 +523,13 @@ impl MemberList {
                                                     health:            incoming.health,
                                                     health_updated_at: Instant::now(), };
                         trace!("Occupied: Updated");
-                        eprintln!("1");
                         true
                     } else {
                         trace!("Occupied: Not Updated");
-                        eprintln!("2");
                         false
                     }
                 } else {
                     trace!("Occupied: Not Updated");
-                    eprintln!("3");
                     false
                 }
             }

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -541,7 +541,7 @@ impl MemberList {
     pub(crate) fn insert_member_ignore_incarnation_mlw(&self,
                                                        incoming_member: Member,
                                                        incoming_health: Health) {
-        trace!("Inserting Member: {} with Health: {}",
+        trace!("Inserting Member: {:?} with Health: {}",
                incoming_member,
                incoming_health);
         self.insert_membership_mlw(Membership { member: incoming_member,

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -669,14 +669,13 @@ impl Server {
     fn insert_member_from_rumor_mlw_smw_rhw(&self, member: Member, mut health: Health) {
         let rk: RumorKey = RumorKey::from(&member);
 
-        if member.id == self.member_id()
-           && health != Health::Alive
-           && member.incarnation >= self.myself.lock_smr().incarnation()
-        {
-            self.myself
-                .lock_smw()
-                .refute_incarnation(member.incarnation);
+        if member.id == self.member_id() && health != Health::Alive {
             health = Health::Alive;
+            if member.incarnation >= self.myself.lock_smr().incarnation() {
+                self.myself
+                    .lock_smw()
+                    .refute_incarnation(member.incarnation);
+            }
         }
 
         let member_id = member.id.clone();

--- a/components/butterfly/src/server.rs
+++ b/components/butterfly/src/server.rs
@@ -618,6 +618,28 @@ impl Server {
         }
     }
 
+    /// Set the Sender to Alive
+    ///
+    /// If we simply use `insert_member_mlw_rhw` as above, the sender may be having the current
+    /// Incarnation and hence if we try to "update" the sender, it does not get updated. So the
+    /// sender might remain in `Confirmed` state even after having received a message/ack from the
+    /// sender. We need to ignore the `Incarnation` in this case.
+    pub(crate) fn mark_sender_alive_mlw_rhw(&self, sender: Member) {
+        trace!("Marking sender as Alive!");
+        let rk: RumorKey = RumorKey::from(&sender);
+
+        let sender_id = sender.id.clone();
+
+        if self.member_list
+               .insert_member_ignore_incarnation_mlw(sender, Health::Alive)
+        {
+            debug!("Marking member as 'Alive' again, we are 'purging' all old rumours and start \
+                    a new rumour.");
+            self.rumor_heat.lock_rhw().purge(&sender_id);
+            self.rumor_heat.lock_rhw().start_hot_rumor(rk);
+        }
+    }
+
     /// Set our member to departed, then send up to 10 out of order ack messages to other
     /// members to seed our status.
     ///
@@ -669,8 +691,11 @@ impl Server {
     fn insert_member_from_rumor_mlw_smw_rhw(&self, member: Member, mut health: Health) {
         let rk: RumorKey = RumorKey::from(&member);
 
+        trace!("Inserting {} in the member list. ", member.id);
+
         if member.id == self.member_id() && health != Health::Alive {
             health = Health::Alive;
+            trace!("Inserting myself, Always Alive, refute_incarnation");
             if member.incarnation >= self.myself.lock_smr().incarnation() {
                 self.myself
                     .lock_smw()

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -292,6 +292,7 @@ fn process_ping_mlw_smw_rhw(server: &Server, socket: &UdpSocket, addr: SocketAdd
                    membership.health);
             server.insert_member_from_rumor_mlw_smw_rhw(membership.member, membership.health);
         } else {
+            trace!("Originator is in Confirmed or > State.");
             if membership.member.id == originator_id || membership.member.id == server.member_id() {
                 server.insert_member_from_rumor_mlw_smw_rhw(membership.member, Health::Alive);
             }

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -165,7 +165,8 @@ fn process_pingreq_mlr_smr_rhw(server: &Server,
                               forward_to: Some(msg.from.clone()), };
 
         // Add requester to hot rumors, as Requester is now `Alive`?
-        let originator = msg.from.clone();
+        let mut originator = msg.from.clone();
+        originator.address = addr.ip().to_string();
         server.insert_member_mlw_rhw(originator, Health::Alive);
 
         let swim = outbound::populate_membership_rumors_mlr_rhw(server, &target, ping_msg);
@@ -194,7 +195,7 @@ fn process_ack_mlw_smw_rhw(server: &Server,
                            mut msg: Ack) {
     trace!("Ack from {}@{}", msg.from.id, addr);
 
-    let originator = msg.from.clone();
+    let mut originator = msg.from.clone();
     if msg.forward_to.is_some() && *server.member_id != msg.forward_to.as_ref().unwrap().id {
         let (forward_to_addr, from_addr) = {
             let forward_to = msg.forward_to.as_ref().unwrap();
@@ -220,6 +221,7 @@ fn process_ack_mlw_smw_rhw(server: &Server,
 
         // Mark the one we received message from as `Alive` or `Departed` (it should be `Alive`
         // Normally). Similar to `process_ping..` below.
+        originator.address = addr.ip().to_string();
         if originator.departed {
             server.insert_member_mlw_rhw(originator, Health::Departed);
         } else {
@@ -237,6 +239,7 @@ fn process_ack_mlw_smw_rhw(server: &Server,
 
             // TODO: Mark the one we received from either as `Departed` or `Alive`.
             // Similar to `process_ping..` below.
+            originator.address = addr.ip().to_string();
             if originator.departed {
                 server.insert_member_mlw_rhw(originator, Health::Departed);
             } else {

--- a/components/butterfly/src/server/inbound.rs
+++ b/components/butterfly/src/server/inbound.rs
@@ -223,11 +223,9 @@ fn process_ack_mlw_smw_rhw(server: &Server,
         // Normally). Similar to `process_ping..` below.
         originator.address = addr.ip().to_string();
         if originator.departed {
-            server.member_list
-                  .insert_member_ignore_incarnation_mlw(originator, Health::Departed);
+            server.insert_member_mlw_rhw(originator, Health::Departed);
         } else {
-            server.member_list
-                  .insert_member_ignore_incarnation_mlw(originator, Health::Alive);
+            server.insert_member_mlw_rhw(originator, Health::Alive);
         }
 
         return;
@@ -246,11 +244,9 @@ fn process_ack_mlw_smw_rhw(server: &Server,
             // Similar to `process_ping..` below.
             originator.address = addr.ip().to_string();
             if originator.departed {
-                server.member_list
-                      .insert_member_ignore_incarnation_mlw(originator, Health::Departed);
+                server.insert_member_mlw_rhw(originator, Health::Departed);
             } else {
-                server.member_list
-                      .insert_member_ignore_incarnation_mlw(originator, Health::Alive);
+                server.insert_member_mlw_rhw(originator, Health::Alive);
             }
         }
         Err(e) => panic!("Outbound thread has died - this shouldn't happen: #{:?}", e),
@@ -277,10 +273,8 @@ fn process_ping_mlw_smw_rhw(server: &Server, socket: &UdpSocket, addr: SocketAdd
     // everyone as either `Suspect`/`Confirmed` and thus will `gossip` everyone is dead which may
     // include sender.)
     if msg.from.departed {
-        server.member_list
-              .insert_member_ignore_incarnation_mlw(msg.from, Health::Departed);
+        server.insert_member_mlw_rhw(msg.from, Health::Departed);
     } else {
-        server.member_list
-              .insert_member_ignore_incarnation_mlw(msg.from, Health::Alive);
+        server.insert_member_mlw_rhw(msg.from, Health::Alive);
     }
 }

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -251,7 +251,7 @@ fn recv_ack_mlw_rhw(server: &Server,
                     if ack.from.departed {
                         server.insert_member_mlw_rhw(ack.from, Health::Departed);
                     } else {
-                        server.insert_member_mlw_rhw(ack.from, Health::Alive);
+                        server.mark_sender_alive_mlw_rhw(ack.from);
                     }
                     // Keep listening, we want the ack we expected
                     continue;
@@ -260,7 +260,7 @@ fn recv_ack_mlw_rhw(server: &Server,
                     if ack.from.departed {
                         server.insert_member_mlw_rhw(ack.from, Health::Departed);
                     } else {
-                        server.insert_member_mlw_rhw(ack.from, Health::Alive);
+                        server.mark_sender_alive_mlw_rhw(ack.from);
                     }
                     return true;
                 }

--- a/components/butterfly/src/server/outbound.rs
+++ b/components/butterfly/src/server/outbound.rs
@@ -492,7 +492,7 @@ pub fn ack_mlr_smr_rhw(server: &Server,
     let ack_msg = Ack { membership: vec![],
                         from:       server.myself.lock_smr().to_member(),
                         forward_to: forward_to.map(Member::from), };
-    let member_id = ack_msg.from.id.clone();
+
     let swim = populate_membership_rumors_mlr_rhw(server, target, ack_msg);
     let bytes = match swim.encode() {
         Ok(bytes) => bytes,
@@ -514,8 +514,8 @@ pub fn ack_mlr_smr_rhw(server: &Server,
             SWIM_MESSAGES_SENT.with_label_values(label_values).inc();
             SWIM_BYTES_SENT.with_label_values(label_values)
                            .set(payload.len().to_i64());
-            trace!("Sent ack to {}@{}", member_id, addr);
+            trace!("Sent ack to {}@{}", target.id, addr);
         }
-        Err(e) => error!("Failed ack to {}@{}: {}", member_id, addr, e),
+        Err(e) => error!("Failed ack to {}@{}: {}", target.id, addr, e),
     }
 }

--- a/components/butterfly/src/server/pull.rs
+++ b/components/butterfly/src/server/pull.rs
@@ -117,8 +117,13 @@ fn run_loop(server: &Server) -> ! {
             continue 'recv;
         }
 
+        trace!("Received Message from {}", proto.from_id);
         match proto.kind {
             RumorKind::Membership(membership) => {
+                trace!("Received Rumour : {}, Health: {}, from: {}",
+                       membership.member.id,
+                       membership.health,
+                       proto.from_id);
                 server.insert_member_from_rumor_mlw_smw_rhw(membership.member, membership.health);
             }
             RumorKind::Service(service) => server.insert_service_rsw_mlw_rhw(*service),


### PR DESCRIPTION
1. Allow a member in `Suspect` health to participate in the `electorate`.
2. Log failure of `check_quorum` as `warn!` when `check_quorum` fails.
3. Reverse the order of `insert_mlw_` when processing `Ping`.
4. Added `insert_mlw_` when processing `PingReq` or `Ack` to mark the originator as alive.