### PR TITLE
powershell workaround for hab studio rm with powershell 7.5 and older windows os

### DIFF
--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -521,7 +521,7 @@ function Remove-Studio {
     } else {
         if(Test-Path $HAB_STUDIO_ROOT) {
             Write-HabInfo "Destroying Studio at $HAB_STUDIO_ROOT"
-            Get-ChildItem $HAB_STUDIO_ROOT -Recurse | Remove-Item -force -Recurse
+            Get-ChildItem $HAB_STUDIO_ROOT -Recurse | Remove-Item -Force -Recurse
             Remove-Item $HAB_STUDIO_ROOT
         }
     }

--- a/components/studio/bin/hab-studio.ps1
+++ b/components/studio/bin/hab-studio.ps1
@@ -521,7 +521,8 @@ function Remove-Studio {
     } else {
         if(Test-Path $HAB_STUDIO_ROOT) {
             Write-HabInfo "Destroying Studio at $HAB_STUDIO_ROOT"
-            Remove-Item $HAB_STUDIO_ROOT -Recurse -Force
+            Get-ChildItem $HAB_STUDIO_ROOT -Recurse | Remove-Item -force -Recurse
+            Remove-Item $HAB_STUDIO_ROOT
         }
     }
 }


### PR DESCRIPTION
A bug with newer powershell version and older windows was discovered in e2e tests. This is from the updated powershell 7.5 which will break in a `hab studio rm` on versions of windows older than 1909 (circa 2018) which we use in our buildkite pipelines.