### PR TITLE
Fixes native build option on macos

### DIFF
--- a/components/hab/src/cli_v4/pkg/build.rs
+++ b/components/hab/src/cli_v4/pkg/build.rs
@@ -86,9 +86,10 @@ impl PkgBuildOptions {
         if self.native_package {
             #[cfg(target_os = "linux")]
             if self.reuse || self.docker {
-                return Err(HabError::ArgumentError(String::from(
-                    "--native-package conflicts with --reuse and --docker"
-                )));
+                return Err(HabError::ArgumentError(String::from("--native-package \
+                                                                 conflicts with \
+                                                                 --reuse and \
+                                                                 --docker")));
             }
         }
 

--- a/components/hab/src/cli_v4/pkg/build.rs
+++ b/components/hab/src/cli_v4/pkg/build.rs
@@ -15,8 +15,10 @@ use habitat_core::{crypto,
                    origin::Origin};
 
 use crate::{command::pkg::build,
-            error::{Error as HabError,
-                    Result as HabResult}};
+            error::Result as HabResult};
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use crate::error::Error as HabError;
 
 use crate::cli_v4::utils::CacheKeyPath;
 


### PR DESCRIPTION
The PR fixes the macOS native plan build by properly handling the -N argument and resolving conflicts during the Clap v4 migration.