### PR TITLE
Fixed issues with indices in `eachAlive` helper

### DIFF
--- a/components/common/src/templating.rs
+++ b/components/common/src/templating.rs
@@ -393,6 +393,25 @@ mod test {
     }
 
     #[test]
+    fn each_alive_helper_with_idx() {
+        let mut renderer = TemplateRenderer::new();
+        // template using the new `eachAlive` helper
+        renderer.register_template_file("each_alive_idx", templates().join("each_alive_idx.txt"))
+                .unwrap();
+
+        // template using an each block with a nested if block filtering on `alive`
+        renderer.register_template_file("all_members_idx", templates().join("all_members_idx.txt"))
+                .unwrap();
+
+        let data = service_config_json_from_toml_file("multiple_supervisors_config.toml");
+
+        let each_alive_render = renderer.render("each_alive_idx", &data).unwrap();
+        let each_if_render = renderer.render("all_members_idx", &data).unwrap();
+
+        assert_eq!(each_alive_render, each_if_render);
+    }
+
+    #[test]
     fn each_alive_helper_with_identifier_alias() {
         let mut renderer = TemplateRenderer::new();
         // template using the new `eachAlive` helper

--- a/components/common/src/templating/helpers/each_alive.rs
+++ b/components/common/src/templating/helpers/each_alive.rs
@@ -38,14 +38,12 @@ impl HelperDef for EachAliveHelper {
                             m.contains_key("alive") && m["alive"].as_bool().unwrap()
                         }
                                                      });
-                    let last_alive_idx = list.iter().rev().rposition(|m| {
-                                                              m.as_object().is_some() && {
+                    let last_alive_idx = list.iter().rposition(|m| {
+                                                        m.as_object().is_some() && {
                             let m = m.as_object().unwrap();
                             m.contains_key("alive") && m["alive"].as_bool().unwrap()
                         }
-                                                          });
-                    eprintln!("first: {:#?}, last: {:#?}", first_alive_idx, last_alive_idx);
-
+                                                    });
                     let array_path = value.context_path();
 
                     let block_context = create_block(value);
@@ -61,9 +59,9 @@ impl HelperDef for EachAliveHelper {
                                     let is_last = last_alive_idx == Some(i);
                                     let index = to_json(alive_idx);
 
-                                    block.set_local_var("@first", to_json(is_first));
-                                    block.set_local_var("@last", to_json(is_last));
-                                    block.set_local_var("@index", to_json(index.clone()));
+                                    block.set_local_var("first", to_json(is_first));
+                                    block.set_local_var("last", to_json(is_last));
+                                    block.set_local_var("index", to_json(index.clone()));
 
                                     update_block_context(block,
                                                          array_path,
@@ -99,8 +97,8 @@ impl HelperDef for EachAliveHelper {
 
                             let key = to_json(k);
 
-                            block.set_local_var("@first", to_json(is_first));
-                            block.set_local_var("@key", to_json(k));
+                            block.set_local_var("first", to_json(is_first));
+                            block.set_local_var("key", to_json(k));
 
                             update_block_context(block, obj_path, k.to_string(), is_first, v);
                             set_block_param(block, h, obj_path, &key, v)?;

--- a/components/common/tests/fixtures/templates/all_members_idx.txt
+++ b/components/common/tests/fixtures/templates/all_members_idx.txt
@@ -1,0 +1,5 @@
+{{~#each svc.members as |member|}}
+{{~#if member.alive}}
+ Member ID: {{member.member_id}} {{@first}} {{@last}}
+{{~/if}}
+{{~/each}}

--- a/components/common/tests/fixtures/templates/each_alive_idx.txt
+++ b/components/common/tests/fixtures/templates/each_alive_idx.txt
@@ -1,0 +1,3 @@
+{{~#eachAlive svc.members as |member|}}
+ Member ID: {{member.member_id}} {{@first}} {{@last}}
+{{~/eachAlive}}


### PR DESCRIPTION
The `first`, `last` etc. indices were not properly assigned in the latest porting to new handlebars API. Fixed the issue (In the old code we had to use the explicit `@first` , `@last` block local variables. In the current APIs the block local variables should simply be named `first`, `last` instead.

Also added a unit test to handle for this scenario