### PR TITLE
Corrects 2s timeout to 20s in test_supervisor_load_service.ps1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,9 +2907,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -2948,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/test/end-to-end/test_supervisor_load_service.ps1
+++ b/test/end-to-end/test_supervisor_load_service.ps1
@@ -45,7 +45,7 @@ if ($IsLinux) {
     Describe 'hab svc load on Linux with umask 077' {
 
         $loadOut = hab svc load core/nginx
-        Wait-SupervisorService nginx -Timeout 2
+        Wait-SupervisorService nginx -Timeout 20
 
         It 'Successfully loads service' {
             ($loadOut | Out-String) |


### PR DESCRIPTION
This PR fixes an issues with test_supervisor_load_service where the wait for nginx was 2s instead of the 20s used elsewhere.

After submitting the PR I hit [a RUSTSEC advisory that came out today](https://rustsec.org/advisories/RUSTSEC-2025-0022) so this also fixes that.