### PR TITLE
Using handlebars 6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ dependencies = [
  "impl-more",
  "itoa",
  "language-tags",
- "log 0.4.25",
+ "log",
  "mime",
  "once_cell",
  "pin-project-lite",
@@ -463,9 +463,9 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
- "lazy_static 1.5.0",
+ "lazy_static",
  "lazycell",
- "log 0.4.25",
+ "log",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -716,7 +716,7 @@ source = "git+https://github.com/habitat-sh/configopt.git#98e4041a9922d6ebb5e548
 dependencies = [
  "colosseum",
  "configopt-derive",
- "lazy_static 1.5.0",
+ "lazy_static",
  "serde",
  "structopt",
  "toml 0.7.8",
@@ -1000,7 +1000,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
- "log 0.4.25",
+ "log",
  "regex 1.11.1",
 ]
 
@@ -1014,7 +1014,7 @@ dependencies = [
  "anstyle",
  "env_filter",
  "humantime",
- "log 0.4.25",
+ "log",
 ]
 
 [[package]]
@@ -1023,7 +1023,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
 dependencies = [
- "log 0.4.25",
+ "log",
  "url",
 ]
 
@@ -1270,7 +1270,7 @@ checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
 dependencies = [
  "cc",
  "libc",
- "log 0.4.25",
+ "log",
  "rustversion",
  "windows 0.48.0",
 ]
@@ -1380,10 +1380,10 @@ dependencies = [
  "habitat_api_client",
  "habitat_common",
  "habitat_core",
- "handlebars 0.29.1",
- "lazy_static 1.5.0",
+ "handlebars",
+ "lazy_static",
  "libc",
- "log 0.4.25",
+ "log",
  "pbr",
  "rants",
  "reqwest",
@@ -1421,7 +1421,7 @@ dependencies = [
  "habitat_core",
  "ipc-channel",
  "libc",
- "log 0.4.25",
+ "log",
  "nix",
  "prost",
  "semver",
@@ -1440,7 +1440,7 @@ dependencies = [
  "habitat_core",
  "ipc-channel",
  "libc",
- "log 0.4.25",
+ "log",
  "prost",
  "serde",
  "thiserror 2.0.11",
@@ -1463,7 +1463,7 @@ dependencies = [
  "clap 4.5.29",
  "env_logger",
  "habitat_butterfly",
- "log 0.4.25",
+ "log",
 ]
 
 [[package]]
@@ -1474,7 +1474,7 @@ dependencies = [
  "habitat-sup-protocol",
  "habitat_common",
  "habitat_core",
- "log 0.4.25",
+ "log",
  "prost",
  "rustls 0.23.23",
  "termcolor",
@@ -1489,8 +1489,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "habitat_core",
- "lazy_static 1.5.0",
- "log 0.4.25",
+ "lazy_static",
+ "log",
  "prost",
  "prost-build",
  "rand 0.9.0",
@@ -1511,7 +1511,7 @@ dependencies = [
  "futures",
  "habitat_core",
  "habitat_http_client",
- "log 0.4.25",
+ "log",
  "pbr",
  "percent-encoding",
  "rand 0.9.0",
@@ -1534,8 +1534,8 @@ dependencies = [
  "env_logger",
  "habitat_common",
  "habitat_core",
- "lazy_static 1.5.0",
- "log 0.4.25",
+ "lazy_static",
+ "log",
  "mktemp",
  "parking_lot",
  "prometheus",
@@ -1565,10 +1565,10 @@ dependencies = [
  "glob",
  "habitat_api_client",
  "habitat_core",
- "handlebars 0.28.3",
- "lazy_static 1.5.0",
+ "handlebars",
+ "lazy_static",
  "libc",
- "log 0.4.25",
+ "log",
  "native-tls",
  "nix",
  "parking_lot",
@@ -1610,9 +1610,9 @@ dependencies = [
  "glob",
  "habitat_win_users",
  "hex",
- "lazy_static 1.5.0",
+ "lazy_static",
  "libc",
- "log 0.4.25",
+ "log",
  "native-tls",
  "nix",
  "num_cpus",
@@ -1622,7 +1622,7 @@ dependencies = [
  "pin-project",
  "rand 0.9.0",
  "rcgen",
- "regex 1.11.1",
+ "regex 0.2.11",
  "reqwest",
  "rustls 0.23.23",
  "rustls-pemfile",
@@ -1654,7 +1654,7 @@ dependencies = [
  "env_proxy",
  "habitat_core",
  "httparse",
- "log 0.4.25",
+ "log",
  "native-tls",
  "pem",
  "reqwest",
@@ -1675,10 +1675,10 @@ dependencies = [
  "hab",
  "habitat_common",
  "habitat_core",
- "handlebars 0.29.1",
- "lazy_static 1.5.0",
+ "handlebars",
+ "lazy_static",
  "linked-hash-map",
- "log 0.4.25",
+ "log",
  "rusoto_core",
  "rusoto_credential",
  "rusoto_ecr",
@@ -1701,7 +1701,7 @@ dependencies = [
  "flate2",
  "habitat_common",
  "habitat_core",
- "log 0.4.25",
+ "log",
  "mktemp",
  "tar",
  "tempfile",
@@ -1737,9 +1737,9 @@ dependencies = [
  "habitat_core",
  "habitat_http_client",
  "hyper 1.6.0",
- "lazy_static 1.5.0",
+ "lazy_static",
  "libc",
- "log 0.4.25",
+ "log",
  "log4rs",
  "mio",
  "multimap",
@@ -1754,7 +1754,7 @@ dependencies = [
  "prost-types",
  "rand 0.9.0",
  "rants",
- "regex 1.11.1",
+ "regex 0.2.11",
  "reqwest",
  "rustls 0.23.23",
  "rustls-pemfile",
@@ -1783,39 +1783,24 @@ name = "habitat_win_users"
 version = "0.0.0"
 dependencies = [
  "cc",
- "log 0.4.25",
+ "log",
  "widestring 1.1.0",
  "winapi",
 ]
 
 [[package]]
 name = "handlebars"
-version = "0.28.3"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bed53dfb11098ec893ed54aa8b9828ffb98d28acbe56a49419935e5a8688ca9"
+checksum = "fd4ccde012831f9a071a637b0d4e31df31c0f6c525784b35ae76a9ac6bc1e315"
 dependencies = [
- "lazy_static 0.2.11",
- "log 0.3.9",
+ "log",
+ "num-order",
  "pest",
- "quick-error",
- "regex 0.2.11",
+ "pest_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "handlebars"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb04af2006ea09d985fef82b81e0eb25337e51b691c76403332378a53d521edc"
-dependencies = [
- "lazy_static 0.2.11",
- "log 0.3.9",
- "pest",
- "quick-error",
- "regex 0.2.11",
- "serde",
- "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2275,7 +2260,7 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "fnv",
- "lazy_static 1.5.0",
+ "lazy_static",
  "libc",
  "mio",
  "rand 0.8.5",
@@ -2387,12 +2372,6 @@ checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
-name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
@@ -2489,15 +2468,6 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.25",
-]
-
-[[package]]
-name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
@@ -2524,7 +2494,7 @@ dependencies = [
  "fnv",
  "humantime",
  "libc",
- "log 0.4.25",
+ "log",
  "log-mdc",
  "once_cell",
  "parking_lot",
@@ -2639,7 +2609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "log 0.4.25",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -2669,7 +2639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
 dependencies = [
  "libc",
- "log 0.4.25",
+ "log",
  "openssl",
  "openssl-probe",
  "openssl-sys",
@@ -2713,7 +2683,7 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "log 0.4.25",
+ "log",
  "mio",
  "notify-types",
  "walkdir",
@@ -2741,6 +2711,21 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
 
 [[package]]
 name = "num-traits"
@@ -2857,7 +2842,7 @@ version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a604e53c24761286860eba4e2c8b23a0161526476b1de520139d69cdb85a6b5"
 dependencies = [
- "log 0.4.25",
+ "log",
  "serde",
  "windows-sys 0.52.0",
 ]
@@ -2929,9 +2914,48 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "0.3.3"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6dda33d67c26f0aac90d324ab2eb7239c819fc7b2552fe9faa4fe88441edc8"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+dependencies = [
+ "memchr",
+ "thiserror 1.0.69",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "petgraph"
@@ -3106,7 +3130,7 @@ checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
 dependencies = [
  "cfg-if",
  "fnv",
- "lazy_static 1.5.0",
+ "lazy_static",
  "memchr",
  "parking_lot",
  "protobuf",
@@ -3187,12 +3211,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3269,7 +3287,7 @@ source = "git+https://github.com/habitat-sh/rants.git#9f268782e17c93d35e24ca433f
 dependencies = [
  "bytes",
  "futures",
- "log 0.4.25",
+ "log",
  "native-tls",
  "nom",
  "pin-project",
@@ -3422,7 +3440,7 @@ dependencies = [
  "hyper-util",
  "ipnet",
  "js-sys",
- "log 0.4.25",
+ "log",
  "mime",
  "native-tls",
  "once_cell",
@@ -3485,8 +3503,8 @@ dependencies = [
  "http 0.2.12",
  "hyper 0.14.32",
  "hyper-tls 0.5.0",
- "lazy_static 1.5.0",
- "log 0.4.25",
+ "lazy_static",
+ "log",
  "rusoto_credential",
  "rusoto_signature",
  "rustc_version",
@@ -3543,14 +3561,14 @@ dependencies = [
  "hmac",
  "http 0.2.12",
  "hyper 0.14.32",
- "log 0.4.25",
+ "log",
  "md-5",
  "percent-encoding",
  "pin-project-lite",
  "rusoto_credential",
  "rustc_version",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "tokio",
 ]
 
@@ -3594,7 +3612,7 @@ version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
- "log 0.4.25",
+ "log",
  "ring",
  "rustls-webpki 0.101.7",
  "sct",
@@ -3607,7 +3625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "aws-lc-rs",
- "log 0.4.25",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki 0.102.8",
@@ -3862,12 +3880,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
- "lazy_static 1.5.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -3973,7 +4002,7 @@ version = "0.3.15"
 source = "git+https://github.com/habitat-sh/structopt.git#63c56f42ae330b15f44a86c160b0cf6868b90a6f"
 dependencies = [
  "clap 2.33.1",
- "lazy_static 1.5.0",
+ "lazy_static",
  "structopt-derive",
 ]
 
@@ -4194,7 +4223,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 dependencies = [
- "lazy_static 1.5.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -4444,7 +4473,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log 0.4.25",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4477,7 +4506,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log 0.4.25",
+ "log",
  "once_cell",
  "tracing-core",
 ]
@@ -4520,6 +4549,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "ucd-util"
@@ -4727,7 +4762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
- "log 0.4.25",
+ "log",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -5321,7 +5356,7 @@ source = "git+https://github.com/habitat-sh/rust-zmq?branch=v0.9.2-symlinks-remo
 dependencies = [
  "bitflags 1.3.2",
  "libc",
- "log 0.4.25",
+ "log",
  "zmq-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,15 +229,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
@@ -469,7 +460,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "regex 1.11.1",
+ "regex",
  "rustc-hash",
  "shlex",
  "syn 2.0.98",
@@ -1001,7 +992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
- "regex 1.11.1",
+ "regex",
 ]
 
 [[package]]
@@ -1065,7 +1056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
- "regex 1.11.1",
+ "regex",
 ]
 
 [[package]]
@@ -1515,7 +1506,7 @@ dependencies = [
  "pbr",
  "percent-encoding",
  "rand 0.9.0",
- "regex 1.11.1",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -1574,7 +1565,7 @@ dependencies = [
  "parking_lot",
  "pbr",
  "petgraph 0.7.1",
- "regex 1.11.1",
+ "regex",
  "reqwest",
  "retry",
  "rustls 0.23.23",
@@ -1622,7 +1613,7 @@ dependencies = [
  "pin-project",
  "rand 0.9.0",
  "rcgen",
- "regex 0.2.11",
+ "regex",
  "reqwest",
  "rustls 0.23.23",
  "rustls-pemfile",
@@ -1754,7 +1745,7 @@ dependencies = [
  "prost-types",
  "rand 0.9.0",
  "rants",
- "regex 0.2.11",
+ "regex",
  "reqwest",
  "rustls 0.23.23",
  "rustls-pemfile",
@@ -3162,7 +3153,7 @@ dependencies = [
  "prettyplease",
  "prost",
  "prost-types",
- "regex 1.11.1",
+ "regex",
  "syn 2.0.98",
  "tempfile",
 ]
@@ -3348,24 +3339,11 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-dependencies = [
- "aho-corasick 0.6.10",
- "memchr",
- "regex-syntax 0.5.6",
- "thread_local 0.3.6",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
- "aho-corasick 1.1.3",
+ "aho-corasick",
  "memchr",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
@@ -3386,7 +3364,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
- "aho-corasick 1.1.3",
+ "aho-corasick",
  "memchr",
  "regex-syntax 0.8.5",
 ]
@@ -3396,15 +3374,6 @@ name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-dependencies = [
- "ucd-util",
-]
 
 [[package]]
 name = "regex-syntax"
@@ -4219,15 +4188,6 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
@@ -4520,10 +4480,10 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex 1.11.1",
+ "regex",
  "sharded-slab",
  "smallvec",
- "thread_local 1.1.8",
+ "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4555,12 +4515,6 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "ucd-util"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd2fc5d32b590614af8b0a20d837f32eca055edd0bbead59a9cfe80858be003"
 
 [[package]]
 name = "unicode-ident"
@@ -4613,7 +4567,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcde98d1fc3f528255b1ecb22fb688ee0d23deb672a8c57127df10b98b4bd18c"
 dependencies = [
- "regex 1.11.1",
+ "regex",
 ]
 
 [[package]]
@@ -4633,12 +4587,6 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8-ranges"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,7 +2943,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3155,7 +3155,7 @@ checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
- "log 0.4.25",
+ "log",
  "multimap",
  "once_cell",
  "petgraph 0.7.1",

--- a/components/common/Cargo.toml
+++ b/components/common/Cargo.toml
@@ -32,7 +32,7 @@ habitat_core = { path = "../core" }
 #   with our templating syntax; we use "foo[0]", but it now requires
 #   "foo.[0]"
 #   See https://github.com/sunng87/handlebars-rust/commit/707f05442ef6f441a1cfc6b13ac180b78cb296db
-handlebars = { version = "= 0.28.3", default-features = false }
+handlebars = { version = "*", default-features = false }
 lazy_static = "*"
 libc = "*"
 log = "0.4"

--- a/components/common/src/error.rs
+++ b/components/common/src/error.rs
@@ -102,7 +102,7 @@ pub enum Error {
     StringFromUtf8Error(string::FromUtf8Error),
     /// When an error occurs registering template file
     // Boxed due to clippy::large_enum_variant
-    TemplateFileError(Box<handlebars::TemplateFileError>),
+    TemplateError(handlebars::TemplateError),
     /// When an error occurs rendering template
     /// The error is constructed with a handlebars::RenderError's format string instead
     /// of the handlebars::RenderError itself because the cause field of the
@@ -110,7 +110,7 @@ pub enum Error {
     /// and not sync which can lead to upstream compile errors when dealing with the
     /// failure crate. We should change this to a RenderError after we update the
     /// handlebars crate. See https://github.com/sunng87/handlebars-rust/issues/194
-    TemplateRenderError(String),
+    TemplateRenderError(handlebars::RenderError),
     /// When an error occurs merging toml
     TomlMergeError(String),
     /// When an error occurs parsing toml
@@ -216,7 +216,7 @@ impl fmt::Display for Error {
             }
             Error::StrFromUtf8Error(ref e) => format!("{}", e),
             Error::StringFromUtf8Error(ref e) => format!("{}", e),
-            Error::TemplateFileError(ref err) => format!("{:?}", err),
+            Error::TemplateError(ref err) => format!("{:?}", err),
             Error::TemplateRenderError(ref err) => err.to_string(),
             Error::TomlMergeError(ref e) => format!("Failed to merge TOML: {}", e),
             Error::TomlParser(ref err) => format!("Failed to parse TOML: {}", err),
@@ -242,8 +242,12 @@ impl From<api_client::Error> for Error {
     fn from(err: api_client::Error) -> Self { Error::APIClient(err) }
 }
 
-impl From<handlebars::TemplateFileError> for Error {
-    fn from(err: handlebars::TemplateFileError) -> Self { Error::TemplateFileError(Box::new(err)) }
+impl From<handlebars::TemplateError> for Error {
+    fn from(err: handlebars::TemplateError) -> Self { Error::TemplateError(err) }
+}
+
+impl From<handlebars::RenderError> for Error {
+    fn from(err: handlebars::RenderError) -> Self { Error::TemplateRenderError(err) }
 }
 
 impl From<hcore::Error> for Error {

--- a/components/common/src/templating.rs
+++ b/components/common/src/templating.rs
@@ -75,7 +75,7 @@ pub struct TemplateRenderer(Handlebars<'static>);
 impl TemplateRenderer {
     pub fn new() -> TemplateRenderer {
         let mut handlebars = Handlebars::new();
-        // handlebars.register_helper("eachAlive", Box::new(helpers::EACH_ALIVE));
+        handlebars.register_helper("eachAlive", Box::new(helpers::EACH_ALIVE));
         handlebars.register_helper("pkgPathFor", Box::new(helpers::PKG_PATH_FOR));
         handlebars.register_helper("strConcat", Box::new(helpers::STR_CONCAT));
         handlebars.register_helper("strJoin", Box::new(helpers::STR_JOIN));
@@ -332,7 +332,7 @@ mod test {
 
     #[test]
     fn bind_variable() {
-        let content = "{{bind.foo.members[0].sys.ip}}";
+        let content = "{{bind.foo.members.[0].sys.ip}}";
         let mut renderer = TemplateRenderer::new();
         let data = service_config_json_from_toml_file("complex_config.toml");
 

--- a/components/common/src/templating/helpers.rs
+++ b/components/common/src/templating/helpers.rs
@@ -1,4 +1,5 @@
-// mod each_alive;
+mod block_helpers;
+mod each_alive;
 mod pkg_path_for;
 mod str_concat;
 mod str_join;
@@ -9,7 +10,7 @@ mod to_toml;
 mod to_uppercase;
 mod to_yaml;
 
-pub use self::{// each_alive::EACH_ALIVE,
+pub use self::{each_alive::EACH_ALIVE,
                pkg_path_for::PKG_PATH_FOR,
                str_concat::STR_CONCAT,
                str_join::STR_JOIN,

--- a/components/common/src/templating/helpers.rs
+++ b/components/common/src/templating/helpers.rs
@@ -1,4 +1,4 @@
-mod each_alive;
+// mod each_alive;
 mod pkg_path_for;
 mod str_concat;
 mod str_join;
@@ -9,7 +9,7 @@ mod to_toml;
 mod to_uppercase;
 mod to_yaml;
 
-pub use self::{each_alive::EACH_ALIVE,
+pub use self::{// each_alive::EACH_ALIVE,
                pkg_path_for::PKG_PATH_FOR,
                str_concat::STR_CONCAT,
                str_join::STR_JOIN,
@@ -42,6 +42,7 @@ impl JsonTruthy for Json {
     }
 }
 
+#[allow(dead_code)]
 /// Helper which will serialize to Json the given reference or return `Json::Null`
 fn to_json<T>(src: &T) -> Json
     where T: Serialize

--- a/components/common/src/templating/helpers/block_helpers.rs
+++ b/components/common/src/templating/helpers/block_helpers.rs
@@ -1,0 +1,79 @@
+// helpers for rendering blocks
+// Copied from the `handlebars::each` helper.
+
+use serde_json::value::Value as Json;
+
+use handlebars::{BlockContext,
+                 BlockParams,
+                 Helper,
+                 PathAndJson,
+                 RenderError};
+
+#[inline]
+fn copy_on_push_vec<T>(input: &[T], el: T) -> Vec<T>
+    where T: Clone
+{
+    let mut new_vec = Vec::with_capacity(input.len() + 1);
+    new_vec.extend_from_slice(input);
+    new_vec.push(el);
+    new_vec
+}
+
+pub(super) fn create_block<'rc>(param: &PathAndJson<'rc>) -> BlockContext<'rc> {
+    let mut block = BlockContext::new();
+
+    if let Some(new_path) = param.context_path() {
+        block.base_path_mut().clone_from(new_path);
+    } else {
+        // use clone for now
+        block.set_base_value(param.value().clone());
+    }
+
+    block
+}
+
+pub(super) fn update_block_context(block: &mut BlockContext<'_>,
+                                   base_path: Option<&Vec<String>>,
+                                   relative_path: String,
+                                   is_first: bool,
+                                   value: &Json) {
+    if let Some(p) = base_path {
+        if is_first {
+            *block.base_path_mut() = copy_on_push_vec(p, relative_path);
+        } else if let Some(ptr) = block.base_path_mut().last_mut() {
+            *ptr = relative_path;
+        }
+    } else {
+        block.set_base_value(value.clone());
+    }
+}
+
+pub(super) fn set_block_param<'rc>(block: &mut BlockContext<'rc>,
+                                   h: &Helper<'rc>,
+                                   base_path: Option<&Vec<String>>,
+                                   k: &Json,
+                                   v: &Json)
+                                   -> Result<(), RenderError> {
+    if let Some(bp_val) = h.block_param() {
+        let mut params = BlockParams::new();
+        if base_path.is_some() {
+            params.add_path(bp_val, Vec::with_capacity(0))?;
+        } else {
+            params.add_value(bp_val, v.clone())?;
+        }
+
+        block.set_block_params(params);
+    } else if let Some((bp_val, bp_key)) = h.block_param_pair() {
+        let mut params = BlockParams::new();
+        if base_path.is_some() {
+            params.add_path(bp_val, Vec::with_capacity(0))?;
+        } else {
+            params.add_value(bp_val, v.clone())?;
+        }
+        params.add_value(bp_key, k.clone())?;
+
+        block.set_block_params(params);
+    }
+
+    Ok(())
+}

--- a/components/common/src/templating/helpers/each_alive.rs
+++ b/components/common/src/templating/helpers/each_alive.rs
@@ -1,17 +1,19 @@
-use super::{super::RenderResult,
-            to_json,
+use super::{block_helpers::{create_block,
+                            set_block_param,
+                            update_block_context},
             JsonTruthy};
-use handlebars::{Context,
+
+use handlebars::{to_json,
+                 Context,
                  Handlebars,
                  Helper,
                  HelperDef,
                  HelperResult,
                  Output,
                  RenderContext,
-                 RenderError,
+                 RenderErrorReason,
                  Renderable};
 use serde_json::Value as Json;
-use std::collections::BTreeMap;
 
 #[derive(Clone, Copy)]
 pub struct EachAliveHelper;
@@ -20,107 +22,109 @@ impl HelperDef for EachAliveHelper {
     fn call<'reg: 'rc, 'rc>(&self,
                             h: &Helper<'rc>,
                             r: &'reg Handlebars<'reg>,
-                            rc: &'rc Context,
+                            ctx: &'rc Context,
                             rc: &mut RenderContext<'reg, 'rc>,
-                            _: &mut dyn Output)
+                            out: &mut dyn Output)
                             -> HelperResult {
         let value = h.param(0)
-                     .ok_or(|| RenderErrorReason::ParamNotFoundForIndex("eachAlive", 0))?;
+                     .ok_or_else(|| RenderErrorReason::ParamNotFoundForIndex("eachAlive", 0))?;
 
         if let Some(template) = h.template() {
-            let rendered = match (value.value().is_truthy(), value.value()) {
+            match (value.value().is_truthy(), value.value()) {
                 (true, Json::Array(list)) => {
-                    let alive_members: Vec<Json> = list.iter()
-                                                       .filter_map(|m| {
-                                                           m.as_object().and_then(|m| {
-                                if m.contains_key("alive") && m["alive"].as_bool().unwrap() {
-                                    Some(to_json(&m))
-                                } else {
-                                    None
-                                }
-                            })
-                                                       })
-                                                       .collect();
-                    let len = alive_members.len();
-                    for (i, alive_member) in alive_members.iter().enumerate() {
-                        let mut local_rc = rc.block_mut();
-                        local_rc.set_local_var("@first".to_string(), to_json(&(i == 0usize)));
-                        local_rc.set_local_var("@last".to_string(), to_json(&(i == len - 1)));
-                        local_rc.set_local_var("@index".to_string(), to_json(&i));
-
-                        if let Some(block_param) = h.block_param() {
-                            let mut map = BTreeMap::new();
-                            map.insert(block_param.to_string(), to_json(alive_member));
-                            local_rc.push_block_context(&map)?;
+                    let first_alive_idx = list.iter().position(|m| {
+                                                         m.as_object().is_some() && {
+                            let m = m.as_object().unwrap();
+                            m.contains_key("alive") && m["alive"].as_bool().unwrap()
                         }
+                                                     });
+                    let last_alive_idx = list.iter().rev().rposition(|m| {
+                                                              m.as_object().is_some() && {
+                            let m = m.as_object().unwrap();
+                            m.contains_key("alive") && m["alive"].as_bool().unwrap()
+                        }
+                                                          });
+                    eprintln!("first: {:#?}, last: {:#?}", first_alive_idx, last_alive_idx);
 
-                        template.render(r, &mut local_rc)?;
+                    let array_path = value.context_path();
 
-                        if h.block_param().is_some() {
-                            local_rc.pop_block_context();
+                    let block_context = create_block(value);
+                    rc.push_block(block_context);
+
+                    let mut alive_idx = 0;
+                    for (i, member) in list.iter().enumerate() {
+                        if let Some(m) = member.as_object() {
+                            if m.contains_key("alive") && m["alive"].as_bool().unwrap() {
+                                alive_idx += 1;
+                                if let Some(ref mut block) = rc.block_mut() {
+                                    let is_first = first_alive_idx == Some(i);
+                                    let is_last = last_alive_idx == Some(i);
+                                    let index = to_json(alive_idx);
+
+                                    block.set_local_var("@first", to_json(is_first));
+                                    block.set_local_var("@last", to_json(is_last));
+                                    block.set_local_var("@index", to_json(index.clone()));
+
+                                    update_block_context(block,
+                                                         array_path,
+                                                         i.to_string(),
+                                                         is_first,
+                                                         member);
+                                    set_block_param(block, h, array_path, &index, member)?;
+                                }
+
+                                template.render(r, ctx, rc, out)?;
+                            }
                         }
                     }
+
+                    rc.pop_block();
                     Ok(())
                 }
                 (true, Json::Object(obj)) => {
-                    let mut first: bool = true;
                     if !obj.contains_key("alive") || !obj["alive"].as_bool().unwrap() {
                         return Ok(());
                     }
-                    for k in obj.keys() {
-                        let mut local_rc = rc.derive();
-                        if let Some(ref p) = local_path_root {
-                            local_rc.push_local_path_root(p.clone());
-                        }
-                        local_rc.set_local_var("@first".to_string(), to_json(&first));
-                        local_rc.set_local_var("@key".to_string(), to_json(k));
 
+                    let mut first = true;
+
+                    let block_context = create_block(value);
+                    rc.push_block(block_context);
+
+                    let obj_path = value.context_path();
+
+                    for (i, (k, v)) in obj.iter().enumerate() {
+                        if let Some(ref mut block) = rc.block_mut() {
+                            let is_first = i == 0usize;
+
+                            let key = to_json(k);
+
+                            block.set_local_var("@first", to_json(is_first));
+                            block.set_local_var("@key", to_json(k));
+
+                            update_block_context(block, obj_path, k.to_string(), is_first, v);
+                            set_block_param(block, h, obj_path, &key, v)?;
+                        }
+                        template.render(r, ctx, rc, out)?;
                         if first {
                             first = false;
                         }
-
-                        if let Some(inner_path) = value.path() {
-                            let new_path =
-                                format!("{}/{}.[{}]", local_rc.get_path(), inner_path, k);
-                            local_rc.set_path(new_path);
-                        }
-
-                        if let Some((bp_key, bp_val)) = h.block_param_pair() {
-                            let mut map = BTreeMap::new();
-                            map.insert(bp_key.to_string(), to_json(k));
-                            map.insert(bp_val.to_string(), to_json(obj.get(k).unwrap()));
-                            local_rc.push_block_context(&map)?;
-                        }
-
-                        template.render(r, &mut local_rc)?;
-
-                        if h.block_param().is_some() {
-                            local_rc.pop_block_context();
-                        }
-
-                        if local_path_root.is_some() {
-                            local_rc.pop_local_path_root();
-                        }
                     }
+
+                    rc.pop_block();
                     Ok(())
                 }
                 (false, _) => {
                     if let Some(else_template) = h.inverse() {
-                        else_template.render(r, rc)?;
+                        else_template.render(r, ctx, rc, out)?;
                     }
                     Ok(())
                 }
-                _ => {
-                    Err(RenderError::new(format!("Param type is not iterable: \
-                                                  {:?}",
-                                                 template)))
-                }
-            };
-
-            rc.demote_local_vars();
-            return rendered;
+                _ => Err(RenderErrorReason::InvalidParamType("Param type is not iterable.").into()),
+            }
+        } else {
+            Ok(())
         }
-        Ok(())
     }
 }
 

--- a/components/common/src/templating/helpers/str_replace.rs
+++ b/components/common/src/templating/helpers/str_replace.rs
@@ -1,36 +1,45 @@
-use handlebars::{Handlebars,
+use handlebars::{Context,
+                 Handlebars,
                  Helper,
                  HelperDef,
+                 HelperResult,
+                 Output,
                  RenderContext,
-                 RenderError};
-
-use super::super::RenderResult;
+                 RenderErrorReason};
 
 #[derive(Clone, Copy)]
 pub struct StrReplaceHelper;
 
 impl HelperDef for StrReplaceHelper {
-    fn call(&self, h: &Helper<'_>, _: &Handlebars, rc: &mut RenderContext<'_>) -> RenderResult<()> {
+    fn call<'reg: 'rc, 'rc>(&self,
+                            h: &Helper<'rc>,
+                            _: &'reg Handlebars<'reg>,
+                            _: &'rc Context,
+                            _rc: &mut RenderContext<'reg, 'rc>,
+                            out: &mut dyn Output)
+                            -> HelperResult {
         let param =
             h.param(0).and_then(|v| v.value().as_str()).ok_or_else(|| {
-                                                            RenderError::new("Expected 3 string \
-                                                                              parameters for \
-                                                                              \"strReplace\"")
+                RenderErrorReason::ParamTypeMismatchForName(
+                    stringify!($helper_fn_name),
+                    "0".to_owned(),
+                    "string".to_owned())
                                                         })?;
         let old =
             h.param(1).and_then(|v| v.value().as_str()).ok_or_else(|| {
-                                                            RenderError::new("Expected 3 string \
-                                                                              parameters for \
-                                                                              \"strReplace\"")
+                RenderErrorReason::ParamTypeMismatchForName(
+                    stringify!($helper_fn_name),
+                    "0".to_owned(),
+                    "string".to_owned())
                                                         })?;
         let new =
             h.param(2).and_then(|v| v.value().as_str()).ok_or_else(|| {
-                                                            RenderError::new("Expected 3 string \
-                                                                              parameters for \
-                                                                              \"strReplace\"")
+                RenderErrorReason::ParamTypeMismatchForName(
+                    stringify!($helper_fn_name),
+                    "0".to_owned(),
+                    "string".to_owned())
                                                         })?;
-        rc.writer
-          .write_all(param.replace(old, new).into_bytes().as_ref())?;
+        out.write(param.replace(old, new).as_ref())?;
         Ok(())
     }
 }

--- a/components/common/src/templating/helpers/to_json.rs
+++ b/components/common/src/templating/helpers/to_json.rs
@@ -1,22 +1,32 @@
-use super::super::RenderResult;
-use handlebars::{Handlebars,
+use handlebars::{Context,
+                 Handlebars,
                  Helper,
                  HelperDef,
+                 HelperResult,
+                 Output,
                  RenderContext,
-                 RenderError};
+                 RenderErrorReason};
 
 #[derive(Clone, Copy)]
 pub struct ToJsonHelper;
 
 impl HelperDef for ToJsonHelper {
-    fn call(&self, h: &Helper<'_>, _: &Handlebars, rc: &mut RenderContext<'_>) -> RenderResult<()> {
+    fn call<'reg: 'rc, 'rc>(&self,
+                            h: &Helper<'rc>,
+                            _: &'reg Handlebars<'reg>,
+                            _: &'rc Context,
+                            _rc: &mut RenderContext<'reg, 'rc>,
+                            out: &mut dyn Output)
+                            -> HelperResult {
         let param = h.param(0)
-                     .ok_or_else(|| RenderError::new("Expected 1 parameter for \"toJson\""))?
+                     .ok_or_else(|| {
+                         RenderErrorReason::ParamTypeMismatchForName(stringify!($helper_fn_name),
+                                                                     "0".to_owned(),
+                                                                     "string".to_owned())
+                     })?
                      .value();
-        let json = serde_json::to_string_pretty(param).map_err(|e| {
-                       RenderError::new(format!("Can't serialize parameter to JSON: {}", e))
-                   })?;
-        rc.writer.write_all(json.into_bytes().as_ref())?;
+        let json = serde_json::to_string_pretty(param).map_err(RenderErrorReason::SerdeError)?;
+        out.write(json.as_ref())?;
         Ok(())
     }
 }

--- a/components/common/src/templating/helpers/to_lowercase.rs
+++ b/components/common/src/templating/helpers/to_lowercase.rs
@@ -1,24 +1,33 @@
-use handlebars::{Handlebars,
+use handlebars::{Context,
+                 Handlebars,
                  Helper,
                  HelperDef,
+                 HelperResult,
+                 Output,
                  RenderContext,
-                 RenderError};
-
-use super::super::RenderResult;
+                 RenderErrorReason};
 
 #[derive(Clone, Copy)]
 pub struct ToLowercaseHelper;
 
 impl HelperDef for ToLowercaseHelper {
-    fn call(&self, h: &Helper<'_>, _: &Handlebars, rc: &mut RenderContext<'_>) -> RenderResult<()> {
-        let param =
-            h.param(0).and_then(|v| v.value().as_str()).ok_or_else(|| {
-                                                            RenderError::new("Expected a string \
-                                                                              parameter for \
-                                                                              \"toLowercase\"")
-                                                        })?;
-        rc.writer
-          .write_all(param.to_lowercase().into_bytes().as_ref())?;
+    fn call<'reg: 'rc, 'rc>(&self,
+                            h: &Helper<'rc>,
+                            _: &'reg Handlebars<'reg>,
+                            _: &'rc Context,
+                            _rc: &mut RenderContext<'reg, 'rc>,
+                            out: &mut dyn Output)
+                            -> HelperResult {
+        let param = h.param(0)
+                     .and_then(|v| v.value().as_str())
+                     .ok_or_else(|| {
+                RenderErrorReason::ParamTypeMismatchForName(
+                    stringify!($helper_fn_name),
+                    "0".to_owned(),
+                    "string".to_owned(),
+                    )
+                     })?;
+        out.write(param.to_lowercase().as_ref())?;
         Ok(())
     }
 }

--- a/components/common/src/templating/helpers/to_uppercase.rs
+++ b/components/common/src/templating/helpers/to_uppercase.rs
@@ -1,24 +1,33 @@
-use handlebars::{Handlebars,
+use handlebars::{Context,
+                 Handlebars,
                  Helper,
                  HelperDef,
+                 HelperResult,
+                 Output,
                  RenderContext,
-                 RenderError};
-
-use super::super::RenderResult;
+                 RenderErrorReason};
 
 #[derive(Clone, Copy)]
 pub struct ToUppercaseHelper;
 
 impl HelperDef for ToUppercaseHelper {
-    fn call(&self, h: &Helper<'_>, _: &Handlebars, rc: &mut RenderContext<'_>) -> RenderResult<()> {
-        let param =
-            h.param(0).and_then(|v| v.value().as_str()).ok_or_else(|| {
-                                                            RenderError::new("Expected a string \
-                                                                              parameter for \
-                                                                              \"toUppercase\"")
-                                                        })?;
-        rc.writer
-          .write_all(param.to_uppercase().into_bytes().as_ref())?;
+    fn call<'reg: 'rc, 'rc>(&self,
+                            h: &Helper<'rc>,
+                            _: &'reg Handlebars<'reg>,
+                            _: &'rc Context,
+                            _rc: &mut RenderContext<'reg, 'rc>,
+                            out: &mut dyn Output)
+                            -> HelperResult {
+        let param = h.param(0)
+                     .and_then(|v| v.value().as_str())
+                     .ok_or_else(||
+                RenderErrorReason::ParamTypeMismatchForName(
+                    stringify!($helper_fn_name),
+                    "0".to_owned(),
+                    "string".to_owned(),
+                ))?;
+
+        out.write(param.to_uppercase().as_ref())?;
         Ok(())
     }
 }

--- a/components/common/src/templating/hooks.rs
+++ b/components/common/src/templating/hooks.rs
@@ -137,7 +137,7 @@ pub trait Hook: fmt::Debug + Sized + Send {
     fn compile<T>(&self, service_group: &str, ctx: &T) -> Result<bool>
         where T: Serialize
     {
-        let content = self.renderer().render(Self::FILE_NAME, ctx)?;
+        let content = self.renderer().0.render(Self::FILE_NAME, ctx)?;
         // We make sure we don't use a deprecated file name
         let path = self.path().with_file_name(Self::FILE_NAME);
         if write_hook(&content, &path)? {
@@ -509,7 +509,7 @@ pub struct RenderPair {
 }
 
 impl RenderPair {
-    pub fn new<C, T>(concrete_path: C, template_path: T, name: &'static str) -> Result<Self>
+    pub fn new<C, T>(concrete_path: C, template_path: T, name: &'static str) -> Result<RenderPair>
         where C: Into<PathBuf>,
               T: AsRef<Path>
     {

--- a/components/hab/Cargo.toml
+++ b/components/hab/Cargo.toml
@@ -27,7 +27,7 @@ habitat_core = { path = "../core" }
 habitat-sup-client = { path = "../sup-client" }
 habitat-sup-protocol = { path = "../sup-protocol", default-features = false }
 # We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
-handlebars = { version = "0.29.1", default-features = false }
+handlebars = { version = "*", default-features = false }
 lazy_static = "*"
 libc = "*"
 log = "0.4"

--- a/components/hab/src/command/plan/init.rs
+++ b/components/hab/src/command/plan/init.rs
@@ -1,7 +1,8 @@
 use crate::{common::ui::{Status,
                          UIWriter,
                          UI},
-            error::Result};
+            error::{Error,
+                    Result}};
 use habitat_core::{origin::Origin,
                    package::PackageIdent};
 use handlebars::Handlebars;
@@ -83,21 +84,25 @@ pub fn start(ui: &mut UI,
 
     // We want to render the configured variables.
     if cfg!(windows) {
-        let rendered_plan = handlebars.template_render(PLAN_TEMPLATE_PS1, &data)?;
+        let rendered_plan = handlebars.render_template(PLAN_TEMPLATE_PS1, &data)
+                                      .map_err(|e| Error::HandlebarsRenderError(Box::new(e)))?;
         create_with_template(ui, &format!("{}/plan.ps1", root), &rendered_plan)?;
     } else {
-        let rendered_plan = handlebars.template_render(PLAN_TEMPLATE_SH, &data)?;
+        let rendered_plan = handlebars.render_template(PLAN_TEMPLATE_SH, &data)
+                                      .map_err(|e| Error::HandlebarsRenderError(Box::new(e)))?;
         create_with_template(ui, &format!("{}/plan.sh", root), &rendered_plan)?;
     }
     ui.para("`plan.sh` is the foundation of your new habitat. It contains metadata, \
              dependencies, and tasks.")?;
-    let rendered_default_toml = handlebars.template_render(DEFAULT_TOML_TEMPLATE, &data)?;
+    let rendered_default_toml = handlebars.render_template(DEFAULT_TOML_TEMPLATE, &data)
+                                          .map_err(|e| Error::HandlebarsRenderError(Box::new(e)))?;
     create_with_template(ui,
                          &format!("{}/default.toml", root),
                          &rendered_default_toml)?;
     ui.para("`default.toml` contains default values for `cfg` prefixed variables.")?;
 
-    let rendered_readme_md = handlebars.template_render(README_TEMPLATE, &data)?;
+    let rendered_readme_md = handlebars.render_template(README_TEMPLATE, &data)
+                                       .map_err(|e| Error::HandlebarsRenderError(Box::new(e)))?;
     create_with_template(ui, &format!("{}/README.md", root), &rendered_readme_md)?;
     ui.para("`README.md` contains a basic README document which you should update.")?;
 

--- a/components/hab/src/error.rs
+++ b/components/hab/src/error.rs
@@ -53,7 +53,7 @@ pub enum Error {
     HabitatCommon(common::Error),
     HabitatCore(hcore::Error),
     // Boxed due to clippy::large_enum_variant
-    HandlebarsRenderError(Box<handlebars::TemplateRenderError>),
+    HandlebarsRenderError(Box<handlebars::RenderError>),
     InvalidDnsName(String),
     IO(io::Error),
     JobGroupPromoteOrDemote(api_client::Error, bool /* promote */),
@@ -258,10 +258,8 @@ impl From<HashMap<PackageIdent, Error>> for Error {
     fn from(errors: HashMap<PackageIdent, Error>) -> Self { Error::ErrorPerIdent(errors) }
 }
 
-impl From<handlebars::TemplateRenderError> for Error {
-    fn from(err: handlebars::TemplateRenderError) -> Error {
-        Error::HandlebarsRenderError(Box::new(err))
-    }
+impl From<handlebars::RenderError> for Error {
+    fn from(err: handlebars::RenderError) -> Error { Error::HandlebarsRenderError(Box::new(err)) }
 }
 
 impl From<io::Error> for Error {

--- a/components/pkg-export-container/Cargo.toml
+++ b/components/pkg-export-container/Cargo.toml
@@ -22,7 +22,7 @@ hab = { path = "../hab" }
 habitat_common = { path = "../common" }
 habitat_core = { path = "../core" }
 # We need to lock here since v0.30.0 bumps to a version of pest that fails to build on Windows.
-handlebars = { version = "0.29.1", default-features = false }
+handlebars = { version = "*", default-features = false }
 lazy_static = "*"
 linked-hash-map = "*"
 log = "0.4"

--- a/components/pkg-export-container/src/container.rs
+++ b/components/pkg-export-container/src/container.rs
@@ -82,7 +82,7 @@ impl ContainerImage {
             "name_tags": name_tags.join(","),
         });
         util::write_file(&report,
-                         &Handlebars::new().template_render(BUILD_REPORT, &json)
+                         &Handlebars::new().render_template(BUILD_REPORT, &json)
                                            .map_err(|err| anyhow!("{}", err))?)?;
 
         Self::create_old_report(ui, dst);
@@ -219,7 +219,7 @@ impl BuildContext {
         });
         let init = ctx.rootfs().join("init.sh");
         util::write_file(&init,
-                         &Handlebars::new().template_render(INIT_SH, &json)
+                         &Handlebars::new().render_template(INIT_SH, &json)
                                            .map_err(|err| anyhow!("{}", err))?)?;
         posix_perm::set_permissions(init.to_string_lossy().as_ref(), 0o0755)?;
         Ok(())
@@ -247,7 +247,7 @@ impl BuildContext {
             "packages": self.0.graph().reverse_topological_sort().iter().map(ToString::to_string).collect::<Vec<_>>(),
         });
         util::write_file(self.0.workdir().join("Dockerfile"),
-                         &Handlebars::new().template_render(DOCKERFILE, &json)
+                         &Handlebars::new().render_template(DOCKERFILE, &json)
                                            .map_err(|err| anyhow!("{}", err))?)?;
         Ok(())
     }

--- a/components/pkg-export-container/src/naming.rs
+++ b/components/pkg-export-container/src/naming.rs
@@ -218,7 +218,7 @@ impl Naming {
     fn render<S>(template: &str, context: &S) -> Result<String>
         where S: Serialize
     {
-        Handlebars::new().template_render(template, context)
+        Handlebars::new().render_template(template, context)
                          .map_err(|err| anyhow!("{}", err))
                          .map(|s| s.to_lowercase())
     }


### PR DESCRIPTION
This PR adds support for the latest version of `handlebars` (`6.x`). Almost all the APIs have changed since `0.28`/`0.29`. So implements the functionality using the latest APIs. 

Major changes in our `helpers` 