### PR TITLE
Port hab pkg export tar improvements to v1.6

### DIFF
--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -65,6 +65,13 @@ pub(crate) struct BuildSpec<'a> {
 
     /// The Builder Auth Token to use in the request
     auth: Option<&'a str>,
+
+    /// Whether to exclude the hab bin directory from the final bundle
+    pub(crate) no_hab_bin: bool,
+
+    /// Excludes supervisor and launcher packages (`chef/hab-sup` and `chef/hab-launcher`)
+    /// from the tar archive. These packages work together to provide service management.
+    no_hab_sup: bool,
 }
 
 impl<'a> BuildSpec<'a> {
@@ -86,7 +93,11 @@ impl<'a> BuildSpec<'a> {
 
                     auth: cli.bldr_auth_token.as_deref(),
 
-                    ident_or_archive: cli.pkg_ident.as_str(), }
+                    ident_or_archive: cli.pkg_ident.as_str(),
+
+                    no_hab_bin: cli.no_hab_bin,
+
+                    no_hab_sup: cli.no_hab_sup, }
     }
 
     /// Creates a `BuildRoot` for the given specification.
@@ -153,8 +164,14 @@ impl<'a> BuildSpec<'a> {
 
     async fn install_base_pkgs(&self, ui: &mut UI, rootfs: &Path) -> Result<BasePkgIdents> {
         let hab = self.install_base_pkg(ui, self.hab, rootfs).await?;
-        let sup = self.install_base_pkg(ui, self.hab_sup, rootfs).await?;
-        let launcher = self.install_base_pkg(ui, self.hab_launcher, rootfs).await?;
+
+        let (sup, launcher) = if self.no_hab_sup {
+            (None, None)
+        } else {
+            let sup = self.install_base_pkg(ui, self.hab_sup, rootfs).await?;
+            let launcher = self.install_base_pkg(ui, self.hab_launcher, rootfs).await?;
+            (Some(sup), Some(launcher))
+        };
 
         // TODO (CM): at some point this should be considered as
         // something other than a "base" package... replacing busybox
@@ -266,9 +283,9 @@ struct BasePkgIdents {
     /// Installed package identifer for the Habitat CLI package.
     hab:      PackageIdent,
     /// Installed package identifer for the Supervisor package.
-    sup:      PackageIdent,
+    sup:      Option<PackageIdent>,
     /// Installed package identifer for the Launcher package.
-    launcher: PackageIdent,
+    launcher: Option<PackageIdent>,
     /// Installed package identifer for the Busybox package.
     busybox:  Option<PackageIdent>,
 }

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -69,7 +69,7 @@ pub(crate) struct BuildSpec<'a> {
     /// Whether to exclude the hab bin directory from the final bundle
     pub(crate) no_hab_bin: bool,
 
-    /// Excludes supervisor and launcher packages (`chef/hab-sup` and `chef/hab-launcher`)
+    /// Excludes supervisor and launcher packages (`core/hab-sup` and `core/hab-launcher`)
     /// from the tar archive. These packages work together to provide service management.
     no_hab_sup: bool,
 }

--- a/components/pkg-export-tar/src/cli.rs
+++ b/components/pkg-export-tar/src/cli.rs
@@ -84,6 +84,14 @@ pub(crate) struct Cli {
           env = "HAB_AUTH_TOKEN")]
     pub(crate) bldr_auth_token: Option<String>,
 
+    /// Exclude the hab bin directory from the exported tar
+    #[arg(name = "NO_HAB_BIN", long = "no-hab-bin")]
+    pub(crate) no_hab_bin: bool,
+
+    /// Exclude supervisor and launcher packages from the exported tar
+    #[arg(name = "NO_HAB_SUP", long = "no-hab-sup")]
+    pub(crate) no_hab_sup: bool,
+
     /// A Habitat package identifier (ex: acme/redis) and/or filepath to a Habitat artifact
     /// (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
     #[arg(name = "PKG_IDENT_OR_ARTIFACT",

--- a/test/end-to-end/test_tar_export.ps1
+++ b/test/end-to-end/test_tar_export.ps1
@@ -40,10 +40,10 @@ Describe "hab pkg export tar core/nginx --no-hab-bin" {
         $habBinDir | Should -Be $null
     }
     It "Includes supervisor" {
-        Get-Ident chef/hab-sup $tar | Should -Not -Be $null
+        Get-Ident core/hab-sup $tar | Should -Not -Be $null
     }
     It "Includes launcher" {
-        Get-Ident chef/hab-launcher $tar | Should -Not -Be $null
+        Get-Ident core/hab-launcher $tar | Should -Not -Be $null
     }
 }
 
@@ -61,9 +61,9 @@ Context "hab pkg export tar core/nginx --no-hab-sup" {
         $habBinDir | Should -Not -Be $null
     }
     It "Does not include supervisor" {
-        Get-Ident chef/hab-sup $tar | Should -Be $null
+        Get-Ident core/hab-sup $tar | Should -Be $null
     }
     It "Does not include launcher" {
-        Get-Ident chef/hab-launcher $tar | Should -Be $null
+        Get-Ident core/hab-launcher $tar | Should -Be $null
     }
 }

--- a/test/end-to-end/test_tar_export.ps1
+++ b/test/end-to-end/test_tar_export.ps1
@@ -25,3 +25,45 @@ Describe "hab pkg export tar core/nginx" {
         Get-Ident hab-launcher $tar | Should -Not -Be $null
     }
 }
+
+Describe "hab pkg export tar core/nginx --no-hab-bin" {
+    hab pkg export tar core/nginx --no-hab-bin --base-pkgs-channel $env:HAB_INTERNAL_BLDR_CHANNEL
+    $tar = Get-Item core-nginx-*.tar.gz
+    It "Creates tarball" {
+        $tar | Should -Not -Be $null
+    }
+    It "Includes nginx" {
+        Get-Ident core/nginx $tar | Should -Not -Be $null
+    }
+    It "Does not include hab binary directory" {
+        $habBinDir = tar --list --file $tar | Where-Object { $_ -like "hab/bin/*" }
+        $habBinDir | Should -Be $null
+    }
+    It "Includes supervisor" {
+        Get-Ident chef/hab-sup $tar | Should -Not -Be $null
+    }
+    It "Includes launcher" {
+        Get-Ident chef/hab-launcher $tar | Should -Not -Be $null
+    }
+}
+
+Context "hab pkg export tar core/nginx --no-hab-sup" {
+    hab pkg export tar core/nginx --no-hab-sup --base-pkgs-channel $env:HAB_INTERNAL_BLDR_CHANNEL
+    $tar = Get-Item core-nginx-*.tar.gz
+    It "Creates tarball" {
+        $tar | Should -Not -Be $null
+    }
+    It "Includes nginx" {
+        Get-Ident core/nginx $tar | Should -Not -Be $null
+    }
+    It "Includes hab binary directory" {
+        $habBinDir = tar --list --file $tar | Where-Object { $_ -like "hab/bin/*" }
+        $habBinDir | Should -Not -Be $null
+    }
+    It "Does not include supervisor" {
+        Get-Ident chef/hab-sup $tar | Should -Be $null
+    }
+    It "Does not include launcher" {
+        Get-Ident chef/hab-launcher $tar | Should -Be $null
+    }
+}


### PR DESCRIPTION
This update introduces two new CLI flags to `hab pkg export` tar, giving you more control over what gets included in the final tarball. These options are especially useful for creating minimal or purpose-built bundles.

**New Flags**

- --no-hab-bin
Excludes the `/hab/bin` (or `C:\hab\bin` on Windows) directory from the exported tarball.

- --no-hab-sup
Excludes the `core/hab-sup` (Supervisor) and `core/hab-launcher` packages.