### PR TITLE
Add Export Options to hab pkg export tar

### DIFF
--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -164,7 +164,7 @@ impl<'a> BuildSpec<'a> {
 
     async fn install_base_pkgs(&self, ui: &mut UI, rootfs: &Path) -> Result<BasePkgIdents> {
         let hab = self.install_base_pkg(ui, self.hab, rootfs).await?;
-        
+
         let (sup, launcher) = if self.no_hab_sup {
             (None, None)
         } else {

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -68,6 +68,10 @@ pub(crate) struct BuildSpec<'a> {
 
     /// Whether to exclude the hab bin directory from the final bundle
     pub(crate) no_hab_bin: bool,
+
+    /// Excludes supervisor and launcher packages (`chef/hab-sup` and `chef/hab-launcher`)
+    /// from the tar archive. These packages work together to provide service management.
+    no_hab_sup: bool,
 }
 
 impl<'a> BuildSpec<'a> {
@@ -91,7 +95,9 @@ impl<'a> BuildSpec<'a> {
 
                     ident_or_archive: cli.pkg_ident.as_str(),
                     
-                    no_hab_bin: cli.no_hab_bin, }
+                    no_hab_bin: cli.no_hab_bin,
+
+                    no_hab_sup: cli.no_hab_sup, }
     }
 
     /// Creates a `BuildRoot` for the given specification.
@@ -158,8 +164,14 @@ impl<'a> BuildSpec<'a> {
 
     async fn install_base_pkgs(&self, ui: &mut UI, rootfs: &Path) -> Result<BasePkgIdents> {
         let hab = self.install_base_pkg(ui, self.hab, rootfs).await?;
-        let sup = self.install_base_pkg(ui, self.hab_sup, rootfs).await?;
-        let launcher = self.install_base_pkg(ui, self.hab_launcher, rootfs).await?;
+        
+        let (sup, launcher) = if self.no_hab_sup {
+            (None, None)
+        } else {
+            let sup = self.install_base_pkg(ui, self.hab_sup, rootfs).await?;
+            let launcher = self.install_base_pkg(ui, self.hab_launcher, rootfs).await?;
+            (Some(sup), Some(launcher))
+        };
 
         // TODO (CM): at some point this should be considered as
         // something other than a "base" package... replacing busybox
@@ -271,9 +283,9 @@ struct BasePkgIdents {
     /// Installed package identifer for the Habitat CLI package.
     hab:      PackageIdent,
     /// Installed package identifer for the Supervisor package.
-    sup:      PackageIdent,
+    sup:      Option<PackageIdent>,
     /// Installed package identifer for the Launcher package.
-    launcher: PackageIdent,
+    launcher: Option<PackageIdent>,
     /// Installed package identifer for the Busybox package.
     busybox:  Option<PackageIdent>,
 }

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -65,6 +65,9 @@ pub(crate) struct BuildSpec<'a> {
 
     /// The Builder Auth Token to use in the request
     auth: Option<&'a str>,
+
+    /// Whether to exclude the hab bin directory from the final bundle
+    pub(crate) no_hab_bin: bool,
 }
 
 impl<'a> BuildSpec<'a> {
@@ -86,7 +89,9 @@ impl<'a> BuildSpec<'a> {
 
                     auth: cli.bldr_auth_token.as_deref(),
 
-                    ident_or_archive: cli.pkg_ident.as_str(), }
+                    ident_or_archive: cli.pkg_ident.as_str(),
+                    
+                    no_hab_bin: cli.no_hab_bin, }
     }
 
     /// Creates a `BuildRoot` for the given specification.

--- a/components/pkg-export-tar/src/cli.rs
+++ b/components/pkg-export-tar/src/cli.rs
@@ -85,11 +85,14 @@ pub(crate) struct Cli {
     pub(crate) bldr_auth_token: Option<String>,
 
     /// Exclude the hab bin directory from the exported tar
-    /// Excludes /hab/bin (Linux/macOS) or C:\hab\bin (Windows) directory containing 
-    /// convenience copies of hab binaries. Use when you plan to manage binlinks separately.
     #[arg(name = "NO_HAB_BIN",
           long = "no-hab-bin")]
     pub(crate) no_hab_bin: bool,
+
+    /// Exclude supervisor and launcher packages from the exported tar
+    #[arg(name = "NO_HAB_SUP",
+          long = "no-hab-sup")]
+    pub(crate) no_hab_sup: bool,
 
     /// A Habitat package identifier (ex: acme/redis) and/or filepath to a Habitat artifact
     /// (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)

--- a/components/pkg-export-tar/src/cli.rs
+++ b/components/pkg-export-tar/src/cli.rs
@@ -84,6 +84,13 @@ pub(crate) struct Cli {
           env = "HAB_AUTH_TOKEN")]
     pub(crate) bldr_auth_token: Option<String>,
 
+    /// Exclude the hab bin directory from the exported tar
+    /// Excludes /hab/bin (Linux/macOS) or C:\hab\bin (Windows) directory containing 
+    /// convenience copies of hab binaries. Use when you plan to manage binlinks separately.
+    #[arg(name = "NO_HAB_BIN",
+          long = "no-hab-bin")]
+    pub(crate) no_hab_bin: bool,
+
     /// A Habitat package identifier (ex: acme/redis) and/or filepath to a Habitat artifact
     /// (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
     #[arg(name = "PKG_IDENT_OR_ARTIFACT",

--- a/components/pkg-export-tar/src/lib.rs
+++ b/components/pkg-export-tar/src/lib.rs
@@ -40,16 +40,17 @@ async fn export_for_cli_matches(ui: &mut UI, cli: &cli::Cli) -> Result<()> {
 
 async fn export(ui: &mut UI, build_spec: BuildSpec<'_>) -> Result<()> {
     let hab_pkg = build_spec.hab;
+    let no_hab_bin = build_spec.no_hab_bin;
     let build_result = build_spec.create(ui).await?;
     let builder_dir_path = build_result.0.path();
     let pkg_ident = build_result.1;
 
-    tar_command(builder_dir_path, pkg_ident, hab_pkg);
+    tar_command(builder_dir_path, pkg_ident, hab_pkg, no_hab_bin);
     Ok(())
 }
 
 #[allow(unused_must_use)]
-fn tar_command(temp_dir_path: &Path, pkg_ident: PackageIdent, hab_pkg: &str) {
+fn tar_command(temp_dir_path: &Path, pkg_ident: PackageIdent, hab_pkg: &str, no_hab_bin: bool) {
     let tarball_name = format_tar_name(pkg_ident);
 
     let tarball = File::create(tarball_name).unwrap();
@@ -70,12 +71,15 @@ fn tar_command(temp_dir_path: &Path, pkg_ident: PackageIdent, hab_pkg: &str) {
     // that is returned by this command -NSH
     tar_builder.append_dir_all("hab", hab_pkgs_path);
 
-    // Find the path to the hab binary
-    let mut hab_pkg_binary_path = hab_install_path(&hab_package_ident(hab_pkg), &root_fs);
-    hab_pkg_binary_path.push("bin");
+    // Conditionally include the hab binary if not excluded
+    if !no_hab_bin {
+        // Find the path to the hab binary
+        let mut hab_pkg_binary_path = hab_install_path(&hab_package_ident(hab_pkg), &root_fs);
+        hab_pkg_binary_path.push("bin");
 
-    // Append the hab binary to the tar ball
-    tar_builder.append_dir_all("hab/bin", hab_pkg_binary_path);
+        // Append the hab binary to the tar ball
+        tar_builder.append_dir_all("hab/bin", hab_pkg_binary_path);
+    }
 }
 
 fn format_tar_name(ident: PackageIdent) -> String {

--- a/test/end-to-end/test_tar_export.ps1
+++ b/test/end-to-end/test_tar_export.ps1
@@ -25,3 +25,24 @@ Describe "hab pkg export tar core/nginx" {
         Get-Ident chef/hab-launcher $tar | Should -Not -Be $null
     }
 }
+
+Describe "hab pkg export tar core/nginx --no-hab-bin" {
+    hab pkg export tar core/nginx --no-hab-bin --base-pkgs-channel $env:HAB_INTERNAL_BLDR_CHANNEL
+    $tar = Get-Item core-nginx-*.tar.gz
+    It "Creates tarball" {
+        $tar | Should -Not -Be $null
+    }
+    It "Includes nginx" {
+        Get-Ident core/nginx $tar | Should -Not -Be $null
+    }
+    It "Does not include hab binary directory" {
+        $habBinDir = tar --list --file $tar | Where-Object { $_ -like "hab/bin/*" }
+        $habBinDir | Should -Be $null
+    }
+    It "Includes supervisor" {
+        Get-Ident chef/hab-sup $tar | Should -Not -Be $null
+    }
+    It "Includes launcher" {
+        Get-Ident chef/hab-launcher $tar | Should -Not -Be $null
+    }
+}

--- a/test/end-to-end/test_tar_export.ps1
+++ b/test/end-to-end/test_tar_export.ps1
@@ -46,3 +46,24 @@ Describe "hab pkg export tar core/nginx --no-hab-bin" {
         Get-Ident chef/hab-launcher $tar | Should -Not -Be $null
     }
 }
+
+Context "hab pkg export tar core/nginx --no-hab-sup" {
+    hab pkg export tar core/nginx --no-hab-sup --base-pkgs-channel $env:HAB_INTERNAL_BLDR_CHANNEL
+    $tar = Get-Item core-nginx-*.tar.gz
+    It "Creates tarball" {
+        $tar | Should -Not -Be $null
+    }
+    It "Includes nginx" {
+        Get-Ident core/nginx $tar | Should -Not -Be $null
+    }
+    It "Includes hab binary directory" {
+        $habBinDir = tar --list --file $tar | Where-Object { $_ -like "hab/bin/*" }
+        $habBinDir | Should -Not -Be $null
+    }
+    It "Does not include supervisor" {
+        Get-Ident chef/hab-sup $tar | Should -Be $null
+    }
+    It "Does not include launcher" {
+        Get-Ident chef/hab-launcher $tar | Should -Be $null
+    }
+}


### PR DESCRIPTION
This update introduces two new CLI flags to `hab pkg export tar`, giving you more control over what gets included in the final tarball. These options are especially useful for creating minimal or purpose-built bundles.

New Flags
- --no-hab-bin
Excludes the `/hab/bin` (or `C:\hab\bin` on Windows) directory from the exported tarball.

- --no-hab-sup
Excludes the `chef/hab-sup` (Supervisor) and `chef/hab-launcher` packages.
