### PR TITLE
Fixes 3 e2e test

### DIFF
--- a/components/hab/src/cli_v4/bldr/channel/list.rs
+++ b/components/hab/src/cli_v4/bldr/channel/list.rs
@@ -10,24 +10,23 @@ use habitat_common::ui::UI;
 use habitat_core::origin::Origin;
 
 #[derive(Debug, Clone, Parser)]
-#[command(override_usage = "hab bldr channel list [FLAGS] [OPTIONS] <ORIGIN>",
-          help_template = "{name} {version} {author-section} \
+#[command(help_template = "{name} {version} {author-section} \
                            {about-section}\n{usage-heading}\n{usage}\n\n{all-args}\n")]
 pub(crate) struct ListOpts {
     /// Include sandbox channels for the origin
-    #[arg(short = 's', long = "sandbox")]
+    #[arg(name = "SANDBOX", short = 's', long = "sandbox")]
     sandbox: bool,
 
-    /// Specify an alternate Builder endpoint [env: HAB_BLDR_URL] [default: https://bldr.habitat.sh]
+    /// Specify an alternate Builder endpoint
     #[arg(short = 'u',
-          long = "auth",
+          long = "url",
           value_name = "BLDR_URL",
           env = "HAB_BLDR_URL",
           default_value = "https://bldr.habitat.sh")]
     url: String,
 
     /// Sets the origin to which the channel belongs. Default is from 'HAB_ORIGIN' or cli.toml
-    #[arg(short = 'o', long, value_name = "ORIGIN", value_parser = clap::value_parser!(Origin))]
+    #[arg(value_name = "ORIGIN", index=1, value_parser = clap::value_parser!(Origin))]
     origin: Option<Origin>,
 }
 

--- a/test/end-to-end/test_external_binaries.ps1
+++ b/test/end-to-end/test_external_binaries.ps1
@@ -21,7 +21,7 @@ Describe "`hab` correctly executes external binaries" {
 
     It "`hab pkg export` with bad exporter" {
         hab pkg export a_bad_exporter --help
-        $LastExitCode | Should -Be 1
+        $LastExitCode | Should -Not -Be 0
     }
 
     It "`hab sup --version` correctly reports version" {

--- a/test/end-to-end/test_license.ps1
+++ b/test/end-to-end/test_license.ps1
@@ -10,7 +10,7 @@ Describe "license" {
         hab -V
         $LastExitCode | Should -Be 0
 
-        hab svc load --version
+        hab sup --version
         $LastExitCode | Should -Be 0
 
         hab sup -V


### PR DESCRIPTION
- Changes clap attributes in `hab bldr channel list`
- Updates end-to-end/test_external_binaries.ps1
- Updates test/end-to-end/test_license.ps1

See individual commits for details and rationale about the changes made here.  Also, this change is not going to fix everything with these items.  The hab bldr channel list may be solved. The test_license test is going to need more work as there is work to be with regards to license acceptance.  The test_external_binaries I'm not sure about, I think this commit will move the needle forward but there may be problems I didn't get to reviewing because I got into the license issues.