### PR TITLE
install additional pkgs from env

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -1746,6 +1746,20 @@ try {
 
     Set-HabBin
 
+    # This installs any additional packages required for building.
+    # It is useful in scenarios where you have a newer version of a package
+    # and want Habitat to use the newer, locally installed version during
+    # a studio build. We do exactly this during the package refresh process with `hab-auto-build`.
+    if (-not [string]::IsNullOrEmpty($env:HAB_STUDIO_INSTALL_PKGS)) {
+        Write-BuildLine "Installing additional packages in bootstrap studio"
+        $deps = $env:HAB_STUDIO_INSTALL_PKGS -split ";"
+        foreach ($dep in $deps) {
+            Write-BuildLine "Installing $dep"
+            $cmd = "$HAB_BIN pkg install $dep"
+            Invoke-Expression $cmd
+        }
+    }
+
     # Download and resolve the depdencies
     # Create initial package arrays
     Initialize-DependencyList

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -1755,8 +1755,7 @@ try {
         $deps = $env:HAB_STUDIO_INSTALL_PKGS -split ";"
         foreach ($dep in $deps) {
             Write-BuildLine "Installing $dep"
-            $cmd = "$HAB_BIN pkg install $dep"
-            Invoke-Expression $cmd
+            & $HAB_BIN pkg install "$dep"
         }
     }
 


### PR DESCRIPTION
While building core packages, the hab-auto-build tool does not connect to the builder to download dependent packages; instead, it installs them offline. This is achieved using the NO_INSTALL_DEPS and HAB_STUDIO_INSTALL_PKGS environment variables.

While exploring the possibility of extending hab-auto-build, I encountered a similar requirement to install previously built packages before proceeding to build the current package.

This PR includes changes to read the HAB_STUDIO_INSTALL_PKGS environment variable, where packages to be installed are specified as a string separated by semicolons (;). These packages will then be installed before proceeding with the package build.