### PR TITLE
publish aarch64-linux docker image

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -412,6 +412,14 @@ steps:
         linux:
           privileged: true
 
+  - label: ":docker: Upload containers (aarch64) to Docker Hub"
+    agents:
+      queue: default-privileged-aarch64
+    command: .expeditor/scripts/release_habitat/dockerhub_upload.sh
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    env:
+      BUILD_PKG_TARGET: "aarch64-linux"
+
   - label: ":docker: :windows: Upload windows 2016 container to Docker Hub"
     if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
     command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1

--- a/.expeditor/scripts/release_habitat/dockerhub_upload.sh
+++ b/.expeditor/scripts/release_habitat/dockerhub_upload.sh
@@ -45,6 +45,7 @@ trap 'rm -f $HOME/.docker/config.json' INT TERM EXIT
 
     docker build \
            --build-arg PACKAGE_TARGET="${target}" \
+           --build-arg HAB_AUTH_TOKEN="${HAB_AUTH_TOKEN}" \
            --tag "habitat-${target}:hab-base" .
 
     docker build \
@@ -52,6 +53,7 @@ trap 'rm -f $HOME/.docker/config.json' INT TERM EXIT
            --build-arg BLDR_URL="${bldr_url}" \
            --build-arg BLDR_CHANNEL="${channel}" \
            --build-arg PACKAGE_TARGET="${target}" \
+           --build-arg HAB_AUTH_TOKEN="${HAB_AUTH_TOKEN}" \
            --no-cache \
            --tag "${image_name_with_tag}" \
            ./default

--- a/.expeditor/scripts/release_habitat/dockerhub_upload.sh
+++ b/.expeditor/scripts/release_habitat/dockerhub_upload.sh
@@ -33,7 +33,9 @@ docker login \
   --username="${DOCKER_LOGIN_USER}" \
   --password="${DOCKER_LOGIN_PASSWORD}"
 
-trap 'rm -f $HOME/.docker/config.json' INT TERM EXIT
+# Create the token file securely
+echo "$HAB_AUTH_TOKEN" > ./components/rootless_studio/hab_auth_token.txt
+trap 'rm -f $HOME/.docker/config.json ./components/rootless_studio/hab_auth_token.txt' INT TERM EXIT
 
 (
     cd ./components/rootless_studio
@@ -44,16 +46,16 @@ trap 'rm -f $HOME/.docker/config.json' INT TERM EXIT
     # actually is.
 
     docker build \
+           --secret id=hab_auth_token,src=hab_auth_token.txt \
            --build-arg PACKAGE_TARGET="${target}" \
-           --build-arg HAB_AUTH_TOKEN="${HAB_AUTH_TOKEN}" \
            --tag "habitat-${target}:hab-base" .
 
     docker build \
+           --secret id=hab_auth_token,src=hab_auth_token.txt \
            --build-arg HAB_LICENSE="accept-no-persist" \
            --build-arg BLDR_URL="${bldr_url}" \
            --build-arg BLDR_CHANNEL="${channel}" \
            --build-arg PACKAGE_TARGET="${target}" \
-           --build-arg HAB_AUTH_TOKEN="${HAB_AUTH_TOKEN}" \
            --no-cache \
            --tag "${image_name_with_tag}" \
            ./default

--- a/components/rootless_studio/Dockerfile
+++ b/components/rootless_studio/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine
 ARG HAB_VERSION=
 ARG PACKAGE_TARGET
+ARG HAB_AUTH_TOKEN
 RUN set -ex \
   && apk add --no-cache --virtual .build-deps \
     ca-certificates \
@@ -10,6 +11,8 @@ RUN set -ex \
   \
   && cd /tmp \
   && wget https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
+  && export HAB_AUTH_TOKEN="${HAB_AUTH_TOKEN}" \
   && bash install.sh -t ${PACKAGE_TARGET} -c acceptance -o chef \
+  && unset HAB_AUTH_TOKEN \
   && rm -rf install.sh /hab/cache /root/.wget-hsts /root/.gnupg \
   && apk del .build-deps

--- a/components/rootless_studio/Dockerfile
+++ b/components/rootless_studio/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine
 ARG HAB_VERSION=
 ARG PACKAGE_TARGET
-ARG HAB_AUTH_TOKEN
-RUN set -ex \
+RUN --mount=type=secret,id=hab_auth_token \
+  set -ex \
   && apk add --no-cache --virtual .build-deps \
     ca-certificates \
     gnupg \
@@ -11,7 +11,7 @@ RUN set -ex \
   \
   && cd /tmp \
   && wget https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.sh \
-  && export HAB_AUTH_TOKEN="${HAB_AUTH_TOKEN}" \
+  && export HAB_AUTH_TOKEN=$(cat /run/secrets/hab_auth_token) \
   && bash install.sh -t ${PACKAGE_TARGET} -c acceptance -o chef \
   && unset HAB_AUTH_TOKEN \
   && rm -rf install.sh /hab/cache /root/.wget-hsts /root/.gnupg \

--- a/components/rootless_studio/default/Dockerfile
+++ b/components/rootless_studio/default/Dockerfile
@@ -1,12 +1,15 @@
 ARG PACKAGE_TARGET
 FROM habitat-${PACKAGE_TARGET}:hab-base as hab
+ARG HAB_AUTH_TOKEN
 ENV PATH=${PATH}:/hab/bin
 ARG BLDR_CHANNEL=stable
 ARG BLDR_URL=https://bldr.habitat.sh
 ARG HAB_LICENSE=no-accept
-RUN hab pkg install --url ${BLDR_URL} --channel ${BLDR_CHANNEL} chef/hab-backline \
+RUN export HAB_AUTH_TOKEN=$HAB_AUTH_TOKEN \
+  && hab pkg install --url ${BLDR_URL} --channel ${BLDR_CHANNEL} chef/hab-backline \
   && hab pkg binlink core/bash -d /hab/bin \
-  && hab pkg binlink chef/hab -d /hab/bin
+  && hab pkg binlink chef/hab -d /hab/bin \
+  && unset HAB_AUTH_TOKEN
 
 FROM scratch
 COPY --from=hab /hab /hab

--- a/components/rootless_studio/default/Dockerfile
+++ b/components/rootless_studio/default/Dockerfile
@@ -1,11 +1,11 @@
 ARG PACKAGE_TARGET
 FROM habitat-${PACKAGE_TARGET}:hab-base as hab
-ARG HAB_AUTH_TOKEN
 ENV PATH=${PATH}:/hab/bin
 ARG BLDR_CHANNEL=stable
 ARG BLDR_URL=https://bldr.habitat.sh
 ARG HAB_LICENSE=no-accept
-RUN export HAB_AUTH_TOKEN=$HAB_AUTH_TOKEN \
+RUN --mount=type=secret,id=hab_auth_token \
+  export HAB_AUTH_TOKEN=$(cat /run/secrets/hab_auth_token) \
   && hab pkg install --url ${BLDR_URL} --channel ${BLDR_CHANNEL} chef/hab-backline \
   && hab pkg binlink core/bash -d /hab/bin \
   && hab pkg binlink chef/hab -d /hab/bin \


### PR DESCRIPTION
This PR includes the following updates:

- Updates Dockerfiles to use BuildKit secrets for securely passing HAB_AUTH_TOKEN.
- Updates the pipeline to support and publish the aarch64-linux Docker image as part of the release process.