### PR TITLE
Updated `hab supportbundle` to use clap v4

### DIFF
--- a/components/hab/src/cli_v4.rs
+++ b/components/hab/src/cli_v4.rs
@@ -30,6 +30,9 @@ use ring::RingCommand;
 mod user;
 use user::UserCommand;
 
+mod supportbundle;
+use supportbundle::SupportBundleOpts;
+
 pub(crate) mod sup;
 use sup::SupCommand;
 
@@ -103,7 +106,9 @@ enum Hab {
     #[clap(subcommand)]
     Sup(SupCommand),
 
-    SupportBundle,
+    /// Create a tarball of Habitat Supervisor data to send to support
+    #[command(name = "supportbundle")]
+    SupportBundle(SupportBundleOpts),
 
     /// Commands relating to Habitat Services
     #[clap(subcommand)]
@@ -148,9 +153,12 @@ impl Hab {
             Self::Svc(svc_command) => svc_command.do_command(ui, feature_flags).await,
             Self::License(license_command) => license_command.do_command(ui).await,
             Self::Cli(cli_command) => cli_command.do_command(ui, feature_flags).await,
-            Self::Bldr(b) => b.do_command(ui).await,
+            Self::Bldr(bldr_command) => bldr_command.do_command(ui).await,
             Self::Ring(ring_command) => ring_command.do_command(ui).await,
             Self::Plan(plan_command) => plan_command.do_command(ui).await,
+            Self::SupportBundle(support_bundle_command) => {
+                support_bundle_command.do_command(ui).await
+            }
             _ => todo!(),
         }
     }

--- a/components/hab/src/cli_v4/supportbundle.rs
+++ b/components/hab/src/cli_v4/supportbundle.rs
@@ -1,0 +1,19 @@
+use crate::{cli_v4::clap::Args,
+            command::supportbundle::start,
+            error::Result as HabResult};
+use clap_v4 as clap;
+use habitat_common::ui::UI;
+use habitat_core::crypto::init;
+
+#[derive(Debug, Clone, Args)]
+#[command(name = "supportbundle",
+          help_template = "{name} {version} {author-section} \
+                           {about-section}\n{usage-heading}\n{usage}\n\n{all-args}\n")]
+pub(crate) struct SupportBundleOpts;
+
+impl SupportBundleOpts {
+    pub(crate) async fn do_command(&self, ui: &mut UI) -> HabResult<()> {
+        init()?;
+        start(ui)
+    }
+}


### PR DESCRIPTION
[CHEF-23859](https://progresssoftware.atlassian.net/browse/CHEF-23859)

[CHEF-23859]: https://progresssoftware.atlassian.net/browse/CHEF-23859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ