### PR TITLE
Fix release pipeline - multiple cli fixes

### DIFF
--- a/components/common/src/cli/clap_validators.rs
+++ b/components/common/src/cli/clap_validators.rs
@@ -126,7 +126,7 @@ impl clap_v4::builder::TypedValueParser for FileExistsValueParser {
     }
 }
 
-// TODO: This will be used by `hab config` (this implements the functionality of
+// TODO: This will be used by `hab config`. This implements the functionality of
 // `file_exists_or_stdin` validator in Clap v2.
 /// Struct implementing validator that validates the valie is a valid 'file' or 'stdin'
 #[derive(Clone)]

--- a/components/common/src/cli/clap_validators.rs
+++ b/components/common/src/cli/clap_validators.rs
@@ -77,8 +77,10 @@ impl clap_v4::builder::TypedValueParser for HabPackageInstallSourceValueParser {
 #[derive(Clone)]
 pub struct HabOriginValueParser;
 
+use habitat_core::origin::Origin;
+
 impl clap_v4::builder::TypedValueParser for HabOriginValueParser {
-    type Value = String;
+    type Value = Origin;
 
     fn parse_ref(&self,
                  cmd: &clap_v4::Command,
@@ -101,7 +103,7 @@ impl clap_v4::builder::TypedValueParser for HabOriginValueParser {
                                                                     result.err().unwrap(),)));
             Err(err)
         } else {
-            Ok(value.to_str().unwrap().to_string())
+            Ok(Origin::from_str(value.to_str().unwrap()).unwrap())
         }
     }
 }

--- a/components/hab/src/cli_v4/pkg/exec.rs
+++ b/components/hab/src/cli_v4/pkg/exec.rs
@@ -2,16 +2,14 @@
 
 use clap_v4 as clap;
 
-use std::{ffi::OsString,
-          path::PathBuf};
-
 use clap::Parser;
 
 use habitat_common::cli::clap_validators::HabPkgIdentValueParser;
 
 use habitat_core::package::PackageIdent;
 
-use crate::{command::pkg::exec,
+use crate::{cli_v4::utils::CommandAndArgs,
+            command::pkg::exec,
             error::Result as HabResult};
 
 #[derive(Debug, Clone, Parser)]
@@ -23,13 +21,8 @@ pub(crate) struct PkgExecOptions {
     #[arg(name = "PKG_IDENT", value_parser = HabPkgIdentValueParser::simple())]
     pkg_ident: PackageIdent,
 
-    /// The command to execute (ex: ls)
-    #[arg(name = "CMD")]
-    cmd: PathBuf,
-
-    /// Arguments to be passed to the command
-    #[arg(name = "ARGS")]
-    args: Vec<String>,
+    #[command(flatten)]
+    cmd: CommandAndArgs,
 }
 
 impl PkgExecOptions {
@@ -37,7 +30,6 @@ impl PkgExecOptions {
         // Required to convert to OsStr
         // TODO: This should be internal implementation detail later on and move to actual command
         // implementation when `v2` is removed
-        let args = self.args.iter().map(Into::into).collect::<Vec<OsString>>();
-        exec::start(&self.pkg_ident, &self.cmd, &args)
+        exec::start(&self.pkg_ident, &self.cmd.cmd, &self.cmd.args)
     }
 }

--- a/components/hab/src/cli_v4/pkg/export.rs
+++ b/components/hab/src/cli_v4/pkg/export.rs
@@ -14,6 +14,11 @@ use crate::{command::pkg::export,
             error::Result as HabResult};
 
 #[derive(Debug, Clone, Args)]
+#[command(trailing_var_arg = true,
+          allow_hyphen_values = true,
+          disable_help_flag = true,
+          disable_help_subcommand = true,
+          disable_version_flag = true)]
 pub(crate) struct PkgExportCommandOptions {
     /// Arguments to be passed to the command
     #[arg(name = "ARGS")]

--- a/components/hab/src/cli_v4/pkg/hash.rs
+++ b/components/hab/src/cli_v4/pkg/hash.rs
@@ -2,7 +2,8 @@
 
 use clap_v4 as clap;
 
-use std::io::BufRead;
+use std::{io::BufRead,
+          path::PathBuf};
 
 use clap::Parser;
 
@@ -18,8 +19,7 @@ use crate::error::Result as HabResult;
 pub(crate) struct PkgHashOptions {
     /// Filepath to the Habitat Package file
     #[arg(name = "SOURCE", value_parser = FileExistsValueParser)]
-    source: Option<String>, /* TODO: Convert it to more semantic `PathBuf`, when we get rid of
-                             * `clap-v2` functionality, revisit `command::pkg::hash` */
+    source: Option<PathBuf>,
 }
 
 impl PkgHashOptions {
@@ -27,7 +27,7 @@ impl PkgHashOptions {
         match &self.source {
             Some(source) => {
                 // hash single file
-                hash::start(source.as_str())
+                hash::start(source.to_str().expect("Not a valud UTF-8 filename."))
             }
             None => {
                 // read files from stdin

--- a/components/hab/src/cli_v4/pkg/hash.rs
+++ b/components/hab/src/cli_v4/pkg/hash.rs
@@ -13,8 +13,7 @@ use crate::command::pkg::hash;
 use crate::error::Result as HabResult;
 
 #[derive(Debug, Clone, Parser)]
-#[command(arg_required_else_help = true,
-          help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
+#[command(help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
                            {usage}\n\n{all-args}\n")]
 pub(crate) struct PkgHashOptions {
     /// Filepath to the Habitat Package file

--- a/components/hab/src/cli_v4/pkg/header.rs
+++ b/components/hab/src/cli_v4/pkg/header.rs
@@ -20,13 +20,13 @@ use crate::{command::pkg::header,
 pub(crate) struct PkgHeaderOptions {
     /// A path to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
     #[arg(name = "SOURCE", value_parser = FileExistsValueParser)]
-    source: String,
+    source: PathBuf,
 }
 
 impl PkgHeaderOptions {
     pub(super) fn do_header(&self, ui: &mut UI) -> HabResult<()> {
         crypto::init()?;
 
-        header::start(ui, &PathBuf::from(&self.source))
+        header::start(ui, &self.source)
     }
 }

--- a/components/hab/src/cli_v4/pkg/info.rs
+++ b/components/hab/src/cli_v4/pkg/info.rs
@@ -26,16 +26,15 @@ pub(crate) struct PkgInfoOptions {
           action = ArgAction::SetTrue)]
     json: bool,
 
-    // TODO: Move to semantic PathBuf after CLAP-v2 support is removed kept due to Clap V2 quirk
     /// A path to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
     #[arg(name = "SOURCE", value_parser = FileExistsValueParser)]
-    source: String,
+    source: PathBuf,
 }
 
 impl PkgInfoOptions {
     pub(super) fn do_info(&self, ui: &mut UI) -> HabResult<()> {
         crypto::init()?;
 
-        info::start(ui, &Into::<PathBuf>::into(self.source.clone()), self.json)
+        info::start(ui, &self.source, self.json)
     }
 }

--- a/components/hab/src/cli_v4/pkg/sign.rs
+++ b/components/hab/src/cli_v4/pkg/sign.rs
@@ -29,7 +29,6 @@ pub(crate) struct PkgSignOptions {
     #[arg(name = "ORIGIN", long = "origin", env=crate::ORIGIN_ENVVAR, value_parser = HabOriginValueParser)]
     origin: Option<Origin>,
 
-    // TODO: Move to semantic PathBuf after CLAP-v2 support is removed kept due to Clap V2 quirk
     /// A path to a source archive file (ex: /home/acme-redis-3.0.7-21120102031201.tar.xz)
     #[arg(name = "SOURCE", value_parser = FileExistsValueParser)]
     source: PathBuf,

--- a/components/hab/src/cli_v4/pkg/sign.rs
+++ b/components/hab/src/cli_v4/pkg/sign.rs
@@ -32,7 +32,7 @@ pub(crate) struct PkgSignOptions {
     // TODO: Move to semantic PathBuf after CLAP-v2 support is removed kept due to Clap V2 quirk
     /// A path to a source archive file (ex: /home/acme-redis-3.0.7-21120102031201.tar.xz)
     #[arg(name = "SOURCE", value_parser = FileExistsValueParser)]
-    source: String,
+    source: PathBuf,
 
     /// The destination path to the signed Habitat Artifact (ex:
     /// /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)

--- a/components/hab/src/cli_v4/pkg/upload.rs
+++ b/components/hab/src/cli_v4/pkg/upload.rs
@@ -50,7 +50,7 @@ pub(crate) struct PkgUploadOptions {
     /// One or more filepaths to a Habitat Artifact (ex:
     /// /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
     #[arg(name = "HART_FILE", required = true, value_parser = FileExistsValueParser)]
-    hart_file: Vec<String>,
+    hart_file: Vec<PathBuf>,
 
     #[command(flatten)]
     cache_key_path: CacheKeyPath,
@@ -73,7 +73,7 @@ impl PkgUploadOptions {
                           &self.bldr_url.to_string(),
                           &self.channel,
                           &auth_token,
-                          &Into::<PathBuf>::into(hart_file.clone()),
+                          hart_file,
                           self.force,
                           auto_build,
                           &key_cache).await?;

--- a/components/hab/src/cli_v4/pkg/verify.rs
+++ b/components/hab/src/cli_v4/pkg/verify.rs
@@ -21,10 +21,9 @@ use crate::{cli_v4::utils::CacheKeyPath,
           help_template = "{name} {version} {author-section} {about-section} \n{usage-heading} \
                            {usage}\n\n{all-args}\n")]
 pub(crate) struct PkgVerifyOptions {
-    // TODO: Move to semantic PathBuf once Clap-v2 is removed
     /// A path to a Habitat Artifact (ex: /home/acme-redis-3.0.7-21120102031201-x86_64-linux.hart)
     #[arg(name = "SOURCE", value_parser = FileExistsValueParser)]
-    source: String,
+    source: PathBuf,
 
     #[command(flatten)]
     cache_key_path: CacheKeyPath,
@@ -35,6 +34,6 @@ impl PkgVerifyOptions {
         crypto::init()?;
         let key_cache = KeyCache::new::<PathBuf>((&self.cache_key_path).into());
 
-        verify::start(ui, &Into::<PathBuf>::into(self.source.clone()), &key_cache)
+        verify::start(ui, &self.source, &key_cache)
     }
 }

--- a/components/hab/src/cli_v4/utils.rs
+++ b/components/hab/src/cli_v4/utils.rs
@@ -464,6 +464,24 @@ pub struct ExternalCommandArgs {
     pub args: Vec<OsString>,
 }
 
+// For sending command and args to a sub command where args don't have to be preceeded by --
+// For example:
+// `hab pkg exec core/bash bash --login` instead of `hab pkg exec core/bash bash -- --login`
+#[derive(Clone, Debug, Args)]
+#[command(trailing_var_arg = true,
+          allow_hyphen_values = true,
+          disable_help_flag = true,
+          disable_help_subcommand = true,
+          disable_version_flag = true)]
+pub struct CommandAndArgs {
+    /// Command to execute (eg. ls)
+    pub cmd: PathBuf,
+
+    /// Arguments to the command
+    #[arg(value_name = "ARGS", value_parser = clap::builder::OsStringValueParser::new())]
+    pub args: Vec<OsString>,
+}
+
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn valid_origin(val: &str) -> Result<String, String> {
     CoreOrigin::validate(val.to_string()).map(|()| val.to_string())


### PR DESCRIPTION
The release pipeline was failing because the `pkg exec` command would not accept the arguments to the command without a `--` separating the arguments from the command. This caused the `pkg build` to fail for several components.

Modified the `PkgExecOptions` to utilize a flattened `CommandArgs` struct that is treated as the last argument.