### PR TITLE
fix dep resolution with HAB_STUDIO_INSTALL_PKGS

### DIFF
--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -365,8 +365,8 @@ function Install-Dependency($dependency, $install_args = $null) {
     }
 }
 
-# **Internal** From hab-auto-build, we set the specific packages to be installed using 
-# the environment variable HAB_STUDIO_INSTALL_PKGS before building. This helper function resolves 
+# **Internal** From hab-auto-build, we set the specific packages to be installed using
+# the environment variable HAB_STUDIO_INSTALL_PKGS before building. This helper function resolves
 # the given dependency to the identifier installed from HAB_STUDIO_INSTALL_PKGS.
 function __resolve_full_ident($dep) {
     if (-not [string]::IsNullOrEmpty($env:HAB_STUDIO_INSTALL_PKGS)) {

--- a/components/plan-build-ps1/bin/hab-plan-build.ps1
+++ b/components/plan-build-ps1/bin/hab-plan-build.ps1
@@ -356,7 +356,7 @@ function Install-Dependency($dependency, $install_args = $null) {
         Write-Host $res
         [Console]::OutputEncoding = $oldEncoding
         if($res.Split("`n")[-2] -match "\S+/\S+") {
-           $Matches[0]
+            $Matches[0]
         } else {
             ""
         }


### PR DESCRIPTION
For hab-auto-build, the dependent packages are installed using `HAB_STUDIO_INSTALL_PKGS` when `NO_INSTALL_DEPS` is set. However, the dependencies are not being resolved during the evaluation of those required by the studio. This PR addresses this issue by handling dependency resolution based on `HAB_STUDIO_INSTALL_PKGS` when `NO_INSTALL_DEPS` is set.