### PR TITLE
downgrade native-tls

### DIFF
--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -48,6 +48,17 @@ install_rustup() {
   fi
 }
 
+install_rust_toolchain() {
+  local toolchain="${1?toolchain argument required}"
+
+  if rustup component list --toolchain "$toolchain" &>/dev/null; then
+    echo "--- :rust: Rust $toolchain is already installed."
+  else
+    echo "--- :rust: Installing rust $toolchain."
+    rustup toolchain install "$toolchain"
+  fi
+}
+
 get_toolchain() {
     dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
     tail -n 1 "$dir/../../rust-toolchain" | cut -d'"' -f 2

--- a/.expeditor/scripts/verify/build_mac_package.sh
+++ b/.expeditor/scripts/verify/build_mac_package.sh
@@ -31,11 +31,12 @@ macos_sync_cache_signing_keys
 # set the rust toolchain
 install_rustup
 
+rust_toolchain="$(tail -n 1 rust-toolchain  | cut -d'"' -f 2)"
 if [ "$BUILD_PKG_TARGET" == "aarch64-darwin" ]; then
     rustup target add aarch64-apple-darwin
 fi
 
-rust_toolchain="$(tail -n 1 rust-toolchain  | cut -d'"' -f 2)"
+install_rust_toolchain "$rust_toolchain"
 echo "--- :rust: Using Rust toolchain ${rust_toolchain}"
 rustc --version # just 'cause I'm paranoid and I want to double check
 

--- a/.expeditor/scripts/verify/shared.sh
+++ b/.expeditor/scripts/verify/shared.sh
@@ -39,17 +39,6 @@ install_rustfmt() {
   rustup set profile default
 }
 
-install_rust_toolchain() {
-  local toolchain="${1?toolchain argument required}"
-
-  if rustup component list --toolchain "$toolchain" &>/dev/null; then
-    echo "--- :rust: Rust $toolchain is already installed."
-  else
-    echo "--- :rust: Installing rust $toolchain."
-    rustup toolchain install "$toolchain"
-  fi
-}
-
 # Get the version of the nightly toolchain we use for compiling,
 # running, tests, etc.
 get_nightly_toolchain() {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
  "libc",
  "log",


### PR DESCRIPTION
The upgrade to native-tls 0.2.13, breaks arm when reqwest tries to build a request. I'm can't tell exactly what broke from the native-tls changelog and the error returned on arm from a `hab pkg install` which will produce the error is completely useless. It just returns "builder error". It's inner error array is empty.

There is a native-tls 0.2.14 we could try but it requires at least rust v 1.80. We need to get that available, upgrade rust and give 0.2.14 a try but for now downgrading fixes arm.