### PR TITLE
CHEF-25194: Replace the unmaintained sodiumoxide crate with the maintained libsodium-rs crate

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,14 +5,9 @@
 # permanently specified in this file.
 
 [advisories]
-# JAH: The warnings below have been grandfathered dating to the start of our use
-# JAH: of cargo audit so that they can be dealt with over time. At the bottom of
-# JAH: this file is is a comment block stating what updating each crate would
-# JAH: require and what parts of habitat are downstream dependents
-#
+
 # advisory IDs to ignore e.g. ["RUSTSEC-2019-0001", ...]
 ignore = [
-    "RUSTSEC-2021-0137", # Unmaintained: sodiumoxide
     "RUSTSEC-2025-0134", # Unmaintained: rustls-pemfile, pending AWS SDK updates
 ]
 informational_warnings = [
@@ -31,26 +26,11 @@ stale = false                                      # Allow stale advisory DB (i.
 
 # Output Configuration
 [output]
-deny = [
-    "warnings",
-    "unmaintained",
-    "unsound",
-    "yanked",
-] # exit on error if these are found
-format = "terminal" # "terminal" (human readable report) or "json"
-quiet = false # Only print information on error
-show_tree = true # Show inverse dependency trees along with advisories (default: true)
+deny = ["warnings", "unmaintained", "unsound", "yanked"] # exit on error if these are found
+format = "terminal"                                      # "terminal" (human readable report) or "json"
+quiet = false                                            # Only print information on error
+show_tree = true                                         # Show inverse dependency trees along with advisories (default: true)
 
 [yanked]
 enabled = true      # Warn for yanked crates in Cargo.lock (default: true)
 update_index = true # Auto-update the crates.io index (default: true)
-
-#-------------------------------------------------------------------------------
-# "RUSTSEC-2021-0137",    # Unmaintained: sodiumoxide
-#-------------------------------------------------------------------------------
-#
-# Requires selection of replacement cryptography crate
-#
-# sodiumoxide 0.2.7
-# └── habitat_core 0.0.0
-#

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "bytestring",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "h2 0.3.27",
  "http 0.2.12",
@@ -168,7 +168,7 @@ dependencies = [
  "cfg-if",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -215,6 +215,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +228,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -289,6 +301,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 dependencies = [
  "backtrace",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -1078,6 +1099,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpu-time"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1202,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ct-codecs"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10589d1a5e400d61f9f38f12f884cfd080ff345de8f17efda36fe0e4a02aa8"
+
+[[package]]
+name = "ctor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "ctrlc"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,12 +1270,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1369,19 +1438,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "signature",
-]
 
 [[package]]
 name = "either"
@@ -1519,6 +1594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1533,6 +1609,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1808,7 +1890,7 @@ dependencies = [
  "tar",
  "tempfile",
  "termcolor",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "toml 0.9.8",
  "url",
@@ -1843,7 +1925,7 @@ dependencies = [
  "nix",
  "prost",
  "semver",
- "thiserror",
+ "thiserror 2.0.17",
  "winapi",
 ]
 
@@ -1861,7 +1943,7 @@ dependencies = [
  "log",
  "prost",
  "serde",
- "thiserror",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2004,7 +2086,7 @@ dependencies = [
  "syn",
  "tempfile",
  "termcolor",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "toml 0.9.8",
  "url",
@@ -2031,6 +2113,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "libc",
+ "libsodium-rs",
  "log",
  "native-tls",
  "nix",
@@ -2048,11 +2131,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
- "sodiumoxide",
  "tabwriter",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-rustls 0.26.4",
  "toml 0.9.8",
@@ -2104,7 +2186,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "termcolor",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "url",
 ]
@@ -2182,7 +2264,7 @@ dependencies = [
  "state",
  "tempfile",
  "termcolor",
- "thiserror",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
@@ -2216,7 +2298,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2225,7 +2307,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2600,7 +2693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2799,6 +2892,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libflate"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
+dependencies = [
+ "core2",
+ "hashbrown 0.16.1",
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,15 +2937,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsodium-sys"
-version = "0.2.7"
+name = "libsodium-rs"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
+checksum = "f897e12ec4403768092bcb0f7e81baa8a32c8286273406311584a16f37a704c0"
+dependencies = [
+ "ct-codecs",
+ "ctor",
+ "libc",
+ "libsodium-sys-stable",
+ "pkg-config",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
+name = "libsodium-sys-stable"
+version = "1.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8119f38969584f49be1d1da6f011ed268cc64e3eac5b4f9374c40d9694ad1421"
 dependencies = [
  "cc",
  "libc",
+ "libflate",
+ "minisign-verify",
  "pkg-config",
- "walkdir",
+ "tar",
+ "ureq",
+ "vcpkg",
+ "zip",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2912,7 +3058,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.17",
  "thread-id",
  "typemap-ors",
  "unicode-segmentation",
@@ -2980,6 +3126,12 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43"
 
 [[package]]
 name = "miniz_oxide"
@@ -3478,7 +3630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.17",
  "ucd-trie",
 ]
 
@@ -3542,7 +3694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "serde",
 ]
@@ -3692,7 +3844,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3908,7 +4060,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4012,6 +4164,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rustc-demangle"
@@ -4403,12 +4561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4450,18 +4602,6 @@ checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "sodiumoxide"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26be3acb6c2d9a7aac28482586a7856436af4cfe7100031d219de2d2ecb0028"
-dependencies = [
- "ed25519",
- "libc",
- "libsodium-sys",
- "serde",
 ]
 
 [[package]]
@@ -4634,11 +4774,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.17",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4802,7 +4962,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown",
+ "hashbrown 0.15.5",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -5067,6 +5227,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "ureq"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "ureq-proto",
+ "utf-8",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.3.1",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "uritemplate-next"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5092,6 +5277,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -5872,6 +6063,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeromq-src"
@@ -5917,6 +6122,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+
+[[package]]
 name = "zmq"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5936,4 +6161,16 @@ dependencies = [
  "libc",
  "system-deps",
  "zeromq-src",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/components/core/Cargo.toml
+++ b/components/core/Cargo.toml
@@ -22,6 +22,7 @@ glob = "*"
 hex = "*"
 lazy_static = "*"
 libc = "*"
+libsodium-rs = "*"
 log = "0.4"
 native-tls = { version = "*", features = ["vendored"] }
 os_info = "*"
@@ -34,7 +35,6 @@ rustls = "*"
 rustls-pemfile = "*"
 serde = { version = "*", features = ["derive"] }
 serde_json = { version = "*", features = ["preserve_order"] }
-sodiumoxide = "*"
 tabwriter = "*"
 tar = "*"
 tempfile = "*"

--- a/components/core/src/crypto.rs
+++ b/components/core/src/crypto.rs
@@ -1,7 +1,7 @@
 //! Habitat core encryption and cryptography.
 //!
 //! This module uses [libsodium](https://github.com/jedisct1/libsodium) and its Rust counterpart
-//! [sodiumoxide](https://github.com/dnaq/sodiumoxide) for cryptographic operations.
+//! [libsodium-rs](https://github.com/jedisct1/libsodium-rs) for cryptographic operations.
 //!
 //! # Concepts and terminology:
 //!
@@ -126,7 +126,7 @@
 //!
 //! Note that the BLAKE2b hash functions use a digest length of 32 bytes (256 bits!). More details
 //! about the hashing strategy can be found in the [libsodium hashing
-//! documentation](https://download.libsodium.org/doc/hashing/generic_hashing.html).
+//! documentation](https://doc.libsodium.org/hashing/generic_hashing).
 //!
 //! Signing uses a secret origin key, while verifying uses the public origin key. Thus, it it safe
 //! to distribute public origin keys.
@@ -223,7 +223,7 @@ pub const SECRET_BOX_KEY_SUFFIX: &str = "box.key";
 /// The suffix on the end of a secret symmetric key file
 pub const SECRET_SYM_KEY_SUFFIX: &str = "sym.key";
 /// The hashing function we're using during sign/verify
-/// See also: https://download.libsodium.org/doc/hashing/generic_hashing.html
+/// See also: https://doc.libsodium.org/hashing/generic_hashing
 pub const SIG_HASH_TYPE: &str = "BLAKE2b";
 /// This environment variable allows you to override the fs::CACHE_KEY_PATH
 /// at runtime. This is useful for testing.
@@ -246,7 +246,7 @@ pub mod keys;
 
 pub use hash::Blake2bHash;
 
-pub fn init() -> Result<()> { sodiumoxide::init().map_err(|_| Error::SodiumInitFailed) }
+pub fn init() -> Result<()> { libsodium_rs::ensure_init().map_err(|_| Error::SodiumInitFailed) }
 
 /// A comparison function that takes a consistent amount of time to compare
 /// values of a given number of bytes so as to be resistant to timing attacks.
@@ -256,7 +256,7 @@ pub fn secure_eq<T, U>(t: T, u: U) -> bool
     where T: AsRef<[u8]>,
           U: AsRef<[u8]>
 {
-    sodiumoxide::utils::memcmp(t.as_ref(), u.as_ref())
+    libsodium_rs::utils::memcmp(t.as_ref(), u.as_ref())
 }
 
 #[cfg(test)]

--- a/components/core/src/crypto/keys/cache.rs
+++ b/components/core/src/crypto/keys/cache.rs
@@ -65,7 +65,7 @@ impl KeyCache {
     pub fn new_signing_pair(&self,
                             origin: &Origin)
                             -> Result<(PublicOriginSigningKey, SecretOriginSigningKey)> {
-        let (public, secret) = generate_signing_key_pair(origin);
+        let (public, secret) = generate_signing_key_pair(origin)?;
         self.write_pair(&public, &secret)?;
         Ok((public, secret))
     }
@@ -75,7 +75,7 @@ impl KeyCache {
         &self,
         origin: &Origin)
         -> Result<(OriginPublicEncryptionKey, OriginSecretEncryptionKey)> {
-        let (public, secret) = generate_origin_encryption_key_pair(origin);
+        let (public, secret) = generate_origin_encryption_key_pair(origin)?;
         self.write_pair(&public, &secret)?;
         Ok((public, secret))
     }
@@ -85,7 +85,7 @@ impl KeyCache {
         &self,
         user: &str)
         -> Result<(UserPublicEncryptionKey, UserSecretEncryptionKey)> {
-        let (public, secret) = generate_user_encryption_key_pair(user);
+        let (public, secret) = generate_user_encryption_key_pair(user)?;
         self.write_pair(&public, &secret)?;
         Ok((public, secret))
     }
@@ -96,7 +96,7 @@ impl KeyCache {
         org: &str,
         service_group: &str)
         -> Result<(ServicePublicEncryptionKey, ServiceSecretEncryptionKey)> {
-        let (public, secret) = generate_service_encryption_key_pair(org, service_group);
+        let (public, secret) = generate_service_encryption_key_pair(org, service_group)?;
         self.write_pair(&public, &secret)?;
         Ok((public, secret))
     }
@@ -490,7 +490,7 @@ mod test {
     fn user_keys_round_trip() {
         let (cache, _dir) = new_cache();
         populate_cache(&cache);
-        let (public, secret) = generate_user_encryption_key_pair("my-user");
+        let (public, secret) = generate_user_encryption_key_pair("my-user").unwrap();
         assert_cache_round_trip!(UserPublicEncryptionKey, public, cache);
         assert_cache_round_trip!(UserSecretEncryptionKey, secret, cache);
     }
@@ -500,7 +500,7 @@ mod test {
         let (cache, _dir) = new_cache();
         populate_cache(&cache);
         let origin = "my-origin".parse().unwrap();
-        let (public, secret) = generate_origin_encryption_key_pair(&origin);
+        let (public, secret) = generate_origin_encryption_key_pair(&origin).unwrap();
         assert_cache_round_trip!(OriginPublicEncryptionKey, public, cache);
         assert_cache_round_trip!(OriginSecretEncryptionKey, secret, cache);
     }
@@ -509,7 +509,8 @@ mod test {
     fn service_keys_round_trip() {
         let (cache, _dir) = new_cache();
         populate_cache(&cache);
-        let (public, secret) = generate_service_encryption_key_pair("my-org", "foo.default");
+        let (public, secret) =
+            generate_service_encryption_key_pair("my-org", "foo.default").unwrap();
         assert_cache_round_trip!(ServicePublicEncryptionKey, public, cache);
         assert_cache_round_trip!(ServiceSecretEncryptionKey, secret, cache);
     }
@@ -519,7 +520,7 @@ mod test {
         let (cache, _dir) = new_cache();
         populate_cache(&cache);
         let origin = "my-org".parse().unwrap();
-        let (public, secret) = generate_signing_key_pair(&origin);
+        let (public, secret) = generate_signing_key_pair(&origin).unwrap();
         assert_cache_round_trip!(PublicOriginSigningKey, public, cache);
         assert_cache_round_trip!(SecretOriginSigningKey, secret, cache);
     }
@@ -531,8 +532,8 @@ mod test {
         fn pair_must_actually_be_a_pair_in_order_to_save() {
             let (cache, _dir) = new_cache();
 
-            let (me_public, _me_secret) = generate_user_encryption_key_pair("me");
-            let (_you_public, you_secret) = generate_user_encryption_key_pair("you");
+            let (me_public, _me_secret) = generate_user_encryption_key_pair("me").unwrap();
+            let (_you_public, you_secret) = generate_user_encryption_key_pair("you").unwrap();
 
             let result = cache.write_pair(&me_public, &you_secret);
             assert!(result.is_err(), "Threw an error: {:?}", result);

--- a/components/core/src/crypto/keys/encryption.rs
+++ b/components/core/src/crypto/keys/encryption.rs
@@ -28,15 +28,50 @@ const PUBLIC_BOX_KEY_VERSION: &str = "BOX-PUB-1";
 /// Format version identifier for secret encryption keys.
 const SECRET_BOX_KEY_VERSION: &str = "BOX-SEC-1";
 
-/// Private module to re-export the various sodiumoxide concepts we
+/// Private module to re-export the various libsodium-rs concepts we
 /// use, to ensure everyone is using them consistently.
 mod primitives {
-    pub use sodiumoxide::crypto::{box_::{curve25519xsalsa20poly1305::{Nonce,
-                                                                      PublicKey,
-                                                                      SecretKey,
-                                                                      gen_nonce},
-                                         gen_keypair,
-                                         open,
-                                         seal},
-                                  sealedbox};
+
+    pub use libsodium_rs::crypto_box::{Nonce,
+                                       PublicKey,
+                                       open,
+                                       seal};
+
+    pub mod sealedbox {
+        pub use libsodium_rs::crypto_box::{open_sealed_box as open,
+                                           seal_box as seal};
+    }
+
+    pub fn gen_keypair() -> crate::Result<(PublicKey, SecretKey)> {
+        let key_pair_tuple = libsodium_rs::crypto_box::KeyPair::generate().into_tuple();
+        Ok((key_pair_tuple.0, SecretKey(key_pair_tuple.1)))
+    }
+
+    pub fn gen_nonce() -> Nonce { Nonce::generate() }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct SecretKey(libsodium_rs::crypto_box::SecretKey);
+
+    impl SecretKey {
+        pub fn from_bytes(bytes: &[u8]) -> crate::Result<Self> {
+            Ok(SecretKey(libsodium_rs::crypto_box::SecretKey::from_bytes(bytes)?))
+        }
+
+        pub fn public_key(&self) -> crate::Result<PublicKey> {
+            use libsodium_rs::{crypto_box::SECRETKEYBYTES,
+                               crypto_scalarmult::curve25519::scalarmult_base};
+            let private_key: &[u8; SECRETKEYBYTES] = self.0.as_bytes();
+            Ok(scalarmult_base(private_key).map(PublicKey::from_bytes_exact)?)
+        }
+    }
+
+    impl core::convert::AsRef<[u8]> for SecretKey {
+        fn as_ref(&self) -> &[u8] { self.0.as_ref() }
+    }
+
+    impl std::ops::Deref for SecretKey {
+        type Target = libsodium_rs::crypto_box::SecretKey;
+
+        fn deref(&self) -> &Self::Target { &self.0 }
+    }
 }

--- a/components/core/src/crypto/keys/encryption/service_key.rs
+++ b/components/core/src/crypto/keys/encryption/service_key.rs
@@ -31,16 +31,16 @@ use crate::{crypto::keys::{Key,
 pub fn generate_service_encryption_key_pair(
     org_name: &str,
     service_group_name: &str)
-    -> (ServicePublicEncryptionKey, ServiceSecretEncryptionKey) {
+    -> Result<(ServicePublicEncryptionKey, ServiceSecretEncryptionKey)> {
     let key_name = service_key_name(org_name, service_group_name);
     let named_revision = NamedRevision::new(key_name);
-    let (pk, sk) = primitives::gen_keypair();
+    let (pk, sk) = primitives::gen_keypair()?;
 
     let public = ServicePublicEncryptionKey { named_revision: named_revision.clone(),
                                               key:            pk, };
     let secret = ServiceSecretEncryptionKey { named_revision,
                                               key: sk };
-    (public, secret)
+    Ok((public, secret))
 }
 
 /// Generate the name of a service key.
@@ -130,7 +130,8 @@ mod tests {
         let message = "Korben, sweetheart, what was that? IT WAS BAD! It had nothing! No fire, no \
                        energy, no nothin'!"
                                            .to_string();
-        let signed = user_secret.encrypt_for_service(message.as_bytes(), &service_public);
+        let signed = user_secret.encrypt_for_service(message.as_bytes(), &service_public)
+                                .unwrap();
 
         let decrypted_message = service_secret.decrypt_user_message(&signed, &user_public)
                                               .unwrap();

--- a/components/core/src/crypto/keys/util.rs
+++ b/components/core/src/crypto/keys/util.rs
@@ -78,8 +78,8 @@ macro_rules! from_str_impl_for_key {
                     .map(str::trim)
                     .map(crate::base64::decode)?
                     .map_err(|_| Error::CryptoError("Invalid base64 key material".to_string()))
-                    .map(|b| <Self as crate::crypto::keys::Key>::Crypto::from_slice(&b))?
-                    .ok_or_else(|| {
+                    .map(|b| <Self as crate::crypto::keys::Key>::Crypto::from_bytes(&b))?
+                    .map_err(|_| {
                         Error::CryptoError(format!("Could not parse bytes as key for {}",
                                                    named_revision))
                     })?;
@@ -191,7 +191,7 @@ mod tests {
 
         #[test]
         fn user_keys() {
-            let (public, secret) = generate_user_encryption_key_pair("my-user");
+            let (public, secret) = generate_user_encryption_key_pair("my-user").unwrap();
             assert_parse_round_trip!(UserPublicEncryptionKey, public);
             assert_parse_round_trip!(UserSecretEncryptionKey, secret);
         }
@@ -199,14 +199,15 @@ mod tests {
         #[test]
         fn origin_keys() {
             let origin = "my-origin".parse().unwrap();
-            let (public, secret) = generate_origin_encryption_key_pair(&origin);
+            let (public, secret) = generate_origin_encryption_key_pair(&origin).unwrap();
             assert_parse_round_trip!(OriginPublicEncryptionKey, public);
             assert_parse_round_trip!(OriginSecretEncryptionKey, secret);
         }
 
         #[test]
         fn service_keys() {
-            let (public, secret) = generate_service_encryption_key_pair("my-org", "foo.default");
+            let (public, secret) =
+                generate_service_encryption_key_pair("my-org", "foo.default").unwrap();
             assert_parse_round_trip!(ServicePublicEncryptionKey, public);
             assert_parse_round_trip!(ServiceSecretEncryptionKey, secret);
         }
@@ -214,7 +215,7 @@ mod tests {
         #[test]
         fn signing_keys() {
             let origin = "my-origin".parse().unwrap();
-            let (public, secret) = generate_signing_key_pair(&origin);
+            let (public, secret) = generate_signing_key_pair(&origin).unwrap();
             assert_parse_round_trip!(PublicOriginSigningKey, public);
             assert_parse_round_trip!(SecretOriginSigningKey, secret);
         }
@@ -317,7 +318,8 @@ mod tests {
 
                 #[test]
                 fn user_encryption_keys_can_parse_as_all_other_encryption_keys() {
-                    let (user_public, user_secret) = generate_user_encryption_key_pair("test-user");
+                    let (user_public, user_secret) =
+                        generate_user_encryption_key_pair("test-user").unwrap();
                     assert_public_key_equivalence!(user_public);
                     assert_secret_key_equivalence!(user_secret);
                 }
@@ -325,7 +327,7 @@ mod tests {
                 #[test]
                 fn service_encryption_keys_can_parse_as_all_other_encryption_keys() {
                     let (service_public, service_secret) =
-                        generate_service_encryption_key_pair("org", "testing.default");
+                        generate_service_encryption_key_pair("org", "testing.default").unwrap();
                     assert_public_key_equivalence!(service_public);
                     assert_secret_key_equivalence!(service_secret);
                 }
@@ -334,7 +336,7 @@ mod tests {
                 fn origin_encryption_keys_can_parse_as_all_other_encryption_keys() {
                     let origin = "test-origin".parse().unwrap();
                     let (origin_public, origin_secret) =
-                        generate_origin_encryption_key_pair(&origin);
+                        generate_origin_encryption_key_pair(&origin).unwrap();
                     assert_public_key_equivalence!(origin_public);
                     assert_secret_key_equivalence!(origin_secret);
                 }
@@ -355,7 +357,7 @@ mod tests {
 
         #[test]
         fn user_keys() {
-            let (public, secret) = generate_user_encryption_key_pair("my-user");
+            let (public, secret) = generate_user_encryption_key_pair("my-user").unwrap();
             assert_eq!(format!("UserPublicEncryptionKey my-user-{}",
                                public.named_revision().revision()),
                        format!("{:?}", public));
@@ -367,7 +369,7 @@ mod tests {
         #[test]
         fn origin_keys() {
             let origin = "my-origin".parse().unwrap();
-            let (public, secret) = generate_origin_encryption_key_pair(&origin);
+            let (public, secret) = generate_origin_encryption_key_pair(&origin).unwrap();
 
             assert_eq!(format!("OriginPublicEncryptionKey my-origin-{}",
                                public.named_revision().revision()),
@@ -379,7 +381,8 @@ mod tests {
 
         #[test]
         fn service_keys() {
-            let (public, secret) = generate_service_encryption_key_pair("my-org", "foo.default");
+            let (public, secret) =
+                generate_service_encryption_key_pair("my-org", "foo.default").unwrap();
 
             assert_eq!(format!("ServicePublicEncryptionKey foo.default@my-org-{}",
                                public.named_revision().revision()),
@@ -392,7 +395,7 @@ mod tests {
         #[test]
         fn signing_keys() {
             let origin = "my-origin".parse().unwrap();
-            let (public, secret) = generate_signing_key_pair(&origin);
+            let (public, secret) = generate_signing_key_pair(&origin).unwrap();
             assert_eq!(format!("PublicOriginSigningKey my-origin-{}",
                                public.named_revision().revision()),
                        format!("{:?}", public));
@@ -458,7 +461,7 @@ mod tests {
 
             #[test]
             fn user_keys() {
-                let (public, secret) = generate_user_encryption_key_pair("my-user");
+                let (public, secret) = generate_user_encryption_key_pair("my-user").unwrap();
                 assert_eq!(PathBuf::from(&format!("{}.pub", public.named_revision())),
                            public.own_filename());
                 assert_eq!(PathBuf::from(&format!("{}.box.key", secret.named_revision())),
@@ -468,7 +471,7 @@ mod tests {
             #[test]
             fn origin_keys() {
                 let origin = "my-origin".parse().unwrap();
-                let (public, secret) = generate_origin_encryption_key_pair(&origin);
+                let (public, secret) = generate_origin_encryption_key_pair(&origin).unwrap();
                 assert_eq!(PathBuf::from(&format!("{}.pub", public.named_revision())),
                            public.own_filename());
                 assert_eq!(PathBuf::from(&format!("{}.box.key", secret.named_revision())),
@@ -478,7 +481,7 @@ mod tests {
             #[test]
             fn service_keys() {
                 let (public, secret) =
-                    generate_service_encryption_key_pair("my-org", "foo.default");
+                    generate_service_encryption_key_pair("my-org", "foo.default").unwrap();
                 assert_eq!(PathBuf::from(&format!("{}.pub", public.named_revision())),
                            public.own_filename());
                 assert_eq!(PathBuf::from(&format!("{}.box.key", secret.named_revision())),
@@ -488,7 +491,7 @@ mod tests {
             #[test]
             fn signing_keys() {
                 let origin = "my-origin".parse().unwrap();
-                let (public, secret) = generate_signing_key_pair(&origin);
+                let (public, secret) = generate_signing_key_pair(&origin).unwrap();
                 assert_eq!(PathBuf::from(&format!("{}.pub", public.named_revision())),
                            public.own_filename());
                 assert_eq!(PathBuf::from(&format!("{}.sig.key", secret.named_revision())),

--- a/components/core/src/error.rs
+++ b/components/core/src/error.rs
@@ -143,6 +143,8 @@ pub enum Error {
     /// When an error occurs serializing rendering context
     RenderContextSerialization(serde_json::Error),
     RustlsReader(RustlsReaderError),
+    // Indicates that libsodium-rs returned an error
+    SodiumError(libsodium_rs::SodiumError),
     /// When an error occurs converting a `String` from a UTF-8 byte vector.
     StringFromUtf8Error(string::FromUtf8Error),
     /// When the system target (platform and architecture) do not match the package target.
@@ -355,6 +357,9 @@ impl fmt::Display for Error {
                 format!("Failed to send a signal to the child process: {}, {}", r, e)
             }
             Error::SodiumInitFailed => "Sodium library initialization failed".to_string(),
+            Error::SodiumError(ref e) => {
+                format!("libsodium-rs error: {}", e)
+            }
             Error::GetExitCodeProcessFailed(ref e) => e.to_string(),
             Error::CreateToolhelp32SnapshotFailed(ref e) => e.to_string(),
             Error::WaitForSingleObjectFailed(ref e) => e.to_string(),
@@ -420,4 +425,8 @@ impl From<regex::Error> for Error {
 
 impl From<RustlsReaderError> for Error {
     fn from(err: RustlsReaderError) -> Self { Error::RustlsReader(err) }
+}
+
+impl From<libsodium_rs::SodiumError> for Error {
+    fn from(err: libsodium_rs::SodiumError) -> Self { Error::SodiumError(err) }
 }

--- a/components/hab/src/command/config.rs
+++ b/components/hab/src/command/config.rs
@@ -58,7 +58,7 @@ pub(crate) async fn sub_svc_set<U>(ui: &mut U,
                   format!("Encrypting config (user rev = {}, service rev = {})",
                           user_key.named_revision(),
                           svc_key.named_revision()))?;
-        set_msg.cfg = Some(user_key.encrypt_for_service(&buf, &svc_key)
+        set_msg.cfg = Some(user_key.encrypt_for_service(&buf, &svc_key)?
                                    .to_string()
                                    .into_bytes());
         set_msg.is_encrypted = Some(true);

--- a/components/hab/src/command/file.rs
+++ b/components/hab/src/command/file.rs
@@ -69,7 +69,7 @@ pub(crate) async fn sub_file_put<U>(service_group: &str,
                       format!("file as {} for {}",
                               user_key.named_revision(),
                               service_key.named_revision()))?;
-            msg.content = Some(user_key.encrypt_for_service(&buf, &service_key)
+            msg.content = Some(user_key.encrypt_for_service(&buf, &service_key)?
                                        .to_string()
                                        .into_bytes());
             msg.is_encrypted = Some(true);

--- a/support/linux/install_dev_0_centos_7.sh
+++ b/support/linux/install_dev_0_centos_7.sh
@@ -25,7 +25,7 @@ export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 # needed for the Habitat binaries to find libsodium at runtime
 export LD_LIBRARY_PATH=/usr/local/lib
 
-# Install libsodium for zmq even though it will be automatically vendered with the sodiumoxide crate
+# Installing libsodium for zmq even though we use libsodium-rs elsewhere to maintain independence
 (cd /tmp && git clone https://github.com/jedisct1/libsodium.git)
 (cd /tmp/libsodium \
   && ./autogen.sh \

--- a/support/linux/install_dev_0_ubuntu_14.04.sh
+++ b/support/linux/install_dev_0_ubuntu_14.04.sh
@@ -32,7 +32,7 @@ sudo -E apt-get install -y --no-install-recommends \
   vim \
   wget
 
-# Install libsodium for zmq even though it will be automatically vendered with the sodiumoxide crate
+# Installing libsodium for zmq even though we use libsodium-rs elsewhere to maintain independence
 (cd /tmp && git clone https://github.com/jedisct1/libsodium.git)
 (cd /tmp/libsodium \
   && ./autogen.sh \


### PR DESCRIPTION
This has been a long lived PR as this was created early on to explore options as time allowed. Initially using [Rust Crypto](https://github.com/rustcrypto) seemed liked a good option.  It may well be but it also feels like Rust Crypto is a still a bit of a work in progress in some parts and that seems to be true of the NaCl compatibility layer we would have wanted to leverage.  The next option seriously considered was [dryoc: Don't Roll Your Own Crypto](https://github.com/brndnmtthws/dryoc).  Dryoc does seem like a solid project and it would have probably been a fine choice.  However, the period of time available for dryoc exploration was brief and when work was able to be resumed [libsodium-rs](https://github.com/jedisct1/libsodium-rs) had been created by the original author of the libsodium C library who also maintains numerous libsodium ports.  Given the clear commitment of Frank Denis to all things libsodium the user of libsodium-rs felt like the choice that would have the longest and most stable life.

Library chosen the solution was to leverage the preexisting primitives modules to map from sodiumoxide's api to the api of libsodium-rs. So the work that shook out was 

- Removing sodiumoxide from cargo audit
- Removing sodiumoxide crate from core/Cargo.toml
- Adding libsodium-rs crate to core/Cargo.toml
- Updating core::crypto.rs based on change from sodiumoxide to libsodium-rs
- Newtyping libsodium_rs::crypto_box::SecretKey and mapping the remaining primitives in  core::crypto::keys::encryption::primitives from sodiumoxide to libsodium-rs
- Mapping core::crypto::keys::ring_key::primitives from sodiumoxide to libsodium-rs
- Mapping core::crypto::keys::signing::primitives from sodiumoxide to libsodium-rs

Most of the methods in sodiumoxide were written as though they infallible, meaning they returned a concrete type as opposed to a Result or Option, whereas libsodium-rs mostly returns Results<T,E>.  This change in tact really drives most of the changes outside of the mapping in the primitives layer. One other notable change is that libsodium_rs::crypto_box::SecretKey was newtyped in order to preserve the .public_key() method as extacting the public key from the secret key via a method call was a sodiumoxide specific feature that libsodium-rs lacks for the most part.  The newtyping here hopefully saved even more changes to the outside code.

**NOTE:** If you want the details on "for the most part" you may enter the rabbit hole [via this comment](https://github.com/habitat-sh/habitat/pull/9891#discussion_r2593040048) and go as deep as you like.