### PR TITLE
remove leating tilde in container exporter dockerfile templates

### DIFF
--- a/components/pkg-export-container/defaults/Dockerfile.hbs
+++ b/components/pkg-export-container/defaults/Dockerfile.hbs
@@ -1,7 +1,7 @@
 FROM {{base_image}}
 ENV PATH {{path}}
 
-{{~ #if multi_layer }}
+{{ #if multi_layer }}
 # TODO (CM): If package-per-layer becomes an issue, we could gain a
 # bit of headspace by putting all the Supervisor-related packages and
 # dependencies in one layer, and then add user packages in subsequent
@@ -10,12 +10,12 @@ ENV PATH {{path}}
 # Alternatively, we might take advantage of a Supervisor-only
 # container as a base image:
 # https://github.com/habitat-sh/habitat/issues/4977
-{{~ #each packages as |pkg|}}
+{{ #each packages as |pkg|}}
 COPY {{../rootfs}}/hab/pkgs/{{pkg}} /hab/pkgs/{{pkg}}
 {{ /each }}
-{{~ else }}
+{{ else }}
 ADD {{rootfs}}/hab /hab
-{{~ /if }}
+{{ /if }}
 
 # Contains all our busybox userspace links, hab binary link, and any user
 # package binary links
@@ -59,11 +59,11 @@ COPY {{rootfs}}/init.sh /init.sh
 
 EXPOSE 9631 {{exposes}}
 RUN HAB_FEAT_OFFLINE_INSTALL=ON \
-    {{~ #if environment}}
-    {{~ #each environment}}
+    {{ #if environment}}
+    {{ #each environment}}
         {{@key}}={{{this}}} \
-    {{~ /each}}
-    {{~ /if}}
+    {{ /each}}
+    {{ /if}}
     {{hab_path}} pkg install {{installed_primary_svc_ident}}
 ENTRYPOINT ["/init.sh"]
 CMD ["run", "{{primary_svc_ident}}"]

--- a/components/pkg-export-container/defaults/Dockerfile_win.hbs
+++ b/components/pkg-export-container/defaults/Dockerfile_win.hbs
@@ -1,6 +1,6 @@
 FROM {{base_image}}
 
-{{~ #if multi_layer }}
+{{ #if multi_layer }}
 # TODO (CM): If package-per-layer becomes an issue, we could gain a
 # bit of headspace by putting all the Supervisor-related packages and
 # dependencies in one layer, and then add user packages in subsequent
@@ -9,19 +9,19 @@ FROM {{base_image}}
 # Alternatively, we might take advantage of a Supervisor-only
 # container as a base image:
 # https://github.com/habitat-sh/habitat/issues/4977
-{{~ #each packages as |pkg|}}
+{{ #each packages as |pkg|}}
 COPY {{../rootfs}}/hab/pkgs/{{pkg}} /hab/pkgs/{{pkg}}
 {{ /each }}
-{{~ else }}
+{{ else }}
 ADD {{rootfs}}/hab /hab
-{{~ /if }}
+{{ /if }}
 
 EXPOSE 9631 {{exposes}}
 RUN SET HAB_FEAT_OFFLINE_INSTALL=ON && \
-    {{~ #if environment}}
-    {{~ #each environment}}
+    {{ #if environment}}
+    {{ #each environment}}
         SET {{@key}}={{{this}}}&& \
-    {{~ /each}}
-    {{~ /if}}
+    {{ /each}}
+    {{ /if}}
     {{hab_path}} pkg install {{installed_primary_svc_ident}}
 ENTRYPOINT ["{{hab_path}}", "sup", "run", "{{primary_svc_ident}}"]

--- a/components/pkg-export-container/src/container.rs
+++ b/components/pkg-export-container/src/container.rs
@@ -10,7 +10,8 @@ use habitat_common::ui::{Status,
                          UI};
 use habitat_core::package::PackageIdent;
 use handlebars::Handlebars;
-use log::error;
+use log::{debug,
+          error};
 use serde_json::json;
 use std::{fs,
           path::{Path,
@@ -246,9 +247,10 @@ impl BuildContext {
             "environment": ctx.environment,
             "packages": self.0.graph().reverse_topological_sort().iter().map(ToString::to_string).collect::<Vec<_>>(),
         });
-        util::write_file(self.0.workdir().join("Dockerfile"),
-                         &Handlebars::new().render_template(DOCKERFILE, &json)
-                                           .map_err(|err| anyhow!("{}", err))?)?;
+        let dockerfile = &Handlebars::new().render_template(DOCKERFILE, &json)
+                                           .map_err(|err| anyhow!("{}", err))?;
+        debug!("DOCKERFILE: {}", dockerfile);
+        util::write_file(self.0.workdir().join("Dockerfile"), dockerfile)?;
         Ok(())
     }
 


### PR DESCRIPTION
The latest handlebars crate follows the handlebars spec more rigorously. We were using the `{{~` syntax in our templating which will eliminate all whitespace to the left of the `{{`. I'm not sure why this was originally put here. Perhaps a copy/paste mistake that the older crate did not honor correctly. However by removing the whitespace we ended up with malformed dockerfiles.

```
FROM mcr.microsoft.com/windows/servercore:ltsc2022ADD rootfs/hab /hab
```
vs
```
FROM mcr.microsoft.com/windows/servercore:ltsc2022

    ADD rootfs/hab /hab
```