### PR TITLE
remove unwrap from election rumor retrieval

### DIFF
--- a/components/sup/src/census.rs
+++ b/components/sup/src/census.rs
@@ -162,10 +162,11 @@ impl CensusRing {
     /// * `RumorStore::list` (read)
     fn update_from_election_store_rsr(&mut self, election_rumors: &RumorStore<ElectionRumor>) {
         for (service_group, rumors) in election_rumors.lock_rsr().iter() {
-            let election = rumors.get(ElectionRumor::const_id()).unwrap();
-            if let Ok(sg) = service_group_from_str(service_group) {
-                if let Some(census_group) = self.census_groups.get_mut(&sg) {
-                    census_group.update_from_election_rumor(election);
+            if let Some(election) = rumors.get(ElectionRumor::const_id()) {
+                if let Ok(sg) = service_group_from_str(service_group) {
+                    if let Some(census_group) = self.census_groups.get_mut(&sg) {
+                        census_group.update_from_election_rumor(election);
+                    }
                 }
             }
         }


### PR DESCRIPTION
An automate-HA customer encountered a case where a service group follower was rebooted and a fellow follower's supervisor crashed and restarted. Here is the snippet from the logs:
```
thread 'main' panicked at components/sup/src/census.rs:165:66:
called `Option::unwrap()` on a `None` value
```

I am surprised to see the `unwrap` here since we are usually hyper-vigilant not to include these in production supervisor code and it looks like thi has been present for years and years.

It's unlikely a panic would occur but totally possible. What probably happened here is that the rebooted member departed the butterfly network and the affected supervisor purged its election rumors before a new rumor could populate the store. This is a very time sensitive race condition and it's the first time we have encountered this.

This PR adds some very simple logic to gracefully handle the absence of election rumors.