### PR TITLE
set refresh-channel to LTS-2024 in verify

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -4,6 +4,8 @@ expeditor:
       timeout_in_minutes: 60
       env: 
         HAB_BLDR_CHANNEL: "LTS-2024"
+        HAB_STUDIO_SECRET_HAB_REFRESH_CHANNEL: "LTS-2024"
+        HAB_REFRESH_CHANNEL: "LTS-2024"
 steps:
 #######################################################################
 # Linting!


### PR DESCRIPTION
Now that 1.6.1243 has released to stable. We need to set the `release-channel` to `LTS-2024`.