### PR TITLE
remove HAB_ORIGIN form install.sh

### DIFF
--- a/components/hab/install.sh
+++ b/components/hab/install.sh
@@ -10,9 +10,7 @@ if [ -n "${DEBUG:-}" ]; then set -x; fi
 readonly pcio_root="https://packages.chef.io/files"
 export HAB_LICENSE="accept-no-persist"
 
-# Set the default origin to 'core'. This can be overridden by the HAB_ORIGIN environment variable or the -o flag.
-# Once we're ready for release, consider changing the default to 'chef'.
-origin="${HAB_ORIGIN:-core}"
+origin="core"
 
 # This is the main function that sets up the Habitat environment on macOS.
 # It creates, mounts, and configures a designated volume (Habitat Store) with the necessary settings,


### PR DESCRIPTION
We’ve started moving Habitat components into the chef origin and introduced the `HAB_ORIGIN` environment variable to control which origin to use.

However, this change could break existing pipelines. Typically, the environment is set before Habitat itself is installed. That means the installer would try to fetch Habitat from the origin specified in the env variable—likely before it exists—causing the installation to fail.

This PR removes the `HAB_ORIGIN` environment variable so that it always defaults to the core origin. If we find value in making the origin configurable again in the future, we can introduce a different environment variable specifically for that purpose.