### PR TITLE
fixes for release pipeline (aarch64)

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -118,7 +118,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "LTS-2024"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh plan-build
@@ -162,7 +162,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "LTS-2024"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh backline
@@ -195,7 +195,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "LTS-2024"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh studio
@@ -242,7 +242,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "LTS-2024"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh launcher
@@ -284,7 +284,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "LTS-2024"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh sup
@@ -326,7 +326,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "LTS-2024"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh pkg-export-container
@@ -356,7 +356,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "LTS-2024"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh pkg-export-tar
@@ -422,7 +422,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "LTS-2024"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/package_and_upload_binary.sh

--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -118,7 +118,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_FALLBACK_CHANNEL: "LTS-2024"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh plan-build
@@ -162,7 +162,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_FALLBACK_CHANNEL: "LTS-2024"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh backline
@@ -195,7 +195,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_FALLBACK_CHANNEL: "LTS-2024"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh studio
@@ -242,7 +242,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_FALLBACK_CHANNEL: "LTS-2024"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh launcher
@@ -284,7 +284,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_FALLBACK_CHANNEL: "LTS-2024"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh sup
@@ -326,7 +326,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_FALLBACK_CHANNEL: "LTS-2024"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh pkg-export-container
@@ -356,7 +356,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_FALLBACK_CHANNEL: "LTS-2024"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/build_component.sh pkg-export-tar
@@ -422,7 +422,7 @@ steps:
     agents:
       queue: default-privileged-aarch64
     env:
-      HAB_FALLBACK_CHANNEL: "LTS-2024"
+      HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/release_habitat/package_and_upload_binary.sh

--- a/.expeditor/scripts/release_habitat/build_component.sh
+++ b/.expeditor/scripts/release_habitat/build_component.sh
@@ -33,6 +33,9 @@ ${hab_binary} studio rm
 
 echo "--- :habicat: Building components/${component} using ${hab_binary}"
 
+# Set the refresh channel to the release channel.
+export HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL="${channel}"
+
 HAB_BLDR_CHANNEL="${channel}" ${hab_binary} pkg build "components/${component}"
 source results/last_build.env
 

--- a/.expeditor/scripts/verify/build_package-aarch64.sh
+++ b/.expeditor/scripts/verify/build_package-aarch64.sh
@@ -5,7 +5,7 @@ set -eou pipefail
 package_path=${1?package_path argument required}
 
 # Install hab from a temporarily uploaded aarch64 package
-curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash -s -- -t "$BUILD_PKG_TARGET" -c "$HAB_FALLBACK_CHANNEL" -v 1.6.1178
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash -s -- -t "$BUILD_PKG_TARGET"
 
 # Since we are only verifying we don't have build failures, make everything
 # temp!

--- a/.expeditor/scripts/verify/build_package-aarch64.sh
+++ b/.expeditor/scripts/verify/build_package-aarch64.sh
@@ -19,12 +19,9 @@ HAB_CACHE_KEY_PATH="$JOB_TEMP_ROOT/keys"
 
 export HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL
 HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL="$HAB_FALLBACK_CHANNEL"
-export HAB_PREFER_LOCAL_CHEF_DEPS="true"
+export HAB_PREFER_LOCAL_CHEF_DEPS="false"
 
 echo "--- :key: Generating temporary origin key"
 hab origin key generate "$HAB_ORIGIN"
 echo "--- :hab: Running hab pkg build for $package_path"
-# Install the temporarily built hab-studio.
-# Once hab is released in the LTS channel, this step may no longer be required.
-hab pkg install core/hab-studio -c "$HAB_FALLBACK_CHANNEL"
 hab pkg build "$package_path"

--- a/.expeditor/scripts/verify/build_package-aarch64.sh
+++ b/.expeditor/scripts/verify/build_package-aarch64.sh
@@ -17,10 +17,6 @@ JOB_TEMP_ROOT=$(mktemp -d /tmp/job-root-XXXXXX)
 export HAB_CACHE_KEY_PATH
 HAB_CACHE_KEY_PATH="$JOB_TEMP_ROOT/keys"
 
-export HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL
-HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL="$HAB_FALLBACK_CHANNEL"
-export HAB_PREFER_LOCAL_CHEF_DEPS="false"
-
 echo "--- :key: Generating temporary origin key"
 hab origin key generate "$HAB_ORIGIN"
 echo "--- :hab: Running hab pkg build for $package_path"

--- a/.expeditor/scripts/verify/run_cargo_test-aarch64.sh
+++ b/.expeditor/scripts/verify/run_cargo_test-aarch64.sh
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 # Install hab from a temporarily uploaded aarch64 package
-curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash -s -- -t aarch64-linux -c lts24-aarch64-linux -v 1.6.1178
+curl https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh | sudo bash -s -- -t aarch64-linux
 
 # shellcheck source=.expeditor/scripts/shared.sh
 source .expeditor/scripts/verify/shared.sh

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -853,7 +853,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "lts24-aarch64-linux"
+      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh test-services/test-probe
@@ -886,7 +886,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "lts24-aarch64-linux"
+      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/backline
@@ -915,7 +915,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "lts24-aarch64-linux"
+      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/hab
@@ -944,7 +944,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "lts24-aarch64-linux"
+      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/launcher
@@ -991,7 +991,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "lts24-aarch64-linux"
+      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/pkg-export-container
@@ -1020,7 +1020,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "lts24-aarch64-linux"
+      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/pkg-export-tar
@@ -1063,7 +1063,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "lts24-aarch64-linux"
+      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/plan-build
@@ -1092,7 +1092,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "lts24-aarch64-linux"
+      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/studio
@@ -1121,7 +1121,7 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "lts24-aarch64-linux"
+      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/sup

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -853,7 +853,6 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh test-services/test-probe
@@ -886,7 +885,6 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/backline
@@ -915,7 +913,6 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/hab
@@ -944,7 +941,6 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/launcher
@@ -991,7 +987,6 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/pkg-export-container
@@ -1020,7 +1015,6 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/pkg-export-tar
@@ -1063,7 +1057,6 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/plan-build
@@ -1092,7 +1085,6 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/studio
@@ -1121,7 +1113,6 @@ steps:
       HAB_LICENSE: "accept-no-persist"
       HAB_BLDR_CHANNEL: "LTS-2024"
       HAB_REFRESH_CHANNEL: "LTS-2024"
-      HAB_FALLBACK_CHANNEL: "stable"
       BUILD_PKG_TARGET: "aarch64-linux"
     command:
       - sudo -E .expeditor/scripts/verify/build_package-aarch64.sh components/sup

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1040,6 +1040,16 @@ chown_certs() {
   fi
 }
 
+# **Internal**
+# Mimic delay using busy loop
+busy_sleep() {
+    local duration=$1
+    local end_time=$(( $(date +%s) + duration ))
+    while [ "$(date +%s)" -lt "$end_time" ]; do
+        : # No-op, keeps the loop running
+    done
+}
+
 # **Internal** Unmount mount point if mounted and abort if an unmount is
 # unsuccessful.
 #
@@ -1072,7 +1082,7 @@ umount_fs() {
         i=1
         while [ "$i" -le "$MAX_RETRIES" ]
         do 
-            hab pkg exec core/coreutils sleep $((RETRY_DELAY * i))  # Delay increases with each retry
+            busy_sleep $((RETRY_DELAY * i))  # Delay increases with each retry
             if ! is_fs_mounted "$_mount_point"; then
                 return 0
             fi

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1070,9 +1070,9 @@ umount_fs() {
         RETRY_DELAY=5
         MAX_RETRIES=5
         i=1
-        while [ "$i" -le "$MAX_RETRIES" ] 
+        while [ "$i" -le "$MAX_RETRIES" ]
         do 
-            sleep $((RETRY_DELAY * i))  # Delay increases with each retry
+            hab pkg exec core/coreutils sleep $((RETRY_DELAY * i))  # Delay increases with each retry
             if ! is_fs_mounted "$_mount_point"; then
                 return 0
             fi

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1045,8 +1045,8 @@ chown_certs() {
 # encountering 'device busy' failures on AArch64 Linux. We need this because 
 # we unmounted the resource and want to allow some time for it to be freed.
 busy_sleep() {
-    local duration=$1
-    local end_time=$(( $(date +%s) + duration ))
+    duration="$1"
+    end_time=$(( $(date +%s) + duration ))
     while [ "$(date +%s)" -lt "$end_time" ]; do
         : # No-op, keeps the loop running
     done

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1040,8 +1040,10 @@ chown_certs() {
   fi
 }
 
-# **Internal**
-# Mimic delay using busy loop
+# **Internal** Mimic delay using busy loop
+# We cannot use the sleep command as we have already unmounted, but we are
+# encountering 'device busy' failures on AArch64 Linux. We need this because 
+# we unmounted the resource and want to allow some time for it to be freed.
 busy_sleep() {
     local duration=$1
     local end_time=$(( $(date +%s) + duration ))

--- a/components/studio/bin/hab-studio.sh
+++ b/components/studio/bin/hab-studio.sh
@@ -1069,11 +1069,14 @@ umount_fs() {
         # explored.
         RETRY_DELAY=5
         MAX_RETRIES=5
-        for ((i = 1; i <= MAX_RETRIES; i++)); do
+        i=1
+        while [ "$i" -le "$MAX_RETRIES" ] 
+        do 
             sleep $((RETRY_DELAY * i))  # Delay increases with each retry
             if ! is_fs_mounted "$_mount_point"; then
                 return 0
             fi
+            i=$((i+1))
         done
         # Despite a successful umount, filesystem is still mounted
         >&2 echo "After unmounting filesystem '$_mount_point', the mount \

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -101,6 +101,9 @@ finish_setup() {
   _hab pkg binlink core/bash bash
   _hab pkg binlink core/bash sh
 
+  # binlink sleep command
+  _hab pkg binlink "$coreutils_path/bin/sleep" sleep
+
   # Create a wrapper to `build` so that any calls to it have a super-stripped
   # `$PATH` and not whatever augmented version is currently in use. This should
   # mean that running `build` from inside a `studio enter` and running `studio

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -101,9 +101,6 @@ finish_setup() {
   _hab pkg binlink core/bash bash
   _hab pkg binlink core/bash sh
 
-  # binlink sleep command
-  _hab pkg binlink core/coreutils sleep
-
   # Create a wrapper to `build` so that any calls to it have a super-stripped
   # `$PATH` and not whatever augmented version is currently in use. This should
   # mean that running `build` from inside a `studio enter` and running `studio

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -102,7 +102,7 @@ finish_setup() {
   _hab pkg binlink core/bash sh
 
   # binlink sleep command
-  _hab pkg binlink "$coreutils_path/bin/sleep" sleep
+  _hab pkg binlink core/coreutils sleep
 
   # Create a wrapper to `build` so that any calls to it have a super-stripped
   # `$PATH` and not whatever augmented version is currently in use. This should


### PR DESCRIPTION
Currently, the release pipeline is failing because it is falling back to the LTS-2024 channel, where none of the `hab*` packages exist. To unblock the release pipeline, the fallback channel has been updated to `stable`.

Note: The hab, hab-studio, hab-backline, and hab-plan-build packages with version ~~1.6.1178~~ **1.6.1218** have been promoted to the stable channel.