### PR TITLE
Stops setting permissions in ensure_path_permissions when we reach pkgs directory

### DIFF
--- a/components/core/src/util/posix_perm.rs
+++ b/components/core/src/util/posix_perm.rs
@@ -69,7 +69,7 @@ pub(crate) fn ensure_path_permissions(path: &Path, permissions: u32) -> Result<(
     let euid = users::get_effective_uid();
     let egid = users::get_effective_gid();
     for ancestor in path.ancestors() {
-        if ancestor.ends_with("hab/pkgs") {
+        if ancestor.ends_with(crate::fs::PKG_PATH) {
             break;
         }
         if euid_egid_matches(&euid, &egid, ancestor) {

--- a/components/core/src/util/posix_perm.rs
+++ b/components/core/src/util/posix_perm.rs
@@ -69,6 +69,9 @@ pub(crate) fn ensure_path_permissions(path: &Path, permissions: u32) -> Result<(
     let euid = users::get_effective_uid();
     let egid = users::get_effective_gid();
     for ancestor in path.ancestors() {
+        if ancestor.ends_with("hab/pkgs") {
+            break;
+        }
         if euid_egid_matches(&euid, &egid, ancestor) {
             set_permissions(ancestor, permissions)?
         }


### PR DESCRIPTION
Stops setting permissions in ensure_path_permissions when we reach pkgs directory


An interim version of the code had some print stmts that show the path and the ancestors it walked up.  This show one of those runs where it stoped walking up the path hierarchy when it hit pkgs.

```
PATH: "/tmp/.tmpJ2NRUr/rootfs/hab/pkgs/core/linux-headers/4.20.17"
 ANC:"/tmp/.tmpJ2NRUr/rootfs/hab/pkgs/core/linux-headers/4.20.17"
 ANC:"/tmp/.tmpJ2NRUr/rootfs/hab/pkgs/core/linux-headers"
 ANC:"/tmp/.tmpJ2NRUr/rootfs/hab/pkgs/core"
 ANC:"/tmp/.tmpJ2NRUr/rootfs/hab/pkgs"
```