### PR TITLE
Harmonizing `Origin` usage across different CLI

### DIFF
--- a/components/common/src/cli/clap_validators.rs
+++ b/components/common/src/cli/clap_validators.rs
@@ -71,43 +71,6 @@ impl clap_v4::builder::TypedValueParser for HabPackageInstallSourceValueParser {
     }
 }
 
-/// Struct implementing validator for Habitat Origin
-///
-/// Validates with `habitat_core::origin::Origin::validate` function.
-#[derive(Clone)]
-pub struct HabOriginValueParser;
-
-use habitat_core::origin::Origin;
-
-impl clap_v4::builder::TypedValueParser for HabOriginValueParser {
-    type Value = Origin;
-
-    fn parse_ref(&self,
-                 cmd: &clap_v4::Command,
-                 arg: Option<&clap_v4::Arg>,
-                 value: &std::ffi::OsStr)
-                 -> Result<Self::Value, clap_v4::Error> {
-        let val = value.to_str().unwrap().to_string();
-
-        let result = habitat_core::origin::Origin::validate(val);
-        if result.is_err() {
-            let mut err =
-                clap_v4::Error::new(clap_v4::error::ErrorKind::ValueValidation).with_cmd(cmd);
-            if let Some(arg) = arg {
-                err.insert(clap_v4::error::ContextKind::InvalidArg,
-                           clap_v4::error::ContextValue::String(arg.to_string()));
-            }
-            err.insert(clap_v4::error::ContextKind::InvalidValue,
-                       clap_v4::error::ContextValue::String(format!("`{}`: {}",
-                                                                    value.to_string_lossy(),
-                                                                    result.err().unwrap(),)));
-            Err(err)
-        } else {
-            Ok(Origin::from_str(value.to_str().unwrap()).unwrap())
-        }
-    }
-}
-
 /// Struct implimenting validator that validates the value is a valid path
 #[derive(Clone)]
 pub struct FileExistsValueParser;

--- a/components/hab/src/cli_v4/bldr/channel/create.rs
+++ b/components/hab/src/cli_v4/bldr/channel/create.rs
@@ -1,8 +1,11 @@
-use crate::{cli_v4::utils::AuthToken,
+use clap_v4 as clap;
+
+use clap::Parser;
+
+use crate::{cli_v4::utils::{origin_param_or_env,
+                            AuthToken},
             command::bldr::channel::create::start,
             error::Result as HabResult};
-use clap::Parser;
-use clap_v4 as clap;
 use habitat_common::ui::UI;
 use habitat_core::{origin::Origin,
                    ChannelIdent};
@@ -24,8 +27,8 @@ pub(crate) struct CreateOpts {
     url: String,
 
     /// Sets the origin to which the channel will belong. Default is from 'HAB_ORIGIN' or cli.toml
-    #[arg(short = 'o', long, value_name = "ORIGIN", env = "HAB_ORIGIN")]
-    origin: Origin,
+    #[arg(short = 'o', long, value_name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Option<Origin>,
 
     /// Authentication token for Builder
     #[command(flatten)]
@@ -34,7 +37,8 @@ pub(crate) struct CreateOpts {
 
 impl CreateOpts {
     pub(crate) async fn do_create(&self, ui: &mut UI) -> HabResult<()> {
+        let origin = origin_param_or_env(&self.origin)?;
         let token = self.token.from_cli_or_config()?;
-        start(ui, &self.url, &token, &self.origin, &self.channel).await
+        start(ui, &self.url, &token, &origin, &self.channel).await
     }
 }

--- a/components/hab/src/cli_v4/bldr/channel/demote.rs
+++ b/components/hab/src/cli_v4/bldr/channel/demote.rs
@@ -1,4 +1,5 @@
-use crate::{cli_v4::utils::AuthToken,
+use crate::{cli_v4::utils::{origin_param_or_env,
+                            AuthToken},
             command::bldr::channel::demote::start,
             error::Result as HabResult};
 use clap::Parser;
@@ -32,17 +33,18 @@ pub(crate) struct DemoteOpts {
     url: String,
 
     /// Sets the origin to which the channel belongs. Default is from 'HAB_ORIGIN' or cli.toml
-    #[arg(short = 'o', long, value_name = "ORIGIN", env = "HAB_ORIGIN", value_parser = clap::value_parser!(Origin))]
-    origin: Origin,
+    #[arg(short = 'o', long, value_name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Option<Origin>,
 }
 
 impl DemoteOpts {
     pub(crate) async fn do_demote(&self, ui: &mut UI) -> HabResult<()> {
+        let origin = origin_param_or_env(&self.origin)?;
         let token = self.token.from_cli_or_config()?;
         start(ui,
               &self.url,
               &token,
-              &self.origin,
+              &origin,
               &self.source_channel,
               &self.target_channel).await
     }

--- a/components/hab/src/cli_v4/bldr/channel/destroy.rs
+++ b/components/hab/src/cli_v4/bldr/channel/destroy.rs
@@ -1,4 +1,5 @@
-use crate::{cli_v4::utils::AuthToken,
+use crate::{cli_v4::utils::{origin_param_or_env,
+                            AuthToken},
             command::bldr::channel::destroy::start,
             error::Result as HabResult};
 use clap::Parser;
@@ -24,8 +25,8 @@ pub(crate) struct DestroyOpts {
     url: String,
 
     /// Sets the origin to which the channel belongs. Default is from 'HAB_ORIGIN' or cli.toml
-    #[arg(short = 'o', long, value_name = "ORIGIN", env = "HAB_ORIGIN", value_parser = clap::value_parser!(Origin))]
-    origin: Origin,
+    #[arg(short = 'o', long, value_name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Option<Origin>,
 
     /// Authentication token for Builder
     #[command(flatten)]
@@ -34,7 +35,8 @@ pub(crate) struct DestroyOpts {
 
 impl DestroyOpts {
     pub(crate) async fn do_destroy(&self, ui: &mut UI) -> HabResult<()> {
+        let origin = origin_param_or_env(&self.origin)?;
         let token = self.token.from_cli_or_config()?;
-        start(ui, &self.url, &token, &self.origin, &self.channel).await
+        start(ui, &self.url, &token, &origin, &self.channel).await
     }
 }

--- a/components/hab/src/cli_v4/bldr/channel/list.rs
+++ b/components/hab/src/cli_v4/bldr/channel/list.rs
@@ -1,7 +1,11 @@
-use crate::{command::bldr::channel::list::start,
-            error::Result as HabResult};
-use clap::Parser;
 use clap_v4 as clap;
+
+use clap::Parser;
+
+use crate::{cli_v4::utils::origin_param_or_env,
+            command::bldr::channel::list::start,
+            error::Result as HabResult};
+
 use habitat_common::ui::UI;
 use habitat_core::origin::Origin;
 
@@ -23,12 +27,13 @@ pub(crate) struct ListOpts {
     url: String,
 
     /// Sets the origin to which the channel belongs. Default is from 'HAB_ORIGIN' or cli.toml
-    #[arg(short = 'o', long, value_name = "ORIGIN", env = "HAB_ORIGIN", value_parser = clap::value_parser!(Origin))]
-    origin: Origin,
+    #[arg(short = 'o', long, value_name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Option<Origin>,
 }
 
 impl ListOpts {
     pub(crate) async fn do_list(&self, ui: &mut UI) -> HabResult<()> {
-        start(ui, &self.url, &self.origin, self.sandbox).await
+        let origin = origin_param_or_env(&self.origin)?;
+        start(ui, &self.url, &origin, self.sandbox).await
     }
 }

--- a/components/hab/src/cli_v4/bldr/channel/promote.rs
+++ b/components/hab/src/cli_v4/bldr/channel/promote.rs
@@ -1,4 +1,5 @@
-use crate::{cli_v4::utils::AuthToken,
+use crate::{cli_v4::utils::{origin_param_or_env,
+                            AuthToken},
             command::bldr::channel::promote::start,
             error::Result as HabResult};
 use clap::Parser;
@@ -32,17 +33,18 @@ pub(crate) struct PromoteOpts {
     url: String,
 
     /// Sets the origin to which the channel belongs. Default is from 'HAB_ORIGIN' or cli.toml
-    #[arg(short = 'o', long, value_name = "ORIGIN", env = "HAB_ORIGIN", value_parser = clap::value_parser!(Origin))]
-    origin: Origin,
+    #[arg(short = 'o', long, value_name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Option<Origin>,
 }
 
 impl PromoteOpts {
     pub(crate) async fn do_promote(&self, ui: &mut UI) -> HabResult<()> {
+        let origin = origin_param_or_env(&self.origin)?;
         let token = self.token.from_cli_or_config()?;
         start(ui,
               &self.url,
               &token,
-              &self.origin,
+              &origin,
               &self.source_channel,
               &self.target_channel).await
     }

--- a/components/hab/src/cli_v4/origin/create.rs
+++ b/components/hab/src/cli_v4/origin/create.rs
@@ -4,14 +4,16 @@ use clap_v4 as clap;
 
 use crate::{api_client::{self,
                          Client},
-            cli_v4::utils::{valid_origin,
-                            AuthToken,
+            cli_v4::utils::{AuthToken,
                             BldrUrl},
             error::{Error,
                     Result as HabResult},
             PRODUCT,
             VERSION};
 use clap::Parser;
+
+use habitat_core::origin::Origin;
+
 use habitat_common::ui::{Status,
                          UIWriter,
                          UI};
@@ -23,8 +25,8 @@ use reqwest::StatusCode;
                            {usage}\n\n{all-args}\n")]
 pub(crate) struct OriginCreateOptions {
     /// The origin to be created
-    #[arg(name = "ORIGIN", value_parser = valid_origin)]
-    origin: String,
+    #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Origin,
 
     #[command(flatten)]
     bldr_url: BldrUrl,
@@ -49,7 +51,7 @@ impl OriginCreateOptions {
         ui.status(Status::Creating, format!("origin {}.", self.origin))?;
 
         // Call create_origin with &str for both args
-        match api_client.create_origin(&self.origin, &token).await {
+        match api_client.create_origin(self.origin.as_ref(), &token).await {
             Ok(_) => {
                 ui.status(Status::Created, format!("origin {}.", self.origin))?;
                 Ok(())

--- a/components/hab/src/cli_v4/origin/delete.rs
+++ b/components/hab/src/cli_v4/origin/delete.rs
@@ -4,14 +4,16 @@ use clap_v4 as clap;
 
 use crate::{api_client::{self,
                          Client},
-            cli_v4::utils::{valid_origin,
-                            AuthToken,
+            cli_v4::utils::{AuthToken,
                             BldrUrl},
             error::{Error,
                     Result as HabResult},
             PRODUCT,
             VERSION};
 use clap::Parser;
+
+use habitat_core::origin::Origin;
+
 use habitat_common::ui::{Status,
                          UIWriter,
                          UI};
@@ -23,8 +25,8 @@ use reqwest::StatusCode;
                            {usage}\n\n{all-args}\n")]
 pub(crate) struct OriginDeleteOptions {
     /// The origin to be deleted
-    #[arg(name = "ORIGIN", value_parser = valid_origin)]
-    origin: String,
+    #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Origin,
 
     #[command(flatten)]
     bldr_url: BldrUrl,
@@ -50,7 +52,7 @@ impl OriginDeleteOptions {
         ui.status(Status::Deleting, format!("origin {}.", self.origin))?;
 
         // Call delete_origin and handle the various outcomes
-        match api_client.delete_origin(&self.origin, &token).await {
+        match api_client.delete_origin(self.origin.as_ref(), &token).await {
             Ok(_) => {
                 ui.status(Status::Deleted, format!("origin {}.", self.origin))?;
                 Ok(())

--- a/components/hab/src/cli_v4/origin/depart.rs
+++ b/components/hab/src/cli_v4/origin/depart.rs
@@ -4,14 +4,16 @@ use clap_v4 as clap;
 
 use crate::{api_client::{self,
                          Client},
-            cli_v4::utils::{valid_origin,
-                            AuthToken,
+            cli_v4::utils::{AuthToken,
                             BldrUrl},
             error::{Error,
                     Result as HabResult},
             PRODUCT,
             VERSION};
 use clap::Parser;
+
+use habitat_core::origin::Origin;
+
 use habitat_common::ui::{Status,
                          UIWriter,
                          UI};
@@ -23,8 +25,8 @@ use reqwest::StatusCode;
                            {usage}\n\n{all-args}\n")]
 pub(crate) struct OriginDepartOptions {
     /// The origin name
-    #[arg(name = "ORIGIN", value_parser = valid_origin)]
-    origin: String,
+    #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Origin,
 
     #[command(flatten)]
     bldr_url: BldrUrl,
@@ -51,7 +53,7 @@ impl OriginDepartOptions {
                   format!("membership from origin {}.", self.origin))?;
 
         // Call the API
-        match api_client.depart_origin(&self.origin, &token).await {
+        match api_client.depart_origin(self.origin.as_ref(), &token).await {
             Ok(_) => {
                 // on success, we swallow any error from ui.status
                 ui.status(Status::Departed, "membership successfully!".to_string())

--- a/components/hab/src/cli_v4/origin/info.rs
+++ b/components/hab/src/cli_v4/origin/info.rs
@@ -3,8 +3,7 @@
 use clap_v4 as clap;
 
 use crate::{api_client::Client,
-            cli_v4::utils::{valid_origin,
-                            AuthToken,
+            cli_v4::utils::{AuthToken,
                             BldrUrl},
             error::{Error,
                     Result as HabResult},
@@ -14,8 +13,9 @@ use clap::Parser;
 use habitat_common::ui::{Status,
                          UIWriter,
                          UI};
-use habitat_core::util::text_render::{PortableText,
-                                      TabularText};
+use habitat_core::{origin::Origin,
+                   util::text_render::{PortableText,
+                                       TabularText}};
 
 #[derive(Debug, Clone, Parser)]
 #[command(disable_version_flag = true,
@@ -23,8 +23,8 @@ use habitat_core::util::text_render::{PortableText,
                            {usage}\n\n{all-args}\n")]
 pub(crate) struct OriginInfoOptions {
     /// The origin to be deleted
-    #[arg(name = "ORIGIN", value_parser = valid_origin)]
-    origin: String,
+    #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Origin,
 
     /// Output will be rendered in json
     #[arg(name = "TO_JSON", short = 'j', long = "json")]
@@ -51,7 +51,7 @@ impl OriginInfoOptions {
         let api_client = Client::new(endpoint, PRODUCT, VERSION, None).map_err(Error::APIClient)?;
 
         // Fetch the origin info
-        match api_client.origin_info(&token, &self.origin).await {
+        match api_client.origin_info(&token, self.origin.as_ref()).await {
             Ok(resp) => {
                 if self.to_json {
                     // JSON output path

--- a/components/hab/src/cli_v4/origin/invitations.rs
+++ b/components/hab/src/cli_v4/origin/invitations.rs
@@ -2,8 +2,7 @@
 
 use clap_v4 as clap;
 
-use crate::{cli_v4::utils::{valid_origin,
-                            AuthToken,
+use crate::{cli_v4::utils::{AuthToken,
                             BldrUrl},
             command::origin::invitations,
             error::{Error,
@@ -11,6 +10,8 @@ use crate::{cli_v4::utils::{valid_origin,
 use clap::Parser;
 
 use habitat_common::ui::UI;
+
+use habitat_core::origin::Origin;
 
 #[derive(Debug, Clone, Parser)]
 #[command(disable_version_flag = true,
@@ -20,8 +21,8 @@ pub(crate) enum OriginInvitationsCommand {
     /// Accept an origin member invitation
     Accept {
         /// The origin name the invitation applies to
-        #[arg(name = "ORIGIN", value_parser = valid_origin)]
-        origin: String,
+        #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+        origin: Origin,
 
         /// The id of the invitation to accept
         #[arg(name = "INVITATION_ID")]
@@ -37,8 +38,8 @@ pub(crate) enum OriginInvitationsCommand {
     /// Ignore an origin member invitation
     Ignore {
         /// The origin name the invitation applies to
-        #[arg(name = "ORIGIN", value_parser = valid_origin)]
-        origin: String,
+        #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+        origin: Origin,
 
         /// The id of the invitation to ignore
         #[arg(name = "INVITATION_ID")]
@@ -63,8 +64,8 @@ pub(crate) enum OriginInvitationsCommand {
     /// List pending invitations for a particular origin. Requires that you are the origin owner
     Pending {
         /// The name of the origin you wish to list invitations for
-        #[arg(name = "ORIGIN", value_parser = valid_origin)]
-        origin: String,
+        #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+        origin: Origin,
 
         #[command(flatten)]
         bldr_url: BldrUrl,
@@ -76,8 +77,8 @@ pub(crate) enum OriginInvitationsCommand {
     /// Rescind an existing origin member invitation
     Rescind {
         /// The origin name the invitation applies to
-        #[arg(name = "ORIGIN", value_parser = valid_origin)]
-        origin: String,
+        #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+        origin: Origin,
 
         /// The id of the invitation to rescind
         #[arg(name = "INVITATION_ID")]
@@ -93,8 +94,8 @@ pub(crate) enum OriginInvitationsCommand {
     /// Send an origin member invitation
     Send {
         /// The origin name the invitation applies to
-        #[arg(name = "ORIGIN", value_parser = valid_origin)]
-        origin: String,
+        #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+        origin: Origin,
 
         /// The account name to invite into the origin
         #[arg(name = "INVITEE_ACCOUNT")]
@@ -126,14 +127,14 @@ impl OriginInvitationsCommand {
                                                bldr_url,
                                                auth_token, } => {
                 let (url, token) = get_token_and_endpoint(bldr_url, auth_token)?;
-                invitations::accept::start(ui, &url, origin, &token, *invitation_id).await
+                invitations::accept::start(ui, &url, origin.as_ref(), &token, *invitation_id).await
             }
             OriginInvitationsCommand::Ignore { origin,
                                                invitation_id,
                                                bldr_url,
                                                auth_token, } => {
                 let (url, token) = get_token_and_endpoint(bldr_url, auth_token)?;
-                invitations::ignore::start(ui, &url, origin, &token, *invitation_id).await
+                invitations::ignore::start(ui, &url, origin.as_ref(), &token, *invitation_id).await
             }
             OriginInvitationsCommand::List { bldr_url,
                                              auth_token, } => {
@@ -144,21 +145,21 @@ impl OriginInvitationsCommand {
                                                 bldr_url,
                                                 auth_token, } => {
                 let (url, token) = get_token_and_endpoint(bldr_url, auth_token)?;
-                invitations::list_pending_origin::start(ui, &url, origin, &token).await
+                invitations::list_pending_origin::start(ui, &url, origin.as_ref(), &token).await
             }
             OriginInvitationsCommand::Rescind { origin,
                                                 invitation_id,
                                                 bldr_url,
                                                 auth_token, } => {
                 let (url, token) = get_token_and_endpoint(bldr_url, auth_token)?;
-                invitations::rescind::start(ui, &url, origin, &token, *invitation_id).await
+                invitations::rescind::start(ui, &url, origin.as_ref(), &token, *invitation_id).await
             }
             OriginInvitationsCommand::Send { origin,
                                              invitee_account,
                                              bldr_url,
                                              auth_token, } => {
                 let (url, token) = get_token_and_endpoint(bldr_url, auth_token)?;
-                invitations::send::start(ui, &url, origin, &token, invitee_account).await
+                invitations::send::start(ui, &url, origin.as_ref(), &token, invitee_account).await
             }
         }
     }

--- a/components/hab/src/cli_v4/origin/secret.rs
+++ b/components/hab/src/cli_v4/origin/secret.rs
@@ -3,7 +3,6 @@
 use clap_v4 as clap;
 
 use crate::{cli_v4::utils::{origin_param_or_env,
-                            valid_origin,
                             AuthToken,
                             BldrUrl,
                             CacheKeyPath},
@@ -38,8 +37,8 @@ pub(crate) enum OriginSecretCommand {
 
         /// The origin for which the secret will be deleted. Default is from 'HAB_ORIGIN' or
         /// cli.toml
-        #[arg(name = "ORIGIN",short = 'o', long = "origin", value_parser = valid_origin)]
-        origin: Option<String>,
+        #[arg(name = "ORIGIN",short = 'o', long = "origin", value_parser = clap::value_parser!(Origin))]
+        origin: Option<Origin>,
     },
 
     /// List all secrets for your origin
@@ -51,8 +50,8 @@ pub(crate) enum OriginSecretCommand {
         auth_token: AuthToken,
 
         /// The origin for which secrets will be listed. Default is from 'HAB_ORIGIN' or cli.toml
-        #[arg(name = "ORIGIN",short = 'o', long = "origin", value_parser = valid_origin)]
-        origin: Option<String>,
+        #[arg(name = "ORIGIN",short = 'o', long = "origin", value_parser = clap::value_parser!(Origin))]
+        origin: Option<Origin>,
     },
 
     /// Create and upload a secret for your origin
@@ -73,8 +72,8 @@ pub(crate) enum OriginSecretCommand {
 
         /// The origin for which the secret will be uploaded. Default is from 'HAB_ORIGIN' or
         /// cli.toml
-        #[arg(name = "ORIGIN",short = 'o', long = "origin", value_parser = valid_origin)]
-        origin: Option<String>,
+        #[arg(name = "ORIGIN",short = 'o', long = "origin", value_parser = clap::value_parser!(Origin))]
+        origin: Option<Origin>,
 
         #[command(flatten)]
         cache_key_path: CacheKeyPath,
@@ -85,7 +84,7 @@ impl OriginSecretCommand {
     pub(super) async fn execute(&self, ui: &mut UI) -> HabResult<()> {
         fn get_args(bldr_url: &BldrUrl,
                     auth_token: &AuthToken,
-                    origin_opt: &Option<String>)
+                    origin_opt: &Option<Origin>)
                     -> Result<(String, String, Origin), Error> {
             // URL → String
             let url = bldr_url.resolve()?.to_string();

--- a/components/hab/src/cli_v4/origin/transfer.rs
+++ b/components/hab/src/cli_v4/origin/transfer.rs
@@ -4,8 +4,7 @@ use clap_v4 as clap;
 
 use crate::{api_client::{self,
                          Client},
-            cli_v4::utils::{valid_origin,
-                            AuthToken,
+            cli_v4::utils::{AuthToken,
                             BldrUrl},
             error::{Error,
                     Result as HabResult},
@@ -15,6 +14,8 @@ use clap::Parser;
 use habitat_common::ui::{Status,
                          UIWriter,
                          UI};
+use habitat_core::origin::Origin;
+
 use reqwest::StatusCode;
 
 #[derive(Debug, Clone, Parser)]
@@ -23,8 +24,8 @@ use reqwest::StatusCode;
                            {usage}\n\n{all-args}\n")]
 pub(crate) struct OriginTransferOptions {
     /// The origin name
-    #[arg(name = "ORIGIN", value_parser = valid_origin)]
-    origin: String,
+    #[arg(name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    origin: Origin,
 
     #[arg(name = "NEW_OWNER_ACCOUNT")]
     new_owner_account: String,
@@ -55,7 +56,9 @@ impl OriginTransferOptions {
                           self.origin, self.new_owner_account))?;
 
         // Call the transfer API and handle outcomes
-        match api_client.transfer_origin_ownership(&self.origin, &token, &self.new_owner_account)
+        match api_client.transfer_origin_ownership(self.origin.as_ref(),
+                                                   &token,
+                                                   &self.new_owner_account)
                         .await
         {
             Ok(_) => {

--- a/components/hab/src/cli_v4/pkg/list.rs
+++ b/components/hab/src/cli_v4/pkg/list.rs
@@ -4,9 +4,8 @@ use clap_v4 as clap;
 
 use clap::Parser;
 
-use habitat_core::package::PackageIdent;
-
-use habitat_common::cli::clap_validators::HabOriginValueParser;
+use habitat_core::{origin::Origin,
+                   package::PackageIdent};
 
 use crate::{command::pkg::{list,
                            list::ListingType},
@@ -24,8 +23,8 @@ pub(crate) struct PkgListOptions {
 
     // TODO : Validations
     /// An origin to list
-    #[arg(name = "ORIGIN", short = 'o', long = "origin", value_parser = HabOriginValueParser)]
-    origin: Option<String>,
+    #[arg(name = "ORIGIN", short = 'o', long = "origin", value_parser = clap::value_parser!(Origin))]
+    origin: Option<Origin>,
 
     /// A package identifier (ex: core/redis, core/busybox-static/1.42.2)
     #[arg(name = "PKG_IDENT")]
@@ -41,7 +40,7 @@ impl From<&PkgListOptions> for ListingType {
         if opts.all {
             ListingType::AllPackages
         } else if let Some(origin) = &opts.origin {
-            ListingType::Origin(origin.clone())
+            ListingType::Origin(origin.to_string())
         } else if let Some(ident) = &opts.pkg_ident {
             ListingType::Ident(ident.clone())
         } else {

--- a/components/hab/src/cli_v4/plan/init.rs
+++ b/components/hab/src/cli_v4/plan/init.rs
@@ -7,12 +7,12 @@ use clap::Parser;
 
 use habitat_common::{cli::clap_validators::HabPkgIdentValueParser,
                      ui::UI};
-use habitat_core::package::PackageIdent;
+use habitat_core::{origin::Origin,
+                   package::PackageIdent};
 
 use crate::error::Result as HabResult;
 
-use crate::cli_v4::utils::{origin_param_or_env,
-                           valid_origin};
+use crate::cli_v4::utils::origin_param_or_env;
 
 #[derive(Debug, Clone, Parser)]
 #[command(rename_all = "kebab-case",
@@ -24,8 +24,8 @@ pub(crate) struct PlanInit {
     pkg_name: Option<String>,
 
     /// Origin for the new app
-    #[arg(name = "ORIGIN", short = 'o', long = "origin", value_parser = valid_origin)]
-    origin: Option<String>,
+    #[arg(name = "ORIGIN", short = 'o', long = "origin", value_parser = clap::value_parser!(Origin))]
+    origin: Option<Origin>,
 
     /// Create a minimal plan file
     #[arg(name = "MIN", short = 'm', long = "min")]

--- a/components/hab/src/cli_v4/utils.rs
+++ b/components/hab/src/cli_v4/utils.rs
@@ -436,8 +436,8 @@ pub struct SharedLoad {
 )]
 pub(crate) struct UploadGroup {
     /// The origin name
-    #[arg(value_name = "ORIGIN", value_parser = valid_origin, group = "upload")]
-    pub origin: Option<String>,
+    #[arg(value_name = "ORIGIN", value_parser = clap::value_parser!(CoreOrigin), group = "upload")]
+    pub origin: Option<CoreOrigin>,
 
     /// Path to a local public origin key file on disk
     #[arg(value_name = "PUBLIC_FILE", long = "pubfile", group = "upload")]
@@ -482,17 +482,12 @@ pub struct CommandAndArgs {
     pub args: Vec<OsString>,
 }
 
-#[allow(clippy::needless_pass_by_value)]
-pub(crate) fn valid_origin(val: &str) -> Result<String, String> {
-    CoreOrigin::validate(val.to_string()).map(|()| val.to_string())
-}
-
 // Resolve an optional origin (from `--origin <ORIGIN>` or `-o`) into `Origin`,
 // falling back to HAB_ORIGIN envvar or the `cli.toml` config if none was supplied.
-pub(crate) fn origin_param_or_env(opt: &Option<String>) -> Result<CoreOrigin, Error> {
+pub(crate) fn origin_param_or_env(opt: &Option<CoreOrigin>) -> Result<CoreOrigin, Error> {
     if let Some(o) = opt {
         // User passed `--origin foo`
-        Ok(CoreOrigin::from_str(o).map_err(Error::from)?)
+        Ok(o.clone())
     } else if let Ok(env_val) = hcore_env::var(ORIGIN_ENVVAR) {
         // Fallback to HAB_ORIGIN env var
         Ok(CoreOrigin::from_str(&env_val).map_err(Error::from)?)


### PR DESCRIPTION
Different validators were used in different CLIs for the same Object type `Origin`. Also, at a number of places we were using `String` in place of the semantic `Origin` object in a few sub commands. Also, whenever the 'origin' parameter was optional, we were not using the one provided by `cli.toml` if set. Harmonized all that usage.