### PR TITLE
Calls release_habitat/package_and_upload_binary.sh when branch == main

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -326,7 +326,7 @@ steps:
   - label: "[:linux: upload hab binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     expeditor:
       executor:
         docker:
@@ -337,7 +337,7 @@ steps:
   - label: "[:linux: upload hab aarch64 binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     expeditor:
       executor:
         docker:
@@ -348,7 +348,7 @@ steps:
   - label: "[:windows: upload hab binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     expeditor:
       executor:
         docker:
@@ -359,7 +359,7 @@ steps:
   - label: "[:mac: x86_64 upload hab binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     expeditor:
       executor:
         docker:
@@ -370,7 +370,7 @@ steps:
   - label: "[:mac: aarch64 upload hab binary]"
     command:
       - .expeditor/scripts/release_habitat/package_and_upload_binary.sh
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     expeditor:
       executor:
         docker:
@@ -381,7 +381,7 @@ steps:
   - label: "Update Habitat Documentation"
     command:
       - .expeditor/scripts/release_habitat/update_documentation.sh
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     artifact_paths:
       # See update_documentation.sh script for the naming of this path.
       - "generated-documentation/**"
@@ -412,7 +412,7 @@ steps:
 
   - label: ":docker: Upload containers to Docker Hub"
     command: .expeditor/scripts/release_habitat/dockerhub_upload.sh
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     env:
       BUILD_PKG_TARGET: "x86_64-linux"
     expeditor:
@@ -421,7 +421,7 @@ steps:
           privileged: true
 
   - label: ":docker: :windows: Upload windows 2016 container to Docker Hub"
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1
     expeditor:
       executor:
@@ -429,7 +429,7 @@ steps:
           os_version: 2016
 
   - label: ":docker: :windows: Upload windows 2019 container to Docker Hub"
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1
     expeditor:
       executor:
@@ -437,7 +437,7 @@ steps:
           os_version: 2019
 
   - label: ":docker: :windows: Upload windows 2022 container to Docker Hub"
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1
     expeditor:
       executor:
@@ -450,7 +450,7 @@ steps:
     command:
       - .expeditor/scripts/release_habitat/promote_artifacts_to_dev.sh habitat-release-$BUILDKITE_BUILD_ID
     # Only "real" executions of this pipeline, initiated by Expeditor, should promote anything
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true' || build.branch == 'main'
     expeditor:
       executor:
         docker:


### PR DESCRIPTION
This PR modifies the release_habitat pipeline such that package_and_upload_binary.sh will run whenever the build is being executed against the main branch.  This is an added OR'ed condition to the logic that previously existed.

The motivating issue is that the release_habitat pipeline is a bit fragile and often fails.  One may argue that the real fix would be "fix the pipeline" which is accurate but that's likely to be quite an undertaking, this is fast.  Also, fixing could mean higher costs. For example, bigger and more instances with more processing power would likely help a lot of this fragility because the failure are often related to builds timing out.

However, beyond that there is motivation in that buildkite UI has two flaws IMO.  

First, when the if conditional in the yaml is not met there is a very subtle indicator that steps aren't being run which is the addition of an eye on the right hand side.  In addition, the steps not being run are hidden  It's just so easy to overlook that indicator also to not realize that steps won't be run when you're busy and keeping an eye on the pipeline executing off to the side.

Beyond that, clicking the rebuild button which feels like it should do what you want really doesn't in this case.  The executing user now matches who clicks the button and you don't have the ability to specify the BUILD_AND_PROMOTE environment variable.  To do that you have to click new build, set the envvar, set a build name which you should probably copy and paste it forward.

In short, there's just friction and sharp edges and ruunning package_and_upload_binary.sh when the branch is main should honor the goals that brought about the addition of the if stmt.