### PR TITLE
CHEF-10987: Habitat installs on hardened systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ $(foreach component,$(ALL),$(eval $(call CLEAN,$(component))))
 RUSTFMT_TOOLCHAIN := $(shell cat RUSTFMT_VERSION)
 define FMT
 fmt-$1: image ## formats the $1 component
-	$(run) sh -c 'cd components/$1 && cargo +$(RUSTFMT_TOOLCHAIN) fmt --all -- --check'
+	$(run) sh -c 'cd components/$1 && cargo +$(RUSTFMT_TOOLCHAIN) fmt --all'
 .PHONY: fmt-$1
 
 endef

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ $(foreach component,$(ALL),$(eval $(call CLEAN,$(component))))
 RUSTFMT_TOOLCHAIN := $(shell cat RUSTFMT_VERSION)
 define FMT
 fmt-$1: image ## formats the $1 component
-	$(run) sh -c 'cd components/$1 && cargo +$(RUSTFMT_TOOLCHAIN) fmt'
+	$(run) sh -c 'cd components/$1 && cargo +$(RUSTFMT_TOOLCHAIN) fmt --all -- --check'
 .PHONY: fmt-$1
 
 endef

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -47,7 +47,7 @@ rustls-webpki = "*"
 xz2 = "*"
 
 [target.'cfg(not(windows))'.dependencies]
-nix = { version = "*", features = ["signal", "user"] }
+nix = { version = "*", features = ["signal", "user", "fs"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "*"
 

--- a/components/core/src/package/list.rs
+++ b/components/core/src/package/list.rs
@@ -28,6 +28,8 @@ pub fn temp_package_directory(path: &Path) -> Result<TempDir> {
         )
                              })?;
     fs::create_dir_all(base)?;
+    #[cfg(unix)]
+    crate::util::posix_perm::ensure_path_permissions(base, 0o755)?;
 
     // If this temp directory is being used for installs, we will be untarring archives
     // into the directory. Depending on the length of the paths included in the archives

--- a/components/core/src/util/posix_perm.rs
+++ b/components/core/src/util/posix_perm.rs
@@ -60,7 +60,12 @@ pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> 
     }
 }
 
-pub fn ensure_path_permissions(path: &Path, permissions: u32) -> Result<()> {
+// This is required on machines where umask is set to a higher value like `0077`. (See CHEF-10987)
+// This has a side effect of potentially changing the *mode* of directories not created by us but this
+// is done in order to ensure the ability to execute in the face of the variety of scenarios that may
+// be encounter "in the wild". This is as such not a huge problem as we are only changing the *mode*
+// for `ancestors` we are owner of.
+pub(crate) fn ensure_path_permissions(path: &Path, permissions: u32) -> Result<()> {
     let euid = users::get_effective_uid();
     let egid = users::get_effective_gid();
     for ancestor in path.ancestors() {

--- a/components/core/src/util/posix_perm.rs
+++ b/components/core/src/util/posix_perm.rs
@@ -61,10 +61,10 @@ pub fn set_owner<T: AsRef<Path>, X: AsRef<str>>(path: T, owner: X, group: X) -> 
 }
 
 // This is required on machines where umask is set to a higher value like `0077`. (See CHEF-10987)
-// This has a side effect of potentially changing the *mode* of directories not created by us but this
-// is done in order to ensure the ability to execute in the face of the variety of scenarios that may
-// be encounter "in the wild". This is as such not a huge problem as we are only changing the *mode*
-// for `ancestors` we are owner of.
+// This has a side effect of potentially changing the *mode* of directories not created by us but
+// this is done in order to ensure the ability to execute in the face of the variety of scenarios
+// that may be encounter "in the wild". This is as such not a huge problem as we are only changing
+// the *mode* for `ancestors` we are owner of.
 pub(crate) fn ensure_path_permissions(path: &Path, permissions: u32) -> Result<()> {
     let euid = users::get_effective_uid();
     let egid = users::get_effective_gid();

--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-#
+
 set -eou pipefail
+
+umask 0022
 
 # If the variable `$DEBUG` is set, then print the shell commands as we execute.
 if [ -n "${DEBUG:-}" ]; then set -x; fi

--- a/test/end-to-end/test_pkg_install.ps1
+++ b/test/end-to-end/test_pkg_install.ps1
@@ -16,6 +16,29 @@ Describe "pkg install" {
         hab pkg uninstall $env:HAB_ORIGIN/dep-pkg-4
     }
 
+    It "ensures 755 permissions on umask 0077 systems" {
+
+        $Origin = "core"
+        $Name = "zsh"
+        $Version = "5.8"
+        $Release = "20240110100558"
+        $PkgId = "$Origin/$Name/$Version/$Release" # core/zsh/5.8/20240110100558
+
+        if ($IsLinux) {
+            bash -c "umask 0000; hab pkg install --binlink --force $PkgId"
+            $LASTEXITCODE | Should -Be 0
+
+            "/hab/pkgs/$PkgId --version"
+            $LASTEXITCODE | Should -Be 0
+
+            "/bin/$Name --version"
+            $LASTEXITCODE | Should -Be 0
+
+            "/usr/bin/$Name-$Version --version"
+            $LASTEXITCODE | Should -Be 0
+        }
+    }
+
     It "installs all dependencies and executes all install hooks" {
         $cached = Get-Item "/hab/cache/artifacts/$env:HAB_ORIGIN-dep-pkg-3*"
         hab pkg install $cached.FullName

--- a/test/end-to-end/test_pkg_install.ps1
+++ b/test/end-to-end/test_pkg_install.ps1
@@ -25,7 +25,7 @@ Describe "pkg install" {
         $PkgId = "$Origin/$Name/$Version/$Release" # core/zsh/5.8/20240110100558
 
         if ($IsLinux) {
-            bash -c "umask 0000; hab pkg install --binlink --force $PkgId"
+            bash -c "umask 0077; hab pkg install --binlink --force $PkgId"
             $LASTEXITCODE | Should -Be 0
 
             "/hab/pkgs/$PkgId --version"


### PR DESCRIPTION
- Adds umask 0222 to start of install.sh
- aligns rustfmt between Makefile target and expeditor/buildkite/ci/cd
- Ensures hab pkg installs have 755 dirs