### PR TITLE
fix cache key path location

### DIFF
--- a/components/hab/src/cli_v4/cli/setup.rs
+++ b/components/hab/src/cli_v4/cli/setup.rs
@@ -4,8 +4,7 @@ use crate::{cli_v4::utils::CacheKeyPath,
 use clap::Parser;
 use clap_v4 as clap;
 use habitat_common::ui::UI;
-use habitat_core::{crypto::keys::KeyCache,
-                   fs::cache_key_path};
+use habitat_core::crypto::keys::KeyCache;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Parser)]
@@ -21,7 +20,7 @@ impl CliSetupOptions {
     pub(crate) async fn do_setup(&self, ui: &mut UI) -> HabResult<()> {
         let key_path: PathBuf = (&self.cache_key_path).into();
 
-        let key_cache = KeyCache::new(cache_key_path(key_path));
+        let key_cache = KeyCache::new(key_path);
         key_cache.setup()?;
 
         start(ui, &key_cache)?;

--- a/components/hab/src/cli_v4/ring/key/export.rs
+++ b/components/hab/src/cli_v4/ring/key/export.rs
@@ -3,8 +3,7 @@ use crate::{cli_v4::utils::CacheKeyPath,
             error::Result as HabResult};
 use clap::Parser;
 use clap_v4 as clap;
-use habitat_core::{crypto::keys::KeyCache,
-                   fs::cache_key_path};
+use habitat_core::crypto::keys::KeyCache;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Parser)]
@@ -23,7 +22,7 @@ pub(crate) struct RingKeyExportOpts {
 impl RingKeyExportOpts {
     pub(crate) async fn do_export(&self) -> HabResult<()> {
         let key_path: PathBuf = (&self.cache_key_path).into();
-        let key_cache = KeyCache::new(cache_key_path(key_path));
+        let key_cache = KeyCache::new(key_path);
         key_cache.setup()?;
         start(&self.ring, &key_cache)
     }

--- a/components/hab/src/cli_v4/ring/key/generate.rs
+++ b/components/hab/src/cli_v4/ring/key/generate.rs
@@ -4,9 +4,8 @@ use crate::{cli_v4::utils::CacheKeyPath,
 use clap::Parser;
 use clap_v4 as clap;
 use habitat_common::ui::UI;
-use habitat_core::{crypto::{init,
-                            keys::KeyCache},
-                   fs::cache_key_path};
+use habitat_core::crypto::{init,
+                           keys::KeyCache};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Parser)]
@@ -25,7 +24,7 @@ pub(crate) struct RingKeyGenerateOpts {
 impl RingKeyGenerateOpts {
     pub(crate) async fn do_generate(&self, ui: &mut UI) -> HabResult<()> {
         let key_path: PathBuf = (&self.cache_key_path).into();
-        let key_cache = KeyCache::new(cache_key_path(key_path));
+        let key_cache = KeyCache::new(key_path);
         key_cache.setup()?;
         init()?;
         start(ui, &self.ring, &key_cache)

--- a/components/hab/src/cli_v4/ring/key/import.rs
+++ b/components/hab/src/cli_v4/ring/key/import.rs
@@ -4,9 +4,8 @@ use crate::{cli_v4::utils::CacheKeyPath,
 use clap::Parser;
 use clap_v4 as clap;
 use habitat_common::ui::UI;
-use habitat_core::{crypto::{init,
-                            keys::KeyCache},
-                   fs::cache_key_path};
+use habitat_core::crypto::{init,
+                           keys::KeyCache};
 use std::{io::{self,
                Read},
           path::PathBuf};
@@ -24,7 +23,7 @@ impl RingKeyImportOpts {
         let mut content = String::new();
         io::stdin().read_to_string(&mut content)?;
         let key_path: PathBuf = (&self.cache_key_path).into();
-        let key_cache = KeyCache::new(cache_key_path(key_path));
+        let key_cache = KeyCache::new(key_path);
         key_cache.setup()?;
         init()?;
         start(ui, content.trim(), &key_cache)

--- a/components/hab/src/cli_v4/user/key/generate.rs
+++ b/components/hab/src/cli_v4/user/key/generate.rs
@@ -4,8 +4,7 @@ use clap::Parser;
 use clap_v4 as clap;
 use habitat_common::ui::UI;
 
-use habitat_core::{crypto::keys::KeyCache,
-                   fs::cache_key_path};
+use habitat_core::crypto::keys::KeyCache;
 use std::path::PathBuf;
 
 use crate::command::user::key::generate::start;
@@ -28,7 +27,7 @@ impl UserKeyGenerateOptions {
     pub(crate) async fn do_generate(&self, ui: &mut UI) -> HabResult<()> {
         let key_path: PathBuf = (&self.cache_key_path).into();
 
-        let key_cache = KeyCache::new(cache_key_path(key_path));
+        let key_cache = KeyCache::new(key_path);
         key_cache.setup()?;
 
         start(ui, &self.user, &key_cache)?;


### PR DESCRIPTION
This is a regression introduced with the clap v4 work. Many commands are generating keys in `/hab/cache/keys/hab/cache/keys`.