### PR TITLE
Corrects quoting in test_supervisor_load_service.ps1

### DIFF
--- a/test/end-to-end/test_supervisor_load_service.ps1
+++ b/test/end-to-end/test_supervisor_load_service.ps1
@@ -74,11 +74,11 @@ if ($IsLinux) {
         }
 
         It 'has correct permissions on relevant svc directories' {
-            $out = (bash -c 'ls -l /hab/svc | tail -n 1 | cut -d' ' -f 1')
+            $out = (bash -c "ls -l /hab/ | grep svc | cut -d ' ' -f 1")
             ($out | Out-String) | Should -Match 'drwxr-xr-x'
-            $out = (bash -c 'ls -l /hab/svc/nginx | grep hooks | tail -n 1 | cut -d' ' -f 1')
+            $out = (bash -c "ls -l /hab/svc/nginx | grep hooks | cut -d ' ' -f 1")
             ($out | Out-String) | Should -Match 'drwxr-xr-x'
-            $out = (bash -c 'ls -l /hab/svc/nginx | grep logs | tail -n 1 | cut -d' ' -f 1')
+            $out = (bash -c "ls -l /hab/svc/nginx | grep logs | cut -d ' ' -f 1")
             ($out | Out-String) | Should -Match 'drwxr-xr-x'
         }
 


### PR DESCRIPTION
I added single quotes around a bash -c '' in test_supervisor_load_service.ps1 where I had already used single quotes in the bash pipeline being quoted. This resulted in predictably bad times.