### PR TITLE
Adding clapv4 support for  "hab sup" commands

### DIFF
--- a/components/common/src/types.rs
+++ b/components/common/src/types.rs
@@ -43,7 +43,7 @@ pub struct UserInfo {
     pub gid:       Option<u32>,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 // TODO (DM): This is unnecessarily difficult due to this issue in serde
 // https://github.com/serde-rs/serde/issues/723. The easiest way to get around the issue is to use
 // these proxy types.

--- a/components/hab/src/cli_v4.rs
+++ b/components/hab/src/cli_v4.rs
@@ -12,6 +12,9 @@ use crate::{error::Result as HabResult,
 mod pkg;
 use pkg::PkgCommand;
 
+pub(crate) mod sup;
+use sup::SupCommand;
+
 mod utils;
 use utils::CacheKeyPath;
 
@@ -51,6 +54,8 @@ enum Hab {
 
     Studio(StudioCommand),
 
+    /// The Habitat Supervisor
+    #[clap(subcommand)]
     Sup(SupCommand),
 
     SupportBundle,
@@ -79,6 +84,7 @@ impl Hab {
     async fn do_cli_command(&self, ui: &mut UI, feature_flags: FeatureFlag) -> HabResult<()> {
         match self {
             Self::Pkg(pkg_command) => pkg_command.do_command(ui, feature_flags).await,
+            Self::Sup(sup_command) => sup_command.do_command(ui, feature_flags).await,
             _ => todo!(),
         }
     }
@@ -110,9 +116,6 @@ pub(crate) struct RingCommand;
 
 #[derive(Clone, Debug, Parser)]
 pub(crate) struct StudioCommand;
-
-#[derive(Clone, Debug, Parser)]
-pub(crate) struct SupCommand;
 
 #[derive(Clone, Debug, Parser)]
 pub(crate) struct SvcCommand;

--- a/components/hab/src/cli_v4/sup.rs
+++ b/components/hab/src/cli_v4/sup.rs
@@ -1,0 +1,69 @@
+use clap_v4 as clap;
+
+use crate::error::Result as HabResult;
+use clap::Subcommand;
+use habitat_common::{ui::UI,
+                     FeatureFlag};
+
+mod bash;
+mod depart;
+mod restart;
+mod secret;
+mod sh;
+mod status;
+pub(crate) mod sup_run;
+mod term;
+
+#[derive(Clone, Debug, Subcommand)]
+#[command(author = "\nThe Habitat Maintainers <humans@habitat.sh>",
+          about = "The Habitat Supervisor",
+          arg_required_else_help = true,
+          help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                           {usage}\n\n{all-args}\n")]
+
+pub(super) enum SupCommand {
+    /// Depart a Supervisor from the gossip ring; kicking and banning the target from joining again
+    /// with the same member-id
+    Depart(depart::SupDepartOptions),
+
+    /// Restart a Supervisor without restarting its services
+    Restart(restart::SupRestartOptions),
+
+    /// Commands relating to a Habitat Supervisor's Control Gateway secret
+    #[command(subcommand)]
+    Secret(secret::SupSecretOptions),
+
+    /// Query the status of Habitat services
+    Status(status::SupStatusOptions),
+
+    // Basic Commands (sh, bash , terminate)
+    /// Start an interactive Bourne-like shell
+    Sh(sh::SupShellCommand),
+
+    /// Start an interactive Bash-like shell
+    Bash(bash::SupBashCommand),
+
+    /// Gracefully terminate the Habitat Supervisor and all of its running services
+    Term(term::SupTermCommand),
+
+    /// Run the supervisor (load config and start services)
+    Run(sup_run::SupRunOptions),
+}
+
+impl SupCommand {
+    pub(crate) async fn do_command(&self,
+                                   ui: &mut UI,
+                                   _feature_flags: FeatureFlag)
+                                   -> HabResult<()> {
+        match self {
+            Self::Depart(opts) => opts.do_depart(ui).await,
+            Self::Restart(opts) => opts.do_restart().await,
+            Self::Secret(opts) => opts.execute().await,
+            Self::Status(opts) => opts.do_status().await,
+            Self::Sh(opts) => opts.execute(ui).await,
+            Self::Bash(opts) => opts.execute(ui).await,
+            Self::Term(opts) => opts.execute(ui).await,
+            Self::Run(opts) => opts.do_run(ui).await,
+        }
+    }
+}

--- a/components/hab/src/cli_v4/sup/bash.rs
+++ b/components/hab/src/cli_v4/sup/bash.rs
@@ -14,9 +14,8 @@ use crate::command;
 
 /// Start an interactive Bash-like shell
 #[derive(Debug, Clone, Parser)]
-#[command(arg_required_else_help = true,
-    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
-                     {usage}\n\n{all-args}\n")]
+#[command(help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                           {usage}\n\n{all-args}\n")]
 pub(crate) struct SupBashCommand {
     #[arg()]
     args: Vec<OsString>,
@@ -25,7 +24,9 @@ pub(crate) struct SupBashCommand {
 impl SupBashCommand {
     #[cfg(not(target_os = "macos"))]
     pub(super) async fn execute(&self, ui: &mut UI) -> HabResult<()> {
-        return command::sup::start(ui, &self.args).await;
+        let mut args = vec!["bash".into()];
+        args.extend(self.args.clone());
+        return command::sup::start(ui, &args).await;
     }
 
     #[cfg(target_os = "macos")]

--- a/components/hab/src/cli_v4/sup/bash.rs
+++ b/components/hab/src/cli_v4/sup/bash.rs
@@ -1,0 +1,33 @@
+// To handle basic commands such as launching a shell or terminating
+
+use clap_v4 as clap;
+
+use clap::Parser;
+
+use crate::error::Result as HabResult;
+use habitat_common::ui::UI;
+
+use std::ffi::OsString;
+
+#[cfg(not(target_os = "macos"))]
+use crate::command;
+
+/// Start an interactive Bash-like shell
+#[derive(Debug, Clone, Parser)]
+#[command(arg_required_else_help = true,
+    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                     {usage}\n\n{all-args}\n")]
+pub(crate) struct SupBashCommand {
+    #[arg()]
+    args: Vec<OsString>,
+}
+
+impl SupBashCommand {
+    #[cfg(not(target_os = "macos"))]
+    pub(super) async fn execute(&self, ui: &mut UI) -> HabResult<()> {
+        return command::sup::start(ui, &self.args).await;
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) async fn execute(&self, _ui: &mut UI) -> HabResult<()> { Ok(()) }
+}

--- a/components/hab/src/cli_v4/sup/depart.rs
+++ b/components/hab/src/cli_v4/sup/depart.rs
@@ -25,10 +25,9 @@ use habitat_common::ui::{Status,
                          UIWriter};
 
 #[derive(Debug, Clone, Parser)]
-#[command(arg_required_else_help = true,
-    disable_version_flag = true,
-    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
-                     {usage}\n\n{all-args}\n")]
+#[command(disable_version_flag = true,
+          help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                           {usage}\n\n{all-args}\n")]
 pub(crate) struct SupDepartOptions {
     /// The member-id of the Supervisor to depart
     #[arg(name = "MEMBER_ID")]

--- a/components/hab/src/cli_v4/sup/depart.rs
+++ b/components/hab/src/cli_v4/sup/depart.rs
@@ -1,0 +1,71 @@
+// Implemenatation of `hab sup depart`
+
+use clap_v4 as clap;
+
+use crate::{cli_v4::utils::RemoteSup,
+            error::Result as HabResult};
+use clap::Parser;
+use habitat_common::ui::UI;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_sup_client::{SrvClient,
+                         SrvClientError};
+
+#[cfg(not(target_os = "macos"))]
+use habitat_sup_protocol as sup_proto;
+
+#[cfg(not(target_os = "macos"))]
+use std::io;
+
+#[cfg(not(target_os = "macos"))]
+use futures::stream::StreamExt;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_common::ui::{Status,
+                         UIWriter};
+
+#[derive(Debug, Clone, Parser)]
+#[command(arg_required_else_help = true,
+    disable_version_flag = true,
+    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                     {usage}\n\n{all-args}\n")]
+pub(crate) struct SupDepartOptions {
+    /// The member-id of the Supervisor to depart
+    #[arg(name = "MEMBER_ID")]
+    member_id: String,
+
+    /// Remote supervisor connection options
+    #[command(flatten)]
+    remote_sup: RemoteSup,
+}
+
+impl SupDepartOptions {
+    #[cfg(not(target_os = "macos"))]
+    pub(super) async fn do_depart(&self, ui: &mut UI) -> HabResult<()> {
+        let remote = SrvClient::ctl_addr(self.remote_sup.inner())?;
+        // let mut ui = ui::ui();
+        let msg = sup_proto::ctl::SupDepart { member_id: Some(self.member_id.clone()), };
+
+        ui.begin(format!("Permanently marking {} as departed", &self.member_id))?;
+        ui.status(Status::Applying, format!("via peer {}", remote))?;
+        let mut response = SrvClient::request(Some(&remote), msg).await?;
+
+        while let Some(message_result) = response.next().await {
+            let reply = message_result?;
+            match reply.message_id() {
+                "NetOk" => (),
+                "NetErr" => {
+                    let m = reply.parse::<sup_proto::net::NetErr>()
+                                .map_err(SrvClientError::Decode)?;
+                    return Err(SrvClientError::from(m).into());
+                }
+                _ => return Err(SrvClientError::from(io::Error::from(io::ErrorKind::UnexpectedEof)).into()),
+            }
+        }
+        ui.end("Departure recorded.")?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) async fn do_depart(&self, _ui: &mut UI) -> HabResult<()> { Ok(()) }
+}

--- a/components/hab/src/cli_v4/sup/restart.rs
+++ b/components/hab/src/cli_v4/sup/restart.rs
@@ -1,0 +1,63 @@
+// Implemenatation of `hab sup restart`
+
+use clap_v4 as clap;
+
+use crate::{cli_v4::utils::RemoteSup,
+            error::Result as HabResult};
+use clap::Parser;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_sup_client::{SrvClient,
+                         SrvClientError};
+
+#[cfg(not(target_os = "macos"))]
+use std::io;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_common::ui::{self,
+                         UIWriter};
+
+#[cfg(not(target_os = "macos"))]
+use futures::stream::StreamExt;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_sup_protocol as sup_proto;
+
+#[derive(Debug, Clone, Parser)]
+#[command(arg_required_else_help = true,
+    disable_version_flag = true,
+    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                     {usage}\n\n{all-args}\n")]
+pub(crate) struct SupRestartOptions {
+    #[command(flatten)]
+    remote_sup: RemoteSup,
+}
+
+impl SupRestartOptions {
+    #[cfg(not(target_os = "macos"))]
+    pub(super) async fn do_restart(&self) -> HabResult<()> {
+        let remote = SrvClient::ctl_addr(self.remote_sup.inner())?;
+        let mut ui = ui::ui();
+        let msg = sup_proto::ctl::SupRestart::default();
+
+        ui.begin(format!("Restarting supervisor {}", remote))?;
+        let mut response = SrvClient::request(Some(&remote), msg).await?;
+        while let Some(message_result) = response.next().await {
+            let reply = message_result?;
+            match reply.message_id() {
+                "NetOk" => (),
+                "NetErr" => {
+                    let m = reply.parse::<sup_proto::net::NetErr>()
+                                .map_err(SrvClientError::Decode)?;
+                    return Err(SrvClientError::from(m).into());
+                }
+                _ => return Err(SrvClientError::from(io::Error::from(io::ErrorKind::UnexpectedEof)).into()),
+            }
+        }
+        ui.end("Restart recorded.")?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) async fn do_restart(&self) -> HabResult<()> { Ok(()) }
+}

--- a/components/hab/src/cli_v4/sup/restart.rs
+++ b/components/hab/src/cli_v4/sup/restart.rs
@@ -24,10 +24,9 @@ use futures::stream::StreamExt;
 use habitat_sup_protocol as sup_proto;
 
 #[derive(Debug, Clone, Parser)]
-#[command(arg_required_else_help = true,
-    disable_version_flag = true,
-    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
-                     {usage}\n\n{all-args}\n")]
+#[command(disable_version_flag = true,
+          help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                           {usage}\n\n{all-args}\n")]
 pub(crate) struct SupRestartOptions {
     #[command(flatten)]
     remote_sup: RemoteSup,

--- a/components/hab/src/cli_v4/sup/secret.rs
+++ b/components/hab/src/cli_v4/sup/secret.rs
@@ -21,9 +21,9 @@ use habitat_core::tls::ctl_gateway as ctl_gateway_tls;
 
 #[derive(Debug, Clone, Parser)]
 #[command(arg_required_else_help = true,
-    disable_version_flag = true,
-    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
-                     {usage}\n\n{all-args}\n")]
+          disable_version_flag = true,
+          help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                           {usage}\n\n{all-args}\n")]
 pub enum SupSecretOptions {
     /// Generate a secret key to use as a Supervisor's Control Gateway secret
     Generate,

--- a/components/hab/src/cli_v4/sup/secret.rs
+++ b/components/hab/src/cli_v4/sup/secret.rs
@@ -1,0 +1,65 @@
+// Implemenatation of `hab sup secret`
+/// Commands relating to a Habitat Supervisor's Control Gateway secret
+use clap_v4 as clap;
+
+use clap::Parser;
+
+use crate::{cli_v4::utils::SubjectAlternativeName,
+            error::Result as HabResult};
+use habitat_core::fs::HAB_CTL_KEYS_CACHE;
+use std::path::PathBuf;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_common::ui::{self,
+                         UIWriter};
+
+#[cfg(not(target_os = "macos"))]
+use habitat_sup_protocol as sup_proto;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_core::tls::ctl_gateway as ctl_gateway_tls;
+
+#[derive(Debug, Clone, Parser)]
+#[command(arg_required_else_help = true,
+    disable_version_flag = true,
+    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                     {usage}\n\n{all-args}\n")]
+pub enum SupSecretOptions {
+    /// Generate a secret key to use as a Supervisor's Control Gateway secret
+    Generate,
+
+    /// Generate a private key and certificate for the Supervisor's
+    /// Control Gateway TLS connection
+    GenerateTls {
+        /// The DNS name to use in the certificates subject alternative name extension
+        #[arg(name = "subject-alternative-name")]
+        subject_alternative_name: SubjectAlternativeName,
+
+        /// The directory to store the generated private key and certificate
+        #[arg(name = "path", default_value = HAB_CTL_KEYS_CACHE)]
+        path: PathBuf,
+    },
+}
+
+impl SupSecretOptions {
+    #[cfg(not(target_os = "macos"))]
+    pub(super) async fn execute(&self) -> HabResult<()> {
+        match self {
+            SupSecretOptions::Generate => {
+                let mut ui = ui::ui();
+                let mut buf = String::new();
+                sup_proto::generate_secret_key(&mut buf);
+                ui.info(buf)?;
+                Ok(())
+            }
+
+            SupSecretOptions::GenerateTls {subject_alternative_name, path} => {
+                Ok(ctl_gateway_tls::generate_self_signed_certificate_and_key(&subject_alternative_name.dns_name()?, path)
+                .map_err(habitat_core::Error::from)?)
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) async fn execute(&self) -> HabResult<()> { Ok(()) }
+}

--- a/components/hab/src/cli_v4/sup/sh.rs
+++ b/components/hab/src/cli_v4/sup/sh.rs
@@ -1,0 +1,33 @@
+// To handle basic commands such as launching a shell or terminating
+
+use clap_v4 as clap;
+
+use clap::Parser;
+
+use crate::error::Result as HabResult;
+use habitat_common::ui::UI;
+
+use std::ffi::OsString;
+
+#[cfg(not(target_os = "macos"))]
+use crate::command;
+
+/// Start an interactive Bourne-like shell
+#[derive(Debug, Clone, Parser)]
+#[command(arg_required_else_help = true,
+    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                     {usage}\n\n{all-args}\n")]
+pub(crate) struct SupShellCommand {
+    #[arg()]
+    args: Vec<OsString>,
+}
+
+impl SupShellCommand {
+    #[cfg(not(target_os = "macos"))]
+    pub(super) async fn execute(&self, ui: &mut UI) -> HabResult<()> {
+        return command::sup::start(ui, &self.args).await;
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) async fn execute(&self, _ui: &mut UI) -> HabResult<()> { Ok(()) }
+}

--- a/components/hab/src/cli_v4/sup/sh.rs
+++ b/components/hab/src/cli_v4/sup/sh.rs
@@ -14,9 +14,8 @@ use crate::command;
 
 /// Start an interactive Bourne-like shell
 #[derive(Debug, Clone, Parser)]
-#[command(arg_required_else_help = true,
-    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
-                     {usage}\n\n{all-args}\n")]
+#[command(help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                           {usage}\n\n{all-args}\n")]
 pub(crate) struct SupShellCommand {
     #[arg()]
     args: Vec<OsString>,
@@ -25,7 +24,9 @@ pub(crate) struct SupShellCommand {
 impl SupShellCommand {
     #[cfg(not(target_os = "macos"))]
     pub(super) async fn execute(&self, ui: &mut UI) -> HabResult<()> {
-        return command::sup::start(ui, &self.args).await;
+        let mut args = vec!["sh".into()];
+        args.extend(self.args.clone());
+        return command::sup::start(ui, &args).await;
     }
 
     #[cfg(target_os = "macos")]

--- a/components/hab/src/cli_v4/sup/status.rs
+++ b/components/hab/src/cli_v4/sup/status.rs
@@ -56,10 +56,9 @@ lazy_static! {
 }
 
 #[derive(Debug, Clone, Parser)]
-#[command(arg_required_else_help = true,
-    disable_version_flag = true,
-    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
-                     {usage}\n\n{all-args}\n")]
+#[command(disable_version_flag = true,
+          help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                           {usage}\n\n{all-args}\n")]
 pub(crate) struct SupStatusOptions {
     /// A package identifier (ex: core/redis, core/busybox-static/1.42.2)
     #[arg(name = "PKG_IDENT")]

--- a/components/hab/src/cli_v4/sup/status.rs
+++ b/components/hab/src/cli_v4/sup/status.rs
@@ -1,0 +1,170 @@
+// Implemenatation of `hab sup status`
+
+use clap_v4 as clap;
+
+use clap::Parser;
+
+use crate::{cli_v4::utils::RemoteSup,
+            error::Result as HabResult};
+use habitat_core::package::PackageIdent;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_common::types::ResolvedListenCtlAddr;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_sup_client::{SrvClient,
+                         SrvClientError};
+
+#[cfg(not(target_os = "macos"))]
+use habitat_sup_protocol::{self as sup_proto,
+                           codec::*,
+                           types::*};
+
+#[cfg(not(target_os = "macos"))]
+use futures::stream::StreamExt;
+
+#[cfg(not(target_os = "macos"))]
+use std::{io::{self,
+               Write},
+          result,
+          str::FromStr};
+
+#[cfg(not(target_os = "macos"))]
+use tabwriter::TabWriter;
+
+#[cfg(not(target_os = "macos"))]
+use log::warn;
+
+#[cfg(not(target_os = "macos"))]
+use habitat_common::ui::{self,
+                         UIWriter};
+
+#[cfg(not(target_os = "macos"))]
+use lazy_static::lazy_static;
+
+#[cfg(not(target_os = "macos"))]
+lazy_static! {
+    static ref STATUS_HEADER: Vec<&'static str> = {
+        vec!["package",
+             "type",
+             "desired",
+             "state",
+             "elapsed (s)",
+             "pid",
+             "group",]
+    };
+}
+
+#[derive(Debug, Clone, Parser)]
+#[command(arg_required_else_help = true,
+    disable_version_flag = true,
+    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                     {usage}\n\n{all-args}\n")]
+pub(crate) struct SupStatusOptions {
+    /// A package identifier (ex: core/redis, core/busybox-static/1.42.2)
+    #[arg(name = "PKG_IDENT")]
+    pkg_ident: Option<PackageIdent>,
+
+    // Remote supervisor connection option
+    #[command(flatten)]
+    remote_sup: RemoteSup,
+}
+
+impl SupStatusOptions {
+    #[cfg(not(target_os = "macos"))]
+    pub(super) async fn do_status(&self) -> HabResult<()> {
+        let mut ui = ui::ui();
+        ui.warn("'hab sup status' as an alias for 'hab svc status' is deprecated. Please update \
+                 your automation and processes accordingly.")?;
+        return sub_svc_status(self.pkg_ident.clone(), self.remote_sup.inner()).await;
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) async fn do_status(&self) -> HabResult<()> { Ok(()) }
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn sub_svc_status(pkg_ident: Option<PackageIdent>,
+                        remote_sup: Option<&ResolvedListenCtlAddr>)
+                        -> HabResult<()> {
+    let msg = sup_proto::ctl::SvcStatus { ident: pkg_ident.map(Into::into), };
+
+    let mut out = TabWriter::new(io::stdout());
+    let mut response = SrvClient::request(remote_sup, msg).await?;
+    // Ensure there is at least one result from the server otherwise produce an error
+    if let Some(message_result) = response.next().await {
+        let reply = message_result?;
+        print_svc_status(&mut out, &reply, true)?;
+    } else {
+        return Err(SrvClientError::from(io::Error::from(io::ErrorKind::UnexpectedEof)).into());
+    }
+    while let Some(message_result) = response.next().await {
+        let reply = message_result?;
+        print_svc_status(&mut out, &reply, false)?;
+    }
+    out.flush()?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn print_svc_status<T>(out: &mut T,
+                       reply: &SrvMessage,
+                       print_header: bool)
+                       -> result::Result<(), SrvClientError>
+    where T: io::Write
+{
+    let status = match reply.message_id() {
+        "ServiceStatus" => {
+            reply.parse::<sup_proto::types::ServiceStatus>()
+                 .map_err(SrvClientError::Decode)?
+        }
+        "NetOk" => {
+            println!("No services loaded.");
+            return Ok(());
+        }
+        "NetErr" => {
+            let err = reply.parse::<sup_proto::net::NetErr>()
+                           .map_err(SrvClientError::Decode)?;
+            return Err(SrvClientError::from(err));
+        }
+        _ => {
+            warn!("Unexpected status message, {:?}", reply);
+            return Ok(());
+        }
+    };
+    let svc_desired_state = status.desired_state
+                                  .map_or("<none>".to_string(), |s| s.to_string());
+    let (svc_state, svc_pid, svc_elapsed) = {
+        match status.process {
+            Some(process) => {
+                (process.state.to_string(),
+                 process.pid
+                        .map_or_else(|| "<none>".to_string(), |p| p.to_string()),
+                 process.elapsed.unwrap_or_default().to_string())
+            }
+            None => {
+                (ProcessState::default().to_string(), "<none>".to_string(), "<none>".to_string())
+            }
+        }
+    };
+    if print_header {
+        writeln!(out, "{}", STATUS_HEADER.join("\t")).unwrap();
+    }
+    // Composites were removed in 0.75 but people could be
+    // depending on the exact format of this output even if they
+    // never used composites. We don't want to break their tooling
+    // so we hardcode in 'standalone' as it's the only supported
+    // package type
+    //
+    // TODO: Remove this when we have a stable machine-readable alternative
+    // that scripts could depend on
+    writeln!(out,
+             "{}\tstandalone\t{}\t{}\t{}\t{}\t{}",
+             status.ident,
+             DesiredState::from_str(&svc_desired_state)?,
+             ProcessState::from_str(&svc_state)?,
+             svc_elapsed,
+             svc_pid,
+             status.service_group,)?;
+    Ok(())
+}

--- a/components/hab/src/cli_v4/sup/sup_run.rs
+++ b/components/hab/src/cli_v4/sup/sup_run.rs
@@ -72,13 +72,12 @@ impl From<EventStreamAddress> for NatsAddress {
 }
 
 #[derive(Debug, Clone, Args)]
-#[command(arg_required_else_help = true,
-    disable_version_flag = true,
-    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
-                     {usage}\n\n{all-args}\n")]
+#[command(disable_version_flag = true,
+          help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                           {usage}\n\n{all-args}\n")]
 pub(crate) struct SupRunOptions {
     /// The listen address for the Gossip Gateway.
-    #[arg(long = "listen-gossip", 
+    #[arg(long = "listen-gossip",
         env = GossipListenAddr::ENVVAR,
         default_value = GossipListenAddr::default_as_str())]
     listen_gossip: GossipListenAddr,
@@ -92,7 +91,7 @@ pub(crate) struct SupRunOptions {
     peer_watch_file: Option<PathBuf>,
 
     /// Start in local gossip mode.
-    #[arg(long = "local-gossip-mode", 
+    #[arg(long = "local-gossip-mode",
         conflicts_with_all = &["listen_gossip", "peer", "peer_watch_file"])]
     local_gossip_mode: bool,
 
@@ -253,8 +252,8 @@ pub(crate) struct SupRunOptions {
     ///
     /// This enables the event stream and requires EVENT_STREAM_APPLICATION,
     /// EVENT_STREAM_ENVIRONMENT, and EVENT_STREAM_TOKEN also be set.
-    #[arg(long = "event-stream-url", 
-            requires_all = &["event_stream_application", 
+    #[arg(long = "event-stream-url",
+            requires_all = &["event_stream_application",
                             "event_stream_environment",
                             "event_stream_token"])]
     event_stream_url: Option<EventStreamAddress>,

--- a/components/hab/src/cli_v4/sup/sup_run.rs
+++ b/components/hab/src/cli_v4/sup/sup_run.rs
@@ -1,0 +1,306 @@
+// Implemenatation of `hab sup run`
+
+use clap_v4 as clap;
+
+use clap::Args;
+
+use crate::{cli_v4::utils::{CacheKeyPath,
+                            DurationProxy,
+                            SharedLoad,
+                            SocketAddrProxy},
+            error::Result as HabResult};
+
+use crate::cli::hab::{svc::DEFAULT_SVC_CONFIG_DIR,
+                      util::tls::{CertificateChainCli,
+                                  PrivateKeyCli,
+                                  RootCertificateStoreCli}};
+
+use habitat_common::{cli::{RING_ENVVAR,
+                           RING_KEY_ENVVAR},
+                     command::package::install::InstallSource,
+                     types::{EventStreamConnectMethod,
+                             EventStreamMetaPair,
+                             EventStreamServerCertificate,
+                             EventStreamToken,
+                             GossipListenAddr,
+                             HttpListenAddr,
+                             ListenCtlAddr,
+                             ResolvedListenCtlAddr},
+                     ui::UI,
+                     FeatureFlag,
+                     FEATURE_FLAGS};
+
+use rants::{error::Error as RantsError,
+            Address as NatsAddress};
+
+use serde::{Deserialize,
+            Serialize};
+
+use std::{fmt,
+          net::IpAddr,
+          path::PathBuf,
+          str::FromStr};
+
+use habitat_core::{env::Config,
+                   util as core_util};
+
+#[cfg(not(target_os = "macos"))]
+use crate::command;
+
+#[cfg(not(target_os = "macos"))]
+use std::{env,
+          ffi::OsString};
+
+// TODO (DM): This is unnecessarily difficult due to this issue in serde
+// https://github.com/serde-rs/serde/issues/723. The easiest way to get around the issue is by
+// using a wrapper type since NatsAddress is not defined in this crate.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+struct EventStreamAddress(#[serde(with = "core_util::serde::string")] NatsAddress);
+
+impl fmt::Display for EventStreamAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.0) }
+}
+
+impl FromStr for EventStreamAddress {
+    type Err = RantsError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> { Ok(EventStreamAddress(s.parse()?)) }
+}
+
+impl From<EventStreamAddress> for NatsAddress {
+    fn from(address: EventStreamAddress) -> Self { address.0 }
+}
+
+#[derive(Debug, Clone, Args)]
+#[command(arg_required_else_help = true,
+    disable_version_flag = true,
+    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                     {usage}\n\n{all-args}\n")]
+pub(crate) struct SupRunOptions {
+    /// The listen address for the Gossip Gateway.
+    #[arg(long = "listen-gossip", 
+        env = GossipListenAddr::ENVVAR,
+        default_value = GossipListenAddr::default_as_str())]
+    listen_gossip: GossipListenAddr,
+
+    /// Initial peer addresses (IP[:PORT]).
+    #[arg(long = "peer")]
+    peer: Vec<SocketAddrProxy>,
+
+    /// File to watch for connecting to the ring.
+    #[arg(long = "peer-watch-file", conflicts_with = "peer")]
+    peer_watch_file: Option<PathBuf>,
+
+    /// Start in local gossip mode.
+    #[arg(long = "local-gossip-mode", 
+        conflicts_with_all = &["listen_gossip", "peer", "peer_watch_file"])]
+    local_gossip_mode: bool,
+
+    /// The listen address for the HTTP Gateway.
+    #[arg(long = "listen-http",
+        env = HttpListenAddr::ENVVAR,
+        default_value = HttpListenAddr::default_as_str())]
+    listen_http: HttpListenAddr,
+
+    /// Disable the HTTP Gateway.
+    #[arg(long = "http-disable", short = 'D')]
+    http_disable: bool,
+
+    /// The listen address for the Control Gateway.
+    #[arg(long = "listen-ctl",
+        env = ListenCtlAddr::ENVVAR,
+        default_value = ListenCtlAddr::default_as_str())]
+    listen_ctl: ResolvedListenCtlAddr,
+
+    /// The control gateway server’s TLS certificate.
+    #[arg(long = "ctl-server-certificate")]
+    ctl_server_certificate: Option<CertificateChainCli>,
+
+    /// The control gateway server’s private key.
+    #[arg(long = "ctl-server-key")]
+    ctl_server_key: Option<PrivateKeyCli>,
+
+    /// The client CA certificate.
+    #[arg(long = "ctl-client-ca-certificate")]
+    ctl_client_ca_certificate: Option<RootCertificateStoreCli>,
+
+    /// Organization the Supervisor belongs to.
+    #[arg(long = "org")]
+    organization: Option<String>,
+
+    /// Mark the Supervisor as a permanent peer.
+    #[arg(long = "permanent-peer", short = 'I')]
+    permanent_peer: bool,
+
+    /// Flattened cache key configuration.
+    #[command(flatten)]
+    cache_key_path: CacheKeyPath,
+
+    /// The contents of the ring key when running with wire encryption
+    ///
+    /// This option is explicitly undocumented and for testing purposes only. Do not use it in a
+    /// production system. Use the corresponding environment variable instead. (ex:
+    /// 'SYM-SEC-1\nfoo-20181113185935\n\nGCrBOW6CCN75LMl0j2V5QqQ6nNzWm6and9hkKBSUFPI=')
+    #[arg(long = "ring-key", env = RING_KEY_ENVVAR, hide = true)]
+    ring_key: Option<String>,
+
+    /// The name of the ring used by the Supervisor when running with wire encryption
+    #[arg(long = "ring", short = 'r',
+            env = RING_ENVVAR,
+            conflicts_with = "ring_key")]
+    ring: Option<String>,
+
+    /// Enable automatic updates for the Supervisor itself
+    #[arg(long = "auto-update", short = 'A')]
+    auto_update: bool,
+
+    /// Time (seconds) between Supervisor update checks.
+    #[arg(long = "auto-update-period", default_value = "60")]
+    auto_update_period: DurationProxy,
+
+    /// Time (seconds) between service update checks.
+    #[arg(long = "service-update-period", default_value = "60")]
+    service_update_period: DurationProxy,
+
+    /// The minimum period of time in seconds to wait before attempting to restart a service
+    /// that failed to start up
+    #[arg(long = "service-min-backoff-period", default_value = "0")]
+    service_min_backoff_period: DurationProxy,
+
+    /// The maximum period of time in seconds to wait before attempting to restart a service
+    /// that failed to start up
+    #[arg(long = "service-max-backoff-period", default_value = "0")]
+    service_max_backoff_period: DurationProxy,
+
+    /// The period of time in seconds to wait before assuming that a service started up
+    /// successfully after a restart
+    #[arg(long = "service-restart-cooldown-period", default_value = "300")]
+    service_restart_cooldown_period: DurationProxy,
+
+    /// The private key for HTTP Gateway TLS encryption
+    ///
+    /// Read the private key from KEY_FILE. This should be an RSA private key or PKCS8-encoded
+    /// private key in PEM format.
+    #[arg(long = "key")]
+    key_file: Option<PathBuf>,
+
+    /// The server certificates for HTTP Gateway TLS encryption
+    ///
+    /// Read server certificates from CERT_FILE. This should contain PEM-format certificates in
+    /// the right order. The first certificate should certify KEY_FILE. The last should be a
+    /// root CA.
+    #[arg(long = "certs", requires = "key_file")]
+    cert_file: Option<PathBuf>,
+
+    /// The CA certificate for HTTP Gateway TLS encryption
+    ///
+    /// Read the CA certificate from CA_CERT_FILE. This should contain PEM-format certificate that
+    /// can be used to validate client requests
+    #[arg(long = "ca-certs", requires_all = &["cert_file", "key_file"])]
+    ca_cert_file: Option<PathBuf>,
+
+    /// Load a Habitat package as part of the Supervisor startup
+    ///
+    /// The package can be specified by a package identifier (ex: core/redis) or filepath to a
+    /// Habitat artifact (ex: /home/core-redis-3.0.7-21120102031201-x86_64-linux.hart).    #[arg()]
+    pkg_ident_or_artifact: Option<InstallSource>,
+
+    /// Verbose output showing file and line/column numbers
+    #[arg(short = 'v')]
+    verbose:  bool,
+    /// Disable ANSI color.
+
+    #[arg(long = "no-color")]
+    no_color: bool,
+
+    /// Use structured JSON logging for the Supervisor
+    ///
+    /// This option also sets NO_COLOR.
+    #[arg(long = "json-logging")]
+    json_logging: bool,
+
+    /// The IPv4 address to use as the `sys.ip` template variable
+    ///
+    /// If this argument is not set, the supervisor tries to dynamically determine an IP address.
+    /// If that fails, the supervisor defaults to using `127.0.0.1`.
+    #[arg(long = "sys-ip-address")]
+    sys_ip_address: Option<IpAddr>,
+
+    /// The name of the application for event stream purposes
+    ///
+    /// This will be attached to all events generated by this Supervisor.
+    #[arg(long = "event-stream-application", value_parser = clap::builder::NonEmptyStringValueParser::new())]
+    event_stream_application: Option<String>,
+
+    /// The name of the environment for event stream purposes
+    ///
+    /// This will be attached to all events generated by this Supervisor.
+    #[arg(long = "event-stream-environment", value_parser = clap::builder::NonEmptyStringValueParser::new())]
+    event_stream_environment: Option<String>,
+
+    /// Event stream connection timeout before exiting the Supervisor
+    ///
+    /// Set to '0' to immediately start the Supervisor and continue running regardless of the
+    /// initial connection status.
+    #[arg(long = "event-stream-connect-timeout", env = EventStreamConnectMethod::ENVVAR, default_value = "0")]
+    event_stream_connect_timeout: EventStreamConnectMethod,
+
+    /// The authentication token for connecting the event stream to Chef Automate
+    #[arg(long = "event-stream-token", env = EventStreamToken::ENVVAR)]
+    event_stream_token: Option<EventStreamToken>,
+
+    /// The event stream connection url used to send events to Chef Automate
+    ///
+    /// This enables the event stream and requires EVENT_STREAM_APPLICATION,
+    /// EVENT_STREAM_ENVIRONMENT, and EVENT_STREAM_TOKEN also be set.
+    #[arg(long = "event-stream-url", 
+            requires_all = &["event_stream_application", 
+                            "event_stream_environment",
+                            "event_stream_token"])]
+    event_stream_url: Option<EventStreamAddress>,
+
+    /// The name of the site where this Supervisor is running for event stream purposes
+    #[arg(long = "event-stream-site", value_parser = clap::builder::NonEmptyStringValueParser::new())]
+    event_stream_site: Option<String>,
+
+    /// An arbitrary key-value pair to add to each event generated by this Supervisor
+    #[arg(long = "event-meta")]
+    event_meta: Vec<EventStreamMetaPair>,
+
+    //// The path to Chef Automate's event stream certificate used to establish a TLS connection
+    /// The certificate should be in PEM format.
+    #[arg(long = "event-stream-server-certificate")]
+    event_stream_server_certificate: Option<EventStreamServerCertificate>,
+
+    /// Automatically cleanup old packages
+    ///
+    /// The Supervisor will automatically cleanup old packages only keeping the
+    /// KEEP_LATEST_PACKAGES latest packages. If this argument is not specified, no
+    /// automatic package cleanup is performed.
+    #[arg(long = "keep-latest-packages", env = "HAB_KEEP_LATEST_PACKAGES")]
+    keep_latest_packages: Option<usize>,
+
+    /// Paths to files or directories of service config files to load on startup
+    ///
+    /// See `hab svc bulkload --help` for details
+    #[arg(long = "svc-config-paths",
+                default_value = DEFAULT_SVC_CONFIG_DIR,
+                hide = !FEATURE_FLAGS.contains(FeatureFlag::SERVICE_CONFIG_FILES))]
+    svc_config_paths: Vec<PathBuf>,
+
+    #[command(flatten)]
+    pub shared_load: SharedLoad,
+}
+
+impl SupRunOptions {
+    #[cfg(not(target_os = "macos"))]
+    pub(crate) async fn do_run(&self, ui: &mut UI) -> HabResult<()> {
+        // Skip "hab" and "sup" so we pass only the subcommand + its args.
+        let args: Vec<OsString> = env::args_os().skip(2).collect();
+
+        return command::launcher::start_v4(ui, self.clone(), &args).await;
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(crate) async fn do_run(&self, _ui: &mut UI) -> HabResult<()> { Ok(()) }
+}

--- a/components/hab/src/cli_v4/sup/term.rs
+++ b/components/hab/src/cli_v4/sup/term.rs
@@ -1,0 +1,33 @@
+// To handle basic commands such as launching a shell or terminating
+
+use clap_v4 as clap;
+
+use clap::Parser;
+
+use crate::error::Result as HabResult;
+use habitat_common::ui::UI;
+
+use std::ffi::OsString;
+
+#[cfg(not(target_os = "macos"))]
+use crate::command;
+
+/// Gracefully terminate the Habitat Supervisor and all of its running services
+#[derive(Debug, Clone, Parser)]
+#[command(arg_required_else_help = true,
+    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                     {usage}\n\n{all-args}\n")]
+pub(crate) struct SupTermCommand {
+    #[arg()]
+    args: Vec<OsString>,
+}
+
+impl SupTermCommand {
+    #[cfg(not(target_os = "macos"))]
+    pub(super) async fn execute(&self, ui: &mut UI) -> HabResult<()> {
+        return command::sup::start(ui, &self.args).await;
+    }
+
+    #[cfg(target_os = "macos")]
+    pub(super) async fn execute(&self, _ui: &mut UI) -> HabResult<()> { Ok(()) }
+}

--- a/components/hab/src/cli_v4/sup/term.rs
+++ b/components/hab/src/cli_v4/sup/term.rs
@@ -14,9 +14,8 @@ use crate::command;
 
 /// Gracefully terminate the Habitat Supervisor and all of its running services
 #[derive(Debug, Clone, Parser)]
-#[command(arg_required_else_help = true,
-    help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
-                     {usage}\n\n{all-args}\n")]
+#[command(help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+                           {usage}\n\n{all-args}\n")]
 pub(crate) struct SupTermCommand {
     #[arg()]
     args: Vec<OsString>,
@@ -25,7 +24,9 @@ pub(crate) struct SupTermCommand {
 impl SupTermCommand {
     #[cfg(not(target_os = "macos"))]
     pub(super) async fn execute(&self, ui: &mut UI) -> HabResult<()> {
-        return command::sup::start(ui, &self.args).await;
+        let mut args = vec!["term".into()];
+        args.extend(self.args.clone());
+        return command::sup::start(ui, &args).await;
     }
 
     #[cfg(target_os = "macos")]

--- a/components/hab/src/cli_v4/utils.rs
+++ b/components/hab/src/cli_v4/utils.rs
@@ -6,31 +6,56 @@
 
 use clap_v4 as clap;
 
-use std::path::PathBuf;
-
+use crate::error::Error;
 use clap::Parser;
 use lazy_static::lazy_static;
+use rustls::pki_types::DnsName;
 use url::Url;
 
-use habitat_common::cli_config::CliConfig;
+use habitat_common::{cli_config::CliConfig,
+                     types::{GossipListenAddr,
+                             ListenCtlAddr,
+                             ResolvedListenCtlAddr}};
 
 use habitat_core::{crypto::CACHE_KEY_PATH_ENV_VAR,
                    env as hcore_env,
                    fs::CACHE_KEY_PATH,
+                   os::process::ShutdownTimeout,
+                   service::ServiceBind,
                    url::{BLDR_URL_ENVVAR,
                          DEFAULT_BLDR_URL},
+                   ChannelIdent,
                    AUTH_TOKEN_ENVVAR};
+
+use habitat_sup_protocol::types::UpdateCondition;
 
 use crate::error::{Error as HabError,
                    Result as HabResult};
 
+use std::{convert::TryFrom,
+          fmt,
+          net::SocketAddr,
+          num::ParseIntError,
+          path::PathBuf,
+          str::FromStr,
+          time::Duration};
+
+use serde::{Deserialize,
+            Serialize};
+
 lazy_static! {
     pub(crate) static ref CACHE_KEY_PATH_DEFAULT: String =
         CACHE_KEY_PATH.to_string_lossy().to_string();
+    static ref CHANNEL_IDENT_DEFAULT: String = ChannelIdent::default().to_string();
+    static ref GROUP_DEFAULT: String = String::from("default");
+}
+
+impl GROUP_DEFAULT {
+    fn get() -> String { GROUP_DEFAULT.clone() }
 }
 
 #[derive(Debug, Clone, Parser)]
-pub(crate) struct CacheKeyPath {
+pub struct CacheKeyPath {
     /// Cache for creating and searching for encryption keys
     #[arg(long = "cache-key-path",
                 env = CACHE_KEY_PATH_ENV_VAR,
@@ -110,6 +135,237 @@ impl AuthToken {
             Err(_) => None,
         }
     }
+}
+
+#[derive(Debug, Clone, Parser)]
+pub(crate) struct RemoteSup {
+    /// Address to a remote Supervisor's Control Gateway
+    #[arg(name = "REMOTE_SUP",
+                long = "remote-sup",
+                short = 'r',
+                default_value = ListenCtlAddr::default_as_str())]
+    remote_sup: Option<ResolvedListenCtlAddr>,
+}
+
+impl RemoteSup {
+    pub fn inner(&self) -> Option<&ResolvedListenCtlAddr> { self.remote_sup.as_ref() }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(from = "u64", into = "u64")]
+pub struct DurationProxy(Duration);
+
+impl From<DurationProxy> for u64 {
+    fn from(d: DurationProxy) -> Self { d.0.as_secs() }
+}
+
+impl From<u64> for DurationProxy {
+    fn from(n: u64) -> Self { Self(Duration::from_secs(n)) }
+}
+
+impl From<DurationProxy> for Duration {
+    fn from(d: DurationProxy) -> Self { d.0 }
+}
+
+impl From<Duration> for DurationProxy {
+    fn from(d: Duration) -> Self { Self(d) }
+}
+
+impl FromStr for DurationProxy {
+    type Err = ParseIntError;
+
+    // fn from_str(s: &str) -> std::result::Result<DurationProxy, std::num::ParseIntError> {
+    // Ok(s.parse::<u64>()?.into()) }
+    fn from_str(s: &str) -> Result<Self, Self::Err> { Ok(s.parse::<u64>()?.into()) }
+}
+
+impl fmt::Display for DurationProxy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", u64::from(self.clone()))
+    }
+}
+
+/// A wrapper around `SocketAddr`
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct SocketAddrProxy(SocketAddr);
+
+impl TryFrom<String> for SocketAddrProxy {
+    type Error = Error;
+
+    // fn try_from(value: String) -> HabResult<Self> {
+    // let (_, addr) = habitat_common::util::resolve_socket_addr_with_default_port(
+    // value,
+    // GossipListenAddr::DEFAULT_PORT,
+    // )?;
+    // Ok(SocketAddrProxy(addr))
+    // }
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        let (_, addr) = habitat_common::util::resolve_socket_addr_with_default_port(
+            value,
+            GossipListenAddr::DEFAULT_PORT,
+        )?;
+        Ok(SocketAddrProxy(addr))
+    }
+}
+
+impl From<&SocketAddrProxy> for SocketAddr {
+    fn from(s: &SocketAddrProxy) -> Self { s.0 }
+}
+
+impl From<&SocketAddr> for SocketAddrProxy {
+    fn from(s: &SocketAddr) -> Self { Self(*s) }
+}
+
+impl From<&SocketAddrProxy> for String {
+    fn from(s: &SocketAddrProxy) -> Self { toml::to_string(&s.0).unwrap() }
+}
+
+impl FromStr for SocketAddrProxy {
+    //     type Err = HabError;
+    //
+    // fn from_str(s: &str) -> Result<SocketAddrProxy, HabError> {
+    // let (_, addr) = habitat_common::util::resolve_socket_addr_with_default_port(
+    // s,
+    // GossipListenAddr::DEFAULT_PORT,
+    // )?;
+    // Ok((&addr).into())
+    // }
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<SocketAddrProxy, Error> {
+        let (_, addr) = habitat_common::util::resolve_socket_addr_with_default_port(
+            s,
+            GossipListenAddr::DEFAULT_PORT,
+        )?;
+        Ok((&addr).into())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub(crate) struct SubjectAlternativeName(String);
+
+impl FromStr for SubjectAlternativeName {
+    //  type Err = HabError;
+    //
+    // fn from_str(s: &str) -> HabResult<Self> { Ok(SubjectAlternativeName(s.to_string())) }
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> { Ok(SubjectAlternativeName(s.to_string())) }
+}
+
+impl std::fmt::Display for SubjectAlternativeName {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", AsRef::<str>::as_ref(&self.0))
+    }
+}
+
+impl SubjectAlternativeName {
+    pub fn dns_name(&self) -> Result<DnsName, Error> {
+        DnsName::try_from(self.0.to_owned()).map_err(|_| Error::InvalidDnsName(self.0.to_owned()))
+    }
+}
+
+habitat_core::impl_try_from_string_and_into_string!(SubjectAlternativeName);
+
+fn health_check_interval_default() -> u64 { 30 }
+
+#[derive(Debug, Clone, Parser, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+#[command(disable_version_flag = true, rename_all = "screamingsnake")]
+pub(crate) struct SharedLoad {
+    /// Receive updates from the specified release channel
+    #[arg(long = "channel", default_value = &*CHANNEL_IDENT_DEFAULT)]
+    #[serde(default)]
+    pub channel: ChannelIdent,
+
+    /// Specify an alternate Builder endpoint. If not specified, the value will be taken from
+    /// the HAB_BLDR_URL environment variable if defined. (default: https://bldr.habitat.sh)
+    // TODO (DM): This should probably use `env` and `default_value`
+    // TODO (DM): serde nested flattens do no work https://github.com/serde-rs/serde/issues/1547
+    #[arg(long = "url", short = 'u')]
+    bldr_url: Option<Url>,
+
+    /// The service group with shared config and topology
+    #[arg(long = "group", default_value = &*GROUP_DEFAULT)]
+    #[serde(default = "GROUP_DEFAULT::get")]
+    group: String,
+
+    /// Service topology
+    #[arg(long = "topology", short = 't')]
+    topology: Option<habitat_sup_protocol::types::Topology>,
+
+    /// The update strategy
+    #[arg(long = "strategy", short = 's', default_value = "none")]
+    #[serde(default)]
+    strategy: habitat_sup_protocol::types::UpdateStrategy,
+
+    /// The condition dictating when this service should update
+    ///
+    /// latest: Runs the latest package that can be found in the configured channel and local
+    /// packages.
+    ///
+    /// track-channel: Always run what is at the head of a given channel. This enables service
+    /// rollback where demoting a package from a channel will cause the package to rollback to
+    /// an older version of the package. A ramification of enabling this condition is packages
+    /// newer than the package at the head of the channel will be automatically uninstalled
+    /// during a service rollback.
+    #[arg(long = "update-condition",
+                default_value = UpdateCondition::Latest.as_str())]
+    #[serde(default)]
+    update_condition: UpdateCondition,
+
+    /// One or more service groups to bind to a configuration
+    #[arg(long = "bind")]
+    #[serde(default)]
+    bind: Vec<ServiceBind>,
+
+    /// Governs how the presence or absence of binds affects service startup
+    ///
+    /// strict: blocks startup until all binds are present.
+    #[arg(long = "binding-mode", default_value = "strict")]
+    #[serde(default)]
+    binding_mode: habitat_sup_protocol::types::BindingMode,
+
+    /// The interval in seconds on which to run health checks
+    // We would prefer to use `HealthCheckInterval`. However, `HealthCheckInterval` uses a map based
+    // serialization format. We want to allow the user to simply specify a `u64` to be consistent
+    // with the CLI, but we cannot change the serialization because the spec file depends on the map
+    // based format.
+    #[arg(long = "health-check-interval", default_value = "30")]
+    #[serde(default = "health_check_interval_default")]
+    health_check_interval: u64,
+
+    /// The delay in seconds after sending the shutdown signal to wait before killing the service
+    /// process
+    ///
+    /// The default value can be set in the packages plan file.
+    #[arg(long = "shutdown-timeout")]
+    shutdown_timeout: Option<ShutdownTimeout>,
+
+    #[cfg(target_os = "windows")]
+    /// Password of the service user
+    #[arg(long = "password")]
+    password: Option<String>,
+
+    // TODO (DM): This flag can eventually be removed.
+    // See https://github.com/habitat-sh/habitat/issues/7339
+    /// DEPRECATED
+    #[arg(long = "application", short = 'a', hide = true)]
+    #[serde(skip)]
+    application: Vec<String>,
+
+    // TODO (DM): This flag can eventually be removed.
+    // See https://github.com/habitat-sh/habitat/issues/7339
+    /// DEPRECATED
+    #[arg(long = "environment", short = 'e', hide = true)]
+    #[serde(skip)]
+    environment: Vec<String>,
+
+    /// Use the package config from this path rather than the package itself
+    #[arg(long = "config-from")]
+    config_from: Option<PathBuf>,
 }
 
 #[cfg(test)]

--- a/components/hab/src/command/launcher.rs
+++ b/components/hab/src/command/launcher.rs
@@ -19,12 +19,46 @@ use std::{ffi::OsString,
 #[cfg(feature = "v2")]
 use crate::cli::hab::sup::SupRun;
 
+#[cfg(feature = "v4")]
+use crate::cli_v4::sup::sup_run::SupRunOptions;
+
 const LAUNCH_CMD: &str = "hab-launch";
 const LAUNCH_CMD_ENVVAR: &str = "HAB_LAUNCH_BINARY";
 const LAUNCH_PKG_IDENT: &str = "core/hab-launcher";
 
 #[cfg(feature = "v2")]
 pub async fn start(ui: &mut UI, sup_run: SupRun, args: &[OsString]) -> Result<()> {
+    init()?;
+    let channel = sup_run.shared_load.channel;
+    if henv::var(SUP_CMD_ENVVAR).is_err() {
+        let version: Vec<&str> = VERSION.split('/').collect();
+        exec::command_from_min_pkg_with_channel(ui,
+                                                SUP_CMD,
+                                                &PackageIdent::from_str(&format!("{}/{}",
+                                                                                 SUP_PKG_IDENT,
+                                                                                 version[0]))?,
+                                                channel.clone()).await?;
+    }
+    let command = match henv::var(LAUNCH_CMD_ENVVAR) {
+        Ok(command) => PathBuf::from(command),
+        Err(_) => {
+            init()?;
+            exec::command_from_min_pkg_with_channel(ui,
+                                                    LAUNCH_CMD,
+                                                    &PackageIdent::from_str(LAUNCH_PKG_IDENT)?,
+                                                    channel).await?
+        }
+    };
+    if let Some(cmd) = find_command(&command) {
+        process::become_command(cmd, args)?;
+        Ok(())
+    } else {
+        Err(Error::ExecCommandNotFound(command))
+    }
+}
+
+#[cfg(feature = "v4")]
+pub(crate) async fn start_v4(ui: &mut UI, sup_run: SupRunOptions, args: &[OsString]) -> Result<()> {
     init()?;
     let channel = sup_run.shared_load.channel;
     if henv::var(SUP_CMD_ENVVAR).is_err() {


### PR DESCRIPTION
This PR adds clap v4 the hab sup command to clapv4.

The support for "hab-sup" command which is an extension of this will be handled in a separate PR.