### PR TITLE
add kernel2 back to installer.sh

### DIFF
--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -151,7 +151,12 @@ get_platform() {
 # Target is present in the array.
 validate_target() {
   local valid_targets=("${arch}-${sys}")
-
+  case "${sys}" in
+  linux)
+    valid_targets+=("x86_64-linux-kernel2")
+    ;;
+  esac
+  
   if ! (_array_contains "${target}" "${valid_targets[@]}"); then
     local _vts
     printf -v _vts "%s, " "${valid_targets[@]}"


### PR DESCRIPTION
Even though we are dropping support for kernel2, we need to keep it in install.sh for now so that users of v1 can install it.