### PR TITLE
Fixes for using rand crate with version 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -224,7 +224,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -354,7 +354,7 @@ checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
+checksum = "54ac4f13dad353b209b34cbec082338202cbc01c8f00336b55c750c13ac91f8f"
 dependencies = [
  "bindgen",
  "cc",
@@ -472,7 +472,7 @@ dependencies = [
  "regex 1.11.1",
  "rustc-hash",
  "shlex",
- "syn 2.0.96",
+ "syn 2.0.98",
  "which",
 ]
 
@@ -540,9 +540,9 @@ checksum = "fb214f702da3cc6aa1666520f40ea66f506644db5e1065be4bbc972f7ec3750b"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -552,9 +552,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytestring"
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -672,14 +672,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -690,9 +690,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
@@ -857,15 +857,15 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "0.99.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -943,7 +943,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1229,7 +1229,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1367,7 +1367,7 @@ dependencies = [
  "bitflags 2.8.0",
  "chrono",
  "clap 2.33.1",
- "clap 4.5.27",
+ "clap 4.5.29",
  "configopt",
  "ctrlc",
  "dirs",
@@ -1460,7 +1460,7 @@ dependencies = [
 name = "habitat-rst-reader"
 version = "0.0.0"
 dependencies = [
- "clap 4.5.27",
+ "clap 4.5.29",
  "env_logger",
  "habitat_butterfly",
  "log 0.4.25",
@@ -1493,7 +1493,7 @@ dependencies = [
  "log 0.4.25",
  "prost",
  "prost-build",
- "rand",
+ "rand 0.9.0",
  "serde",
  "tempfile",
  "tokio",
@@ -1514,7 +1514,7 @@ dependencies = [
  "log 0.4.25",
  "pbr",
  "percent-encoding",
- "rand",
+ "rand 0.9.0",
  "regex 1.11.1",
  "reqwest",
  "serde",
@@ -1541,7 +1541,7 @@ dependencies = [
  "prometheus",
  "prost",
  "prost-build",
- "rand",
+ "rand 0.9.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -1560,7 +1560,7 @@ dependencies = [
  "bimap",
  "bitflags 2.8.0",
  "clap 2.33.1",
- "clap 4.5.27",
+ "clap 4.5.29",
  "dirs",
  "glob",
  "habitat_api_client",
@@ -1620,7 +1620,7 @@ dependencies = [
  "paste",
  "pem",
  "pin-project",
- "rand",
+ "rand 0.9.0",
  "rcgen",
  "regex 1.11.1",
  "reqwest",
@@ -1670,7 +1670,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "clap 4.5.27",
+ "clap 4.5.29",
  "env_logger",
  "hab",
  "habitat_common",
@@ -1696,7 +1696,7 @@ name = "habitat_pkg_export_tar"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "clap 4.5.27",
+ "clap 4.5.29",
  "env_logger",
  "flate2",
  "habitat_common",
@@ -1752,7 +1752,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "rand",
+ "rand 0.9.0",
  "rants",
  "regex 1.11.1",
  "reqwest",
@@ -2206,7 +2206,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2278,7 +2278,7 @@ dependencies = [
  "lazy_static 1.5.0",
  "libc",
  "mio",
- "rand",
+ "rand 0.8.5",
  "serde",
  "tempfile",
  "uuid",
@@ -2308,9 +2308,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2528,7 +2528,7 @@ dependencies = [
  "log-mdc",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde-value",
  "serde_json",
@@ -2625,9 +2625,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
 dependencies = [
  "adler2",
 ]
@@ -2772,9 +2772,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "opaque-debug"
@@ -2805,7 +2805,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2816,9 +2816,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.1+3.4.0"
+version = "300.4.2+3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
 dependencies = [
  "cc",
 ]
@@ -2979,7 +2979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3008,7 +3008,7 @@ checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3041,7 +3041,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -3051,7 +3051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3125,21 +3125,21 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log 0.4.25",
  "multimap",
  "once_cell",
- "petgraph 0.6.5",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost",
  "prost-types",
  "regex 1.11.1",
- "syn 2.0.96",
+ "syn 2.0.98",
  "tempfile",
 ]
 
@@ -3150,10 +3150,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3173,9 +3173,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psl"
-version = "2.1.81"
+version = "2.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5871e872678223987b84739333bf13e42f0c1fb102e30bba8dcdf1340d0bbcc9"
+checksum = "49531bbe7afe7b7253f4b18bfee08909be85491f866ab19ae5df6c17d7909363"
 dependencies = [
  "psl-types",
 ]
@@ -3208,8 +3208,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -3219,7 +3230,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -3229,6 +3250,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.17",
 ]
 
 [[package]]
@@ -3242,7 +3273,7 @@ dependencies = [
  "native-tls",
  "nom",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "safer_owning_ref",
  "serde",
  "serde_json",
@@ -3419,9 +3450,9 @@ dependencies = [
 [[package]]
 name = "retry"
 version = "1.0.0"
-source = "git+https://github.com/habitat-sh/retry#42c71e75aa231d8bf9befa7a0ec93dd570a21454"
+source = "git+https://github.com/habitat-sh/retry#5c28be96c18e0f771720666cbbd74c5a8dc3c5bc"
 dependencies = [
- "rand",
+ "rand 0.9.0",
  "tokio",
 ]
 
@@ -3595,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -3629,9 +3660,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "safer_owning_ref"
@@ -3747,7 +3778,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3977,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4003,7 +4034,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4133,7 +4164,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4144,7 +4175,7 @@ checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4252,7 +4283,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4427,7 +4458,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4498,9 +4529,9 @@ checksum = "abd2fc5d32b590614af8b0a20d837f32eca055edd0bbead59a9cfe80858be003"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4699,7 +4730,7 @@ dependencies = [
  "log 0.4.25",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -4734,7 +4765,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4893,7 +4924,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -4904,7 +4935,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5189,7 +5220,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -5200,7 +5231,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa91407dacce3a68c56de03abe2760159582b846c6a4acd2f456618087f12713"
+dependencies = [
+ "zerocopy-derive 0.8.17",
 ]
 
 [[package]]
@@ -5211,7 +5251,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718a168365cad3d5ff0bb133aad346959a2074bd4a85c121255a11304a8626"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -5231,7 +5282,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure",
 ]
 
@@ -5260,7 +5311,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/components/butterfly/src/member.rs
+++ b/components/butterfly/src/member.rs
@@ -19,9 +19,9 @@ use log::{debug,
           trace};
 use prometheus::{register_int_gauge_vec,
                  IntGaugeVec};
-use rand::{seq::{IteratorRandom,
-                 SliceRandom},
-           thread_rng};
+use rand::{rng,
+           seq::{IteratorRandom,
+                 SliceRandom}};
 use serde::{de,
             ser::{SerializeMap,
                   SerializeStruct},
@@ -705,7 +705,7 @@ impl MemberList {
                                       .filter(|member| member.id != exclude_id)
                                       .cloned()
                                       .collect();
-        members.shuffle(&mut thread_rng());
+        members.shuffle(&mut rng());
 
         members
     }
@@ -728,7 +728,7 @@ impl MemberList {
                     && member.id != target_member_id
                     && *health == Health::Alive
                 })
-                .choose_multiple(&mut thread_rng(), PINGREQ_TARGETS)
+                .choose_multiple(&mut rng(), PINGREQ_TARGETS)
         {
             with_closure(member);
         }

--- a/components/butterfly/tests/rumor/election.rs
+++ b/components/butterfly/tests/rumor/election.rs
@@ -1,6 +1,6 @@
 use std::iter::FromIterator;
 
-use rand::prelude::SliceRandom;
+use rand::prelude::IndexedRandom;
 
 use crate::btest;
 use habitat_butterfly::{member::Health,
@@ -250,7 +250,7 @@ fn five_persistent_members_same_leader_multiple_non_quorum_partitions() {
 
     // Making sure - running multiple times after a subset of follower (non-quorum) is partitioned
     // and reconnected the leader stays the same.
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let idxes = Vec::from_iter(1_usize..5_usize).choose_multiple(&mut rng, 2)
                                                 .copied()
                                                 .collect::<Vec<usize>>();

--- a/components/core/src/flowcontrol/backoff.rs
+++ b/components/core/src/flowcontrol/backoff.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rand::{thread_rng,
+use rand::{rng,
            Rng};
 use tokio::time::Instant;
 
@@ -48,12 +48,13 @@ impl Backoff {
     pub fn record_attempt_start(&mut self) -> Option<Duration> {
         match &self.last_attempt {
             Some(RetryAttempt { sleep_duration, .. }) => {
-                let mut rng = thread_rng();
+                let mut rng = rng();
                 // We use the decorrelated jitter algorithm mentioned here:
                 // https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
                 let new_sleep_duration =
-                    self.max_backoff.min(rng.gen_range(self.base_backoff
-                                                       ..=sleep_duration.mul_f64(self.multiplier)));
+                    self.max_backoff
+                        .min(rng.random_range(self.base_backoff
+                                              ..=sleep_duration.mul_f64(self.multiplier)));
                 self.last_attempt = Some(RetryAttempt { attempt_started_at: Instant::now(),
                                                         attempt_ended_at:   None,
                                                         sleep_duration:     new_sleep_duration, });

--- a/components/core/src/os/process/windows_child.rs
+++ b/components/core/src/os/process/windows_child.rs
@@ -424,7 +424,7 @@ pub fn anon_pipe(ours_readable: bool) -> io::Result<Pipes> {
         let mut reject_remote_clients_flag = PIPE_REJECT_REMOTE_CLIENTS;
         loop {
             tries += 1;
-            let key: u64 = rand::thread_rng().gen();
+            let key: u64 = rand::rng().random();
             name = format!(r"\\.\pipe\__rust_anonymous_pipe1__.{}.{}",
                            processthreadsapi::GetCurrentProcessId(),
                            key);

--- a/components/sup-protocol/Cargo.toml
+++ b/components/sup-protocol/Cargo.toml
@@ -13,7 +13,7 @@ habitat_core = { path = "../core" }
 lazy_static = "*"
 log = "0.4"
 prost = { version = "*", features = ["prost-derive"] }
-rand = "*"
+rand = { version = "0.9", features = ["thread_rng"] }
 serde = {version = "*", features = ["derive"] }
 tokio = { version = "*", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }

--- a/components/sup-protocol/src/lib.rs
+++ b/components/sup-protocol/src/lib.rs
@@ -38,12 +38,15 @@ pub mod types;
 use crate::{core::env as henv,
             net::{ErrCode,
                   NetResult}};
-use rand::RngCore;
+
 use std::{fs::File,
           io::Read,
           net::SocketAddr,
           path::{Path,
                  PathBuf}};
+
+use rand::{rngs::OsRng,
+           TryRngCore};
 
 // Name of file containing the CtlGateway secret key.
 const CTL_SECRET_FILENAME: &str = "CTL_SECRET";
@@ -63,9 +66,9 @@ lazy_static! {
 
 /// Generate a new secret key used for authenticating clients to the `CtlGateway`.
 pub fn generate_secret_key(out: &mut String) {
-    let mut rng = rand::rngs::OsRng;
+    let mut rng = OsRng;
     let mut result = vec![0u8; CTL_SECRET_LEN];
-    rng.fill_bytes(&mut result);
+    let _ = rng.try_fill_bytes(&mut result);
     *out = core::base64::encode(&result);
 }
 

--- a/components/sup/src/manager/self_updater.rs
+++ b/components/sup/src/manager/self_updater.rs
@@ -101,7 +101,7 @@ impl SelfUpdater {
                      update_channel,
                      period, } = runner;
         let period = SelfUpdatePeriod::get().unwrap_or(period);
-        let splay = Duration::from_secs(rand::thread_rng().gen_range(0..period.as_secs()));
+        let splay = Duration::from_secs(rand::rng().random_range(0..period.as_secs()));
         debug!("Starting self updater with current package {} in {}s",
                current,
                splay.as_secs());

--- a/components/sup/src/manager/service/health.rs
+++ b/components/sup/src/manager/service/health.rs
@@ -198,7 +198,7 @@ pub fn check_repeatedly(supervisor: Arc<Mutex<Supervisor>>,
                 if !first_ok_health_check_recorded {
                     // If this was the first successful check, splay future health check runs across
                     // the nominal interval
-                    let splay = rand::thread_rng().gen_range(0..u64::from(nominal_interval));
+                    let splay = rand::rng().random_range(0..u64::from(nominal_interval));
                     let splay = Duration::from_secs(splay);
                     debug!("Following `{}`'s first `ok` health-check, delaying a randomly chosen \
                             {}s to introduce health-check splay",

--- a/components/sup/src/manager/service_updater/package_update_worker.rs
+++ b/components/sup/src/manager/service_updater/package_update_worker.rs
@@ -156,7 +156,7 @@ impl PackageUpdateWorker {
     pub async fn update(&self) -> IncarnatedPackageIdent {
         let ident = self.ident.clone();
         let period = PackageUpdateWorkerPeriod::get().unwrap_or(self.period);
-        let splay = Duration::from_secs(rand::thread_rng().gen_range(0..period.as_secs()));
+        let splay = Duration::from_secs(rand::rng().random_range(0..period.as_secs()));
         debug!("Starting package update worker for {} in {}s",
                ident,
                splay.as_secs());

--- a/components/sup/tests/utils/test_sup.rs
+++ b/components/sup/tests/utils/test_sup.rs
@@ -5,8 +5,8 @@ use anyhow::{anyhow,
              Result};
 use habitat_core::os::process::Pid;
 use rand::{self,
-           distributions::{Distribution,
-                           Uniform}};
+           distr::{Distribution,
+                   Uniform}};
 use reqwest::Method;
 use serde_json::Value;
 use std::{collections::HashSet,
@@ -109,8 +109,8 @@ async fn unclaimed_port(max_attempts: u16) -> Result<u16> {
 /// Return a random unprivileged, unregistered TCP port number.
 fn random_port() -> u16 {
     // IANA port registrations go to 49151
-    let between = Uniform::new_inclusive(49152, u16::MAX);
-    let mut rng = rand::thread_rng();
+    let between = Uniform::new_inclusive(49152, u16::MAX).expect("Invalid Parameters");
+    let mut rng = rand::rng();
     between.sample(&mut rng)
 }
 


### PR DESCRIPTION
This avoids intermittent failures when using our own `retry`, which is now updated to version `0.9`