### PR TITLE
do not brew install gpung on mac install tests

### DIFF
--- a/.expeditor/scripts/verify/test_install_script.sh
+++ b/.expeditor/scripts/verify/test_install_script.sh
@@ -7,13 +7,6 @@ if ! command -v bats >/dev/null; then
   fi
 fi
 
-if ! command -v gpg >/dev/null; then
-  if [ "$(uname)" = "Darwin" ]; then
-    echo "--- Installing gpg"
-    brew install gnupg
-  fi
-fi
-
 echo "--- Testing install.sh"
 # Bats in chefes/buildkite is a hab-binliked install to the default directory
 # of /bin, but /bin isn't on our path. 


### PR DESCRIPTION
Installing the gnupg tooling on mac takes about 50 minutes on average. As a result, our mac agents are encountering very long wait times. The install tests should pass even without this tooling. Our install scripts will gracefully ignore gpg verification if the tooling is not present. We already have linux tests that have the gnupg tooling and thus test the gpg verification code and this code is exactly the same on linux and mac.