### PR TITLE
Removes rusoto, derivative, & humantime from audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,11 +15,8 @@ ignore = [
     "RUSTSEC-2021-0137", # Unmaintained: sodiumoxide
     "RUSTSEC-2021-0139", # Unmaintained: ansi_term
     "RUSTSEC-2021-0145", # Unsound, Unmaintained: atty
-    "RUSTSEC-2022-0071", # Unmaintained: rusoto
     "RUSTSEC-2024-0370", # Unmaintained: proc-macro-error (used by structopt)
     "RUSTSEC-2024-0375", # Unmaintained: atty (used by clap v2)
-    "RUSTSEC-2024-0388", # Unmaintained: derivative (used by log4rs)
-    "RUSTSEC-2025-0014", # Unmaintained: humantime (used by log4rs)
 ]
 informational_warnings = [
     "notice",
@@ -83,18 +80,3 @@ update_index = true # Auto-update the crates.io index (default: true)
 #     ├── habitat_common 0.0.0
 #     ├── habitat-rst-reader 0.0.0
 #     └── hab 0.0.0
-#
-#-------------------------------------------------------------------------------
-# "RUSTSEC-2022-0071"     # Unmaintained: rusoto
-#-------------------------------------------------------------------------------
-#
-# Requires selection of new "AWS crate"
-#
-# rusoto_credential 0.48.0
-# ├── rusoto_signature 0.48.0
-# │   └── rusoto_core 0.48.0
-# │       ├── rusoto_ecr 0.48.0
-# │       │   └── habitat_pkg_export_container 0.0.0
-# │       └── habitat_pkg_export_container 0.0.0
-# ├── rusoto_core 0.48.0
-# └── habitat_pkg_export_container 0.0.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,17 +1241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,7 +2149,6 @@ dependencies = [
  "configopt",
  "cpu-time",
  "ctrlc",
- "derivative",
  "fs2",
  "futures",
  "glob",

--- a/components/sup/Cargo.toml
+++ b/components/sup/Cargo.toml
@@ -23,7 +23,6 @@ actix-http = { version = "3", features = [ "rustls-0_23" ]}
 actix-rt = "*"
 byteorder = "*"
 cpu-time = "*"
-derivative = "*"
 fs2 = "*"
 futures = "*"
 glob = "*"

--- a/components/sup/src/manager.rs
+++ b/components/sup/src/manager.rs
@@ -46,7 +46,6 @@ use crate::{census::{CensusRing,
             util::pkg,
             VERSION};
 use cpu_time::ProcessTime;
-use derivative::Derivative;
 use futures::{channel::{mpsc as fut_mpsc,
                         oneshot},
               future,
@@ -304,8 +303,7 @@ impl Clone for CloneablePkcs8PrivKey {
     fn clone(&self) -> Self { Self(self.0.clone_key()) }
 }
 
-#[derive(Clone, Debug, Derivative)]
-#[derivative(PartialEq)]
+#[derive(Clone, Debug)]
 pub struct ManagerConfig {
     pub auto_update:                bool,
     pub auto_update_period:         Duration,
@@ -319,7 +317,6 @@ pub struct ManagerConfig {
     pub ctl_listen:                 ListenCtlAddr,
     pub ctl_server_certificates:    Option<Vec<CertificateDer<'static>>>,
     pub ctl_server_key:             Option<CloneablePkcs8PrivKey>,
-    #[derivative(PartialEq = "ignore")]
     pub ctl_client_ca_certificates: Option<RootCertStore>,
     pub http_listen:                HttpListenAddr,
     pub http_disable:               bool,
@@ -367,6 +364,36 @@ impl ManagerConfig {
         // JC: This mimics the logic from when we had composites.  But
         // should we check for Err ?
         ServiceSpec::from_file(spec_file).ok()
+    }
+}
+
+impl PartialEq for ManagerConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.auto_update == other.auto_update
+            && self.auto_update_period == other.auto_update_period
+            && self.service_update_period == other.service_update_period
+            && self.service_restart_config == other.service_restart_config
+            && self.custom_state_path == other.custom_state_path
+            && self.key_cache == other.key_cache
+            && self.update_url == other.update_url
+            && self.update_channel == other.update_channel
+            && self.gossip_listen == other.gossip_listen
+            && self.ctl_listen == other.ctl_listen
+            && self.ctl_server_certificates == other.ctl_server_certificates
+            && self.ctl_server_key == other.ctl_server_key
+            // Explicitly excluding ctl_client_ca_certificates from comparison
+            && self.http_listen == other.http_listen
+            && self.http_disable == other.http_disable
+            && self.gossip_peers == other.gossip_peers
+            && self.gossip_permanent == other.gossip_permanent
+            && self.ring_key == other.ring_key
+            && self.organization == other.organization
+            && self.watch_peer_file == other.watch_peer_file
+            && self.tls_config == other.tls_config
+            && self.feature_flags == other.feature_flags
+            && self.event_stream_config == other.event_stream_config
+            && self.keep_latest_packages == other.keep_latest_packages
+            && self.sys_ip == other.sys_ip
     }
 }
 


### PR DESCRIPTION
This removes the following 3 items from the ignore list in audit.toml
- "RUSTSEC-2022-0071", # Unmaintained: rusoto
  - The rusoto crate was removed in PR https://github.com/habitat-sh/habitat/pull/9816
- "RUSTSEC-2025-0014", # Unmaintained: humantime (used by log4rs)
  - The humantime advisory was rescinded as a maintainer was found
- "RUSTSEC-2024-0388", # Unmaintained: derivative (used by log4rs)
  - The use of derivative by log4rs was addressed by https://github.com/habitat-sh/habitat/pull/9903
  - The derivative create was also used in the habitat_supervisor code. Initially looked to replace it with the derive_more crate which felt like it was the most used of the suggested alternatives and as though should be a drop in replacement. While there seems to be a lot of good stuff in derive_more that wasn't my experience with the PartialEq trait so I just implemented the one instance of PartialEq where derivative had been used and removed the dependency.