### PR TITLE
add retry logic to the temp dir rename in hab pkg install

### DIFF
--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -60,8 +60,6 @@ steps:
 
   - label: "[:mac: x86_64 build hab]"
     command:
-      # We need to install bash 4+ so we are able to use all the modern capabilities.
-      - brew install bash
       - .expeditor/scripts/release_habitat/build_mac_hab_binary.sh
     env:
       BUILD_PKG_TARGET: "x86_64-darwin"
@@ -79,8 +77,6 @@ steps:
 
   - label: "[:mac: aarch64 build hab]"
     command:
-      # We need to install bash 4+ so we are able to use all the modern capabilities.
-      - brew install bash
       - .expeditor/scripts/release_habitat/build_mac_hab_binary.sh
     env:
       BUILD_PKG_TARGET: "aarch64-darwin"

--- a/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
+++ b/.expeditor/scripts/release_habitat/build_mac_hab_binary.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/bin/bash
 
 set -euo pipefail
 
@@ -21,7 +21,7 @@ echo "--- Channel: $channel - bldr url: $HAB_BLDR_URL"
 
 macos_install_bootstrap_package
 
-declare -g hab_binary
+hab_binary=""
 curlbash_hab "x86_64-darwin"
 import_keys
 

--- a/.expeditor/scripts/verify/build_mac_package.sh
+++ b/.expeditor/scripts/verify/build_mac_package.sh
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bash
+#!/bin/bash
 
 set -eou pipefail
 

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -332,6 +332,7 @@ steps:
   - label: "[unit] :darwin: install script"
     env:
       HAB_LICENSE: "accept-no-persist"
+      HOMEBREW_NO_AUTO_UPDATE: 1
     command:
       - .expeditor/scripts/verify/test_install_script.sh
     expeditor:
@@ -955,8 +956,6 @@ steps:
 #######################################################################
   - label: "[build] :mac: x86_64 hab"
     command:
-      # We need to install bash 4+ so we are able to use all the modern capabilities.
-      - brew install bash
       - .expeditor/scripts/verify/build_mac_package.sh components/hab
     env:
       HAB_LICENSE: "accept-no-persist"
@@ -975,8 +974,6 @@ steps:
 
   - label: "[build] :mac: aarch64 hab"
     command:
-      # We need to install bash 4+ so we are able to use all the modern capabilities.
-      - brew install bash
       - .expeditor/scripts/verify/build_mac_package.sh components/hab
     env:
       HAB_LICENSE: "accept-no-persist"


### PR DESCRIPTION
This adds retry logic to the temp directory rename in `hab pkg install`. The reason for this is that on windows we sometimes see "ACCESS DENIED" errors when installing packages. The reason for this almost always is due to the fact that the antivirus software is locking files for scanning in the temp directory which prevents the rename operation from completing. This is not a problem on linux because linux allows renames to open files.

The retry timeout is configurable and defaults to 5 seconds. In my local testing, I have found that only a single retry in necessary when the directory is locked. The wait between retries is 200 milliseconds.