### PR TITLE
fix docker builds in release pipeline

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -407,6 +407,7 @@ steps:
     if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
     env:
       BUILD_PKG_TARGET: "x86_64-linux"
+      DOCKER_BUILDKIT: "1"
     expeditor:
       executor:
         linux:
@@ -419,14 +420,7 @@ steps:
     if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
     env:
       BUILD_PKG_TARGET: "aarch64-linux"
-
-  - label: ":docker: :windows: Upload windows 2016 container to Docker Hub"
-    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
-    command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1
-    expeditor:
-      executor:
-        windows:
-          os_version: 2016
+      DOCKER_BUILDKIT: "1"
 
   - label: ":docker: :windows: Upload windows 2019 container to Docker Hub"
     if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'

--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -428,6 +428,14 @@ steps:
     expeditor:
       executor:
         windows:
+          os_version: 2016
+
+  - label: ":docker: :windows: Upload windows 2019 container to Docker Hub"
+    if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
+    command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1
+    expeditor:
+      executor:
+        windows:
           os_version: 2019
 
   - label: ":docker: :windows: Upload windows 2022 container to Docker Hub"

--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -422,7 +422,7 @@ steps:
       BUILD_PKG_TARGET: "aarch64-linux"
       DOCKER_BUILDKIT: "1"
 
-  - label: ":docker: :windows: Upload windows 2019 container to Docker Hub"
+  - label: ":docker: :windows: Upload windows 2016 container to Docker Hub"
     if: build.creator.name == 'Chef Expeditor' || build.env("UPLOAD_AND_PROMOTE") == 'true'
     command: .expeditor/scripts/release_habitat/publish_docker_studio.ps1
     expeditor:

--- a/.expeditor/scripts/release_habitat/build_docker_image.ps1
+++ b/.expeditor/scripts/release_habitat/build_docker_image.ps1
@@ -92,7 +92,7 @@ RUN `$env:HAB_LICENSE='accept-no-persist'; ``
     # we run it again here without the flag so that its install hook is run in
     # the image. We don't want a windows service installed in the local build
     # environment, but we do want one in the image.
-    &/hab/pkgs/$ident/bin/hab/hab.exe pkg install core/windows-service --channel=$ReleaseChannel --url=$BldrUrl; ``
+    &/hab/pkgs/$ident/bin/hab/hab.exe pkg install chef/windows-service --channel=$ReleaseChannel --url=$BldrUrl; ``
     (Get-Content /hab/svc/windows-service/HabService.dll.config).replace('--no-color', '') | Set-Content /hab/svc/windows-service/HabService.dll.config; ``
     (Get-Content /hab/svc/windows-service/log4net.xml).replace('%date - ', '') | Set-Content /hab/svc/windows-service/log4net.xml; ``
     Remove-Item /hab/cache -Recurse -Force


### PR DESCRIPTION
This includes the following:
* Enables buildkit for the linux docker build required to mount the secrets. 
* Removes the windows 2016 docker build
* Corrects the install of the windows-service in the image by using the chef origin

I'm wondering if we have retired our 2016 windows buildkite agents because the windows 2016 job was waiting forever. I went ahead and just removed this because the docker studios are not used in "production" and are so very old that I seriously questions if anyone would ever use/need it. It seems safe to say we do not support this for a 2.0 release.