### PR TITLE
hab plan CLI fixes

### DIFF
--- a/components/hab/src/cli_v4/plan/init.rs
+++ b/components/hab/src/cli_v4/plan/init.rs
@@ -1,13 +1,9 @@
-// Implementation of `hab plan init` subcommand
-use std::str::FromStr;
-
 use clap_v4 as clap;
 
 use clap::Parser;
 
 use habitat_common::ui::UI;
-use habitat_core::{origin::Origin,
-                   package::PackageIdent};
+use habitat_core::origin::Origin;
 
 use crate::error::Result as HabResult;
 
@@ -38,13 +34,9 @@ pub(crate) struct PlanInit {
 impl PlanInit {
     pub(crate) fn do_command(&self, ui: &mut UI) -> HabResult<()> {
         let origin = origin_param_or_env(&self.origin)?;
-        let scaffolding = if cfg!(windows) {
-            self.scaffolding
-                .as_deref()
-                .map(|s| PackageIdent::from_str(s).unwrap())
-        } else {
-            crate::scaffolding::scaffold_check(ui, self.scaffolding.as_deref())?
-        };
+
+        // Use scaffold_check for all platforms - it handles aliases and validation
+        let scaffolding = crate::scaffolding::scaffold_check(ui, self.scaffolding.as_deref())?;
 
         crate::command::plan::init::start(ui, &origin, self.min, scaffolding, self.pkg_name.clone())
     }

--- a/components/hab/src/cli_v4/plan/init.rs
+++ b/components/hab/src/cli_v4/plan/init.rs
@@ -35,8 +35,12 @@ impl PlanInit {
     pub(crate) fn do_command(&self, ui: &mut UI) -> HabResult<()> {
         let origin = origin_param_or_env(&self.origin)?;
 
-        // Use scaffold_check for all platforms - it handles aliases and validation
-        let scaffolding = crate::scaffolding::scaffold_check(ui, self.scaffolding.as_deref())?;
+        // Only call scaffold_check if scaffolding was explicitly provided
+        let scaffolding = if self.scaffolding.is_some() {
+            crate::scaffolding::scaffold_check(ui, self.scaffolding.as_deref())?
+        } else {
+            None // Don't auto-detect if no scaffolding was specified
+        };
 
         crate::command::plan::init::start(ui, &origin, self.min, scaffolding, self.pkg_name.clone())
     }

--- a/components/hab/src/cli_v4/plan/init.rs
+++ b/components/hab/src/cli_v4/plan/init.rs
@@ -5,8 +5,7 @@ use clap_v4 as clap;
 
 use clap::Parser;
 
-use habitat_common::{cli::clap_validators::HabPkgIdentValueParser,
-                     ui::UI};
+use habitat_common::ui::UI;
 use habitat_core::{origin::Origin,
                    package::PackageIdent};
 
@@ -32,7 +31,7 @@ pub(crate) struct PlanInit {
     min: bool,
 
     /// Specify explicit Scaffolding for your app (ex: node, ruby)
-    #[arg(name = "SCAFFOLDING", short = 's', long = "scaffolding", value_parser = HabPkgIdentValueParser::simple())]
+    #[arg(name = "SCAFFOLDING", short = 's', long = "scaffolding")]
     scaffolding: Option<String>,
 }
 

--- a/components/hab/src/command/plan/render.rs
+++ b/components/hab/src/command/plan/render.rs
@@ -119,9 +119,9 @@ pub fn start(ui: &mut UI,
 }
 
 fn toml_to_json(cfg: &str) -> Result<Json> {
-    let toml_value = cfg.parse::<Value>()?;
-    let toml_string = serde_json::to_string(&toml_value)?;
-    let json = serde_json::from_str(&format!(r#"{{ "cfg": {} }}"#, &toml_string))?;
+    let toml_value: Value = toml::from_str(cfg).map_err(crate::error::Error::from)?;
+    let toml_string = serde_json::to_string(&toml_value).map_err(crate::error::Error::from)?;
+    let json = serde_json::from_str(&format!(r#"{{ "cfg": {} }}"#, &toml_string)).map_err(crate::error::Error::from)?;
     Ok(json)
 }
 

--- a/components/hab/static/template_plan.ps1
+++ b/components/hab/static/template_plan.ps1
@@ -1,288 +1,256 @@
-{{~ #unless minimal ~}}
+{{~ #unless minimal }}
 # This file is the heart of your application's habitat.
-# See full docs at https://www.habitat.sh/docs/reference/plan-syntax/
-{{~ /unless ~}}
+# See Overview Docs at https://docs.chef.io/habitat/plan_contents/
 
+################################################################################
+# SETTINGS - https://docs.chef.io/habitat/plan_settings/
+################################################################################
 
-{{~ #unless minimal}}
-
-# Required.
+# REQUIRED
 # Sets the name of the package. This will be used along with `$pkg_origin`,
 # and `$pkg_version` to define the fully-qualified package name, which determines
 # where the package is installed to on disk, how it is referred to in package
 # metadata, and so on.
-{{/unless ~}}
+{{ /unless ~}}
 $pkg_name="{{ pkg_name }}"
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required unless overridden by the `HAB_ORIGIN` environment variable.
+# REQUIRED (unless overridden by the `HAB_ORIGIN` environment variable)
 # The origin is used to denote a particular upstream of a package.
-{{~ /unless}}
+{{ /unless }}
 $pkg_origin="{{ pkg_origin }}"
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required.
+# REQUIRED
 # Sets the version of the package
-{{~ /unless}}
-{{#if pkg_version ~}}
+{{ /unless }}
+{{ #if pkg_version }}
 $pkg_version="{{ pkg_version }}"
-{{~ else ~}}
+{{ else }}
 $pkg_version="0.1.0"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # The name and email address of the package maintainer.
-{{~ /unless}}
-{{#if pkg_maintainer ~}}
+{{ /unless }}
+{{ #if pkg_maintainer }}
 $pkg_maintainer="{{ pkg_maintainer }}"
-{{~ else ~}}
+{{ else }}
 $pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of valid software licenses that relate to this package.
 # Please choose a license from http://spdx.org/licenses/
-{{~ /unless}}
-{{#if pkg_license ~}}
+{{ /unless }}
+{{ #if pkg_license }}
 $pkg_license="{{ pkg_license }}"
-{{~ else ~}}
+{{ else }}
 $pkg_license=@("Apache-2.0")
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # The scaffolding base for this plan.
-{{~ /unless}}
-{{#if scaffolding_ident ~}}
+{{ /unless }}
+{{ #if scaffolding_ident }}
 $pkg_scaffolding="{{ scaffolding_ident }}"
-{{~ else ~}}
+{{ else }}
 # $pkg_scaffolding="some/scaffolding"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # A URL that specifies where to download the source from. Any valid wget url
 # will work. Typically, the relative path for the URL is partially constructed
 # from the pkg_name and pkg_version values; however, this convention is not
 # required.
-{{~ /unless}}
-{{#if pkg_source ~}}
+{{ /unless }}
+{{ #if pkg_source }}
 $pkg_source="{{ pkg_source }}"
-{{~ else ~}}
+{{ else }}
 # $pkg_source="http://some_source_url/releases/$pkg_name-$pkg_version.zip"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # The resulting filename for the download, typically constructed from the
 # pkg_name and pkg_version values.
-{{~ /unless}}
-{{#if pkg_filename ~}}
+{{ /unless }}
+{{ #if pkg_filename }}
 $pkg_filename="{{ pkg_filename }}"
-{{~ else ~}}
+{{ else }}
 # $pkg_filename="$pkg_name-$pkg_version.zip"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required if a valid URL is provided for pkg_source or unless Invoke-Verify is overridden.
+# REQUIRED (if a valid URL is provided for pkg_source or unless Invoke-Verify is overridden)
 # The value for pkg_shasum is a sha-256 sum of the downloaded pkg_source. If you
 # do not have the checksum, you can easily generate it by downloading the source
 # and using Get-FileHash. Also, if you do not have
 # Invoke-Verify overridden, and you do not have the correct sha-256 sum, then the
 # expected value will be shown in the build output of your package.
-{{~ /unless}}
-{{#if pkg_shasum ~}}
+{{ /unless }}
+{{ #if pkg_shasum }}
 $pkg_shasum="{{ pkg_shasum }}"
-{{~ else ~}}
+{{ else }}
 $pkg_shasum="TODO"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of package dependencies needed at runtime. You can refer to packages
 # at three levels of specificity: `origin/package`, `origin/package/version`, or
 # `origin/package/version/release`.
-{{~ /unless}}
-{{#if pkg_deps ~}}
+{{ /unless }}
+{{ #if pkg_deps }}
 $pkg_deps={{ pkg_deps }}
-{{~ else ~}}
+{{ else }}
 $pkg_deps=@()
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of the package dependencies needed only at build time.
-{{~ /unless}}
-{{#if pkg_build_deps ~}}
+{{ /unless }}
+{{ #if pkg_build_deps }}
 $pkg_build_deps={{ pkg_build_deps }}
-{{~ else ~}}
+{{ else }}
 $pkg_build_deps=@()
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of paths, relative to the final install of the software, where
 # libraries can be found for native builds.
-{{~ /unless}}
-{{#if pkg_lib_dirs ~}}
+{{ /unless }}
+{{ #if pkg_lib_dirs }}
 $pkg_lib_dirs={{ pkg_lib_dirs }}
-{{~ else ~}}
+{{ else }}
 # $pkg_lib_dirs=@("lib")
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of paths, relative to the final install of the software, where
 # headers can be found.
-{{~ /unless}}
-{{#if pkg_include_dirs ~}}
+{{ /unless }}
+{{ #if pkg_include_dirs }}
 $pkg_include_dirs={{ pkg_include_dirs }}
-{{~ else ~}}
+{{ else }}
 # $pkg_include_dirs=@("include")
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of paths, relative to the final install of the software, where
 # binaries can be found. Used to populate $ENV:PATH for software that depends on
 # your package.
-{{~ /unless}}
-{{#if pkg_bin_dirs ~}}
+{{ /unless }}
+{{ #if pkg_bin_dirs }}
 $pkg_bin_dirs={{ pkg_bin_dirs }}
-{{~ else ~}}
+{{ else }}
 # $pkg_bin_dirs=@("bin")
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # The command for the Supervisor to execute when starting a service. You can
 # omit this setting if your package is not intended to be run directly by a
 # Supervisor of if your plan contains a run hook in hooks/run.
-{{#if pkg_svc_run ~}}
+{{ #if pkg_svc_run }}
 $pkg_svc_run="{{ pkg_svc_run }}"
-{{~ else ~}}
+{{ else }}
 # $pkg_svc_run="MyBinary.exe"
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # A hashtable representing configuration data which should be gossiped to peers. The keys
 # in this hashtable represent the name the value will be assigned and the values represent the toml path
 # to read the value.
-{{#if pkg_exports ~}}
+{{ #if pkg_exports }}
 $pkg_exports={{ pkg_exports }}
-{{~ else ~}}
+{{ else }}
 # $pkg_exports=@{
 #   host="srv.address"
 #   port="srv.port"
 #   ssl-port="srv.ssl.port"
 # }
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # An array of `$pkg_exports` keys containing default values for which ports that this package
 # exposes. These values are used as sensible defaults for other tools. For example, when exporting
 # a package to a container format.
-{{#if pkg_exposes ~}}
+{{ #if pkg_exposes }}
 $pkg_exposes={{ pkg_exposes }}
-{{~ else ~}}
+{{ else }}
 # $pkg_exposes=@("port," "ssl-port")
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # A hashtable representing services which you depend on and the configuration keys that
 # you expect the service to export (by their `$pkg_exports`). These binds *must* be set for the
 # Supervisor to load the service. The loaded service will wait to run until it's bind becomes
 # available. If the bind does not contain the expected keys, the service will not start
 # successfully.
-{{#if pkg_binds ~}}
+{{ #if pkg_binds }}
 $pkg_binds={{ pkg_binds }}
-{{~ else ~}}
+{{ else }}
 # $pkg_binds=@{
 #   database="port host"
 # }
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # Same as `$pkg_binds` but these represent optional services to connect to.
-{{#if pkg_binds_optional ~}}
+{{ #if pkg_binds_optional }}
 $pkg_binds_optional={{ pkg_binds_optional }}
-{{~ else ~}}
+{{ else }}
 # $pkg_binds_optional=@{
 #   storage="port host"
 # }
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # The number of seconds to wait for a service to shutdown. After this interval
 # the service will forcibly be killed. The default is 8.
-{{#if pkg_shutdown_timeout_sec ~}}
+{{ #if pkg_shutdown_timeout_sec }}
 $pkg_shutdown_timeout_sec={{ pkg_shutdown_timeout_sec }}
-{{~ else ~}}
+{{ else }}
 # $pkg_shutdown_timeout_sec=8
-{{~ /if}}
-{{~ /unless}}
+{{ /if }}
+{{ /unless }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required for core plans, optional otherwise.
+# REQUIRED for core plans, OPTIONAL otherwise
 # A short description of the package. It can be a simple string, or you can
 # create a multi-line description using markdown to provide a rich description
 # of your package.
-{{~ /unless}}
-{{#if pkg_description ~}}
+{{ /unless }}
+{{ #if pkg_description }}
 $pkg_description="{{ pkg_description }}"
-{{~ else ~}}
+{{ else }}
 # $pkg_description="Some description."
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required for core plans, optional otherwise.
+# REQUIRED for core plans, OPTIONAL otherwise
 # The project home page for the package.
-{{~ /unless}}
-{{#if pkg_upstream_url ~}}
+{{ /unless }}
+{{ #if pkg_upstream_url }}
 $pkg_upstream_url="{{ pkg_upstream_url }}"
-{{~ else ~}}
+{{ else }}
 # $pkg_upstream_url="http://example.com/project-name"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
+################################################################################
+# CALLBACKS - https://docs.chef.io/habitat/build_phase_callbacks/
+################################################################################
 
-{{~ #unless minimal}}
-
-# Callback Functions
-#
 # When defining your plan, you have the flexibility to override the default
 # behavior of Habitat in each part of the package building stage through a
 # series of callbacks. To define a callback, simply create a shell function
@@ -291,13 +259,9 @@ $pkg_upstream_url="{{ pkg_upstream_url }}"
 # with an empty implementation in the function definition.
 #
 # Callbacks are defined here with either their "Invoke-DefaultX", if they have a
-# default implementation, or empty if they have no default implementation. If callbacks do
-# nothing or do the same as the default implementation, they can be removed from
-# this template.
-#
-# The default implementations (the Invoke-Default* functions) are defined in the
-# plan build script:
-# https://github.com/habitat-sh/habitat/tree/master/components/plan-build-ps1/bin/hab-plan-build.ps1
+# default implementation, or empty if they have no default implementation. If
+# callbacks do nothing or do the same as the default implementation, they can be
+# removed from this template.
 
 # The default implmentation does nothing. You can use it to execute any
 # arbitrary commands before anything else happens.
@@ -371,7 +335,8 @@ function Invoke-Install {
 function Invoke-End {
   Invoke-DefaultEnd
 }
-{{~ else}}
+
+{{ else }}
 
 function Invoke-Build {
   Invoke-DefaultBuild
@@ -381,4 +346,4 @@ function Invoke-Install {
   Invoke-DefaultInstall
 }
 
-{{~ /unless}}
+{{ /unless }}

--- a/components/hab/static/template_plan.sh
+++ b/components/hab/static/template_plan.sh
@@ -1,341 +1,307 @@
-{{~ #unless minimal ~}}
+{{~ #unless minimal }}
 # This file is the heart of your application's habitat.
-# See full docs at https://www.habitat.sh/docs/reference/plan-syntax/
-{{~ /unless ~}}
+# See Overview Docs at https://docs.chef.io/habitat/plan_contents/
 
+################################################################################
+# SETTINGS - https://docs.chef.io/habitat/plan_settings/
+################################################################################
 
-{{~ #unless minimal}}
-
-# Required.
+# REQUIRED
 # Sets the name of the package. This will be used in along with `pkg_origin`,
 # and `pkg_version` to define the fully-qualified package name, which determines
 # where the package is installed to on disk, how it is referred to in package
 # metadata, and so on.
 {{/unless ~}}
 pkg_name={{ pkg_name }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required unless overridden by the `HAB_ORIGIN` environment variable.
+# REQUIRED (unless overridden by the `HAB_ORIGIN` environment variable)
 # The origin is used to denote a particular upstream of a package.
-{{~ /unless}}
+{{ /unless }}
 pkg_origin={{ pkg_origin }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required.
+# REQUIRED
 # Sets the version of the package
-{{~ /unless}}
-{{#if pkg_version ~}}
+{{ /unless }}
+{{#if pkg_version }}
 pkg_version="{{ pkg_version }}"
-{{~ else ~}}
+{{ else }}
 pkg_version="0.1.0"
-{{~ /if}}
+{{/if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # The name and email address of the package maintainer.
-{{~ /unless}}
-{{#if pkg_maintainer ~}}
+{{ /unless }}
+{{ #if pkg_maintainer }}
 pkg_maintainer="{{ pkg_maintainer }}"
-{{~ else ~}}
+{{ else }}
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of valid software licenses that relate to this package.
 # Please choose a license from http://spdx.org/licenses/
-{{~ /unless}}
-{{#if pkg_license ~}}
+{{ /unless }}
+{{ #if pkg_license }}
 pkg_license={{ pkg_license }}
-{{~ else ~}}
+{{ else }}
 pkg_license=("Apache-2.0")
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # The scaffolding base for this plan.
-{{~ /unless}}
-{{#if scaffolding_ident ~}}
+{{ /unless }}
+{{ #if scaffolding_ident }}
 pkg_scaffolding="{{ scaffolding_ident }}"
-{{~ else ~}}
+{{ else }}
 # pkg_scaffolding="some/scaffolding"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # A URL that specifies where to download the source from. Any valid wget url
 # will work. Typically, the relative path for the URL is partially constructed
 # from the pkg_name and pkg_version values; however, this convention is not
 # required.
-{{~ /unless}}
-{{#if pkg_source ~}}
+{{ /unless }}
+{{ #if pkg_source }}
 pkg_source="{{ pkg_source }}"
-{{~ else ~}}
+{{ else }}
 # pkg_source="http://some_source_url/releases/${pkg_name}-${pkg_version}.tar.gz"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # The resulting filename for the download, typically constructed from the
 # pkg_name and pkg_version values.
-{{~ /unless}}
-{{#if pkg_filename ~}}
+{{ /unless }}
+{{ #if pkg_filename }}
 pkg_filename="{{ pkg_filename }}"
-{{~ else ~}}
+{{ else }}
 # pkg_filename="${pkg_name}-${pkg_version}.tar.gz"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required if a valid URL is provided for pkg_source or unless do_verify() is overridden.
+# REQUIRED (if a valid URL is provided for pkg_source or unless do_verify() is overridden)
 # The value for pkg_shasum is a sha-256 sum of the downloaded pkg_source. If you
 # do not have the checksum, you can easily generate it by downloading the source
 # and using the sha256sum or gsha256sum tools. Also, if you do not have
 # do_verify() overridden, and you do not have the correct sha-256 sum, then the
 # expected value will be shown in the build output of your package.
-{{~ /unless}}
-{{#if pkg_shasum ~}}
+{{ /unless }}
+{{ #if pkg_shasum }}
 pkg_shasum="{{ pkg_shasum }}"
-{{~ else ~}}
+{{ else }}
 pkg_shasum="TODO"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of package dependencies needed at runtime. You can refer to packages
 # at three levels of specificity: `origin/package`, `origin/package/version`, or
 # `origin/package/version/release`.
-{{~ /unless}}
-{{#if pkg_deps ~}}
+{{ /unless }}
+{{ #if pkg_deps }}
 pkg_deps={{ pkg_deps }}
-{{~ else ~}}
+{{ else }}
 pkg_deps=(core/glibc)
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of the package dependencies needed only at build time.
-{{~ /unless}}
-{{#if pkg_build_deps ~}}
+{{ /unless }}
+{{ #if pkg_build_deps }}
 pkg_build_deps={{ pkg_build_deps }}
-{{~ else ~}}
+{{ else }}
 pkg_build_deps=(core/make core/gcc)
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of paths, relative to the final install of the software, where
 # libraries can be found. Used to populate LD_FLAGS and LD_RUN_PATH for
 # software that depends on your package.
-{{~ /unless}}
-{{#if pkg_lib_dirs ~}}
+{{ /unless }}
+{{ #if pkg_lib_dirs }}
 pkg_lib_dirs={{ pkg_lib_dirs }}
-{{~ else ~}}
+{{ else }}
 # pkg_lib_dirs=(lib)
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of paths, relative to the final install of the software, where
 # headers can be found. Used to populate CFLAGS for software that depends on
 # your package.
-{{~ /unless}}
-{{#if pkg_include_dirs ~}}
+{{ /unless }}
+{{ #if pkg_include_dirs }}
 pkg_include_dirs={{ pkg_include_dirs }}
-{{~ else ~}}
+{{ else }}
 # pkg_include_dirs=(include)
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of paths, relative to the final install of the software, where
 # binaries can be found. Used to populate PATH for software that depends on
 # your package.
-{{~ /unless}}
-{{#if pkg_bin_dirs ~}}
+{{ /unless }}
+{{ #if pkg_bin_dirs }}
 pkg_bin_dirs={{ pkg_bin_dirs }}
-{{~ else ~}}
+{{ else }}
 # pkg_bin_dirs=(bin)
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # An array of paths, relative to the final install of the software, where
 # pkg-config metadata (.pc files) can be found. Used to populate
 # PKG_CONFIG_PATH for software that depends on your package.
-{{~ /unless}}
-{{#if pkg_pconfig_dirs ~}}
+{{ /unless }}
+{{ #if pkg_pconfig_dirs }}
 pkg_pconfig_dirs={{ pkg_pconfig_dirs }}
-{{~ else ~}}
+{{ else }}
 # pkg_pconfig_dirs=(lib/pconfig)
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Optional.
+# OPTIONAL
 # The command for the Supervisor to execute when starting a service. You can
 # omit this setting if your package is not intended to be run directly by a
 # Supervisor of if your plan contains a run hook in hooks/run.
-{{#if pkg_svc_run ~}}
+{{ #if pkg_svc_run }}
 pkg_svc_run="{{ pkg_svc_run }}"
-{{~ else ~}}
+{{ else }}
 # pkg_svc_run="haproxy -f $pkg_svc_config_path/haproxy.conf"
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # An associative array representing configuration data which should be gossiped to peers. The keys
 # in this array represent the name the value will be assigned and the values represent the toml path
 # to read the value.
-{{#if pkg_exports ~}}
+{{ #if pkg_exports }}
 pkg_exports={{ pkg_exports }}
-{{~ else ~}}
+{{ else }}
 # pkg_exports=(
 #   [host]=srv.address
 #   [port]=srv.port
 #   [ssl-port]=srv.ssl.port
 # )
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # An array of `pkg_exports` keys containing default values for which ports that this package
 # exposes. These values are used as sensible defaults for other tools. For example, when exporting
 # a package to a container format.
-{{#if pkg_exposes ~}}
+{{ #if pkg_exposes }}
 pkg_exposes={{ pkg_exposes }}
-{{~ else ~}}
+{{ else }}
 # pkg_exposes=(port ssl-port)
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # An associative array representing services which you depend on and the configuration keys that
 # you expect the service to export (by their `pkg_exports`). These binds *must* be set for the
 # Supervisor to load the service. The loaded service will wait to run until it's bind becomes
 # available. If the bind does not contain the expected keys, the service will not start
 # successfully.
-{{#if pkg_binds ~}}
+{{ #if pkg_binds }}
 pkg_binds={{ pkg_binds }}
-{{~ else ~}}
+{{ else }}
 # pkg_binds=(
 #   [database]="port host"
 # )
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # Same as `pkg_binds` but these represent optional services to connect to.
-{{#if pkg_binds_optional ~}}
+{{ #if pkg_binds_optional }}
 pkg_binds_optional={{ pkg_binds_optional }}
-{{~ else ~}}
+{{ else }}
 # pkg_binds_optional=(
 #   [storage]="port host"
 # )
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # An array of interpreters used in shebang lines for scripts. Specify the
 # subdirectory where the binary is relative to the package, for example,
 # bin/bash or libexec/neverland, since binaries can be located in directories
 # besides bin. This list of interpreters will be written to the metadata
 # INTERPRETERS file, located inside a package, with their fully-qualified path.
 # Then these can be used with the fix_interpreter function.
-{{#if pkg_interpreters ~}}
+{{ #if pkg_interpreters }}
 pkg_interpreters={{ pkg_interpreters }}
-{{~ else ~}}
+{{ else }}
 # pkg_interpreters=(bin/bash)
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # The user to run the service as. The default is hab.
-{{#if pkg_svc_user ~}}
+{{#if pkg_svc_user }}
 pkg_svc_user="{{ pkg_svc_user }}"
-{{~ else ~}}
+{{ else }}
 # pkg_svc_user="hab"
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # The group to run the service as. The default is hab.
-{{#if pkg_svc_group ~}}
+{{ #if pkg_svc_group }}
 pkg_svc_group="{{ pkg_svc_group }}"
-{{~ else ~}}
+{{ else }}
 # pkg_svc_group="$pkg_svc_user"
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # The signal to send the service to shutdown. The default is TERM.
-{{#if pkg_shutdown_signal ~}}
+{{#if pkg_shutdown_signal }}
 pkg_shutdown_signal="{{ pkg_shutdown_signal }}"
-{{~ else ~}}
+{{ else }}
 # pkg_shutdown_signal="TERM"
-{{~ /if}}
+{{ /if }}
 
-# Optional.
+# OPTIONAL
 # The number of seconds to wait for a service to shutdown. After this interval
 # the service will forcibly be killed. The default is 8.
-{{#if pkg_shutdown_timeout_sec ~}}
+{{ #if pkg_shutdown_timeout_sec }}
 pkg_shutdown_timeout_sec="{{ pkg_shutdown_timeout_sec }}"
-{{~ else ~}}
+{{ else }}
 # pkg_shutdown_timeout_sec=8
-{{~ /if}}
-{{~ /unless}}
+{{ /if }}
+{{ /unless }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required for core plans, optional otherwise.
+# REQUIRED for core plans, OPTIONAL otherwise
 # A short description of the package. It can be a simple string, or you can
 # create a multi-line description using markdown to provide a rich description
 # of your package.
-{{~ /unless}}
-{{#if pkg_description ~}}
+{{ /unless }}
+{{#if pkg_description }}
 pkg_description="{{ pkg_description }}"
-{{~ else ~}}
+{{ else }}
 # pkg_description="Some description."
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
-
-{{~ #unless minimal}}
-
-# Required for core plans, optional otherwise.
+# REQUIRED for core plans, OPTIONAL otherwise
 # The project home page for the package.
-{{~ /unless}}
-{{#if pkg_upstream_url ~}}
+{{ /unless }}
+{{#if pkg_upstream_url }}
 pkg_upstream_url="{{ pkg_upstream_url }}"
-{{~ else ~}}
+{{ else }}
 # pkg_upstream_url="http://example.com/project-name"
-{{~ /if}}
+{{ /if }}
+{{ #unless minimal }}
 
+################################################################################
+# CALLBACKS - https://docs.chef.io/habitat/build_phase_callbacks/
+################################################################################
 
-{{~ #unless minimal}}
-
-# Callback Functions
-#
 # When defining your plan, you have the flexibility to override the default
 # behavior of Habitat in each part of the package building stage through a
 # series of callbacks. To define a callback, simply create a shell function
@@ -348,10 +314,6 @@ pkg_upstream_url="{{ pkg_upstream_url }}"
 # implementation (Bash does not allow empty function bodies.) If callbacks do
 # nothing or do the same as the default implementation, they can be removed from
 # this template.
-#
-# The default implementations (the do_default_* functions) are defined in the
-# plan build script:
-# https://github.com/habitat-sh/habitat/tree/master/components/plan-build/bin/hab-plan-build.sh
 
 # The default implmentation does nothing. You can use it to execute any
 # arbitrary commands before anything else happens.
@@ -450,7 +412,8 @@ do_strip() {
 do_end() {
   do_default_end
 }
-{{~ else}}
+
+{{ else }}
 
 do_build() {
   do_default_build
@@ -460,4 +423,4 @@ do_install() {
   do_default_install
 }
 
-{{~ /unless}}
+{{ /unless }}

--- a/test/end-to-end/test_hab_plan_cli.ps1
+++ b/test/end-to-end/test_hab_plan_cli.ps1
@@ -1,0 +1,108 @@
+Describe 'hab plan render' {
+
+    BeforeAll {
+        $tempdir = New-TemporaryDirectory
+
+        $output = hab plan render ./test/fixtures/render/consul/config/consul_config.json `
+            --default-toml ./test/fixtures/render/consul/default.toml `
+            --mock-data ./test/fixtures/render/consul/override.json `
+            --render-dir $tempdir `
+            --user-toml ./test/fixtures/render/consul/user.toml `
+            --print 2>&1
+
+        $render_exitcode = $LASTEXITCODE
+        $outfile = Join-Path -Path $tempdir.FullName consul_config.json
+
+        # PSScriptAnalyzer can't see the actual usages so | Out-Null
+        $output | Out-Null
+        $render_exitcode | Out-Null
+        $outfile | Out-Null
+    }
+
+    AfterAll {
+        Remove-Item -Path $tempdir -Recurse -Force
+    }
+
+    It 'should succeed' {
+        if ( $render_exitcode -ne 0 ) {
+            $output | Write-Host
+        }
+        $render_exitcode | Should -Be 0
+    }
+
+    It '--print should work' {
+        $output | Should -Not -BeNullOrEmpty
+    }
+
+    It '--render-dir should work' {
+        $outfile | Should -Exist
+    }
+
+    It '--default-toml should work' {
+        $outfile | Should -FileContentMatch 'IN_DEFAULT_TOML'
+    }
+
+    It '--mock-data should work' {
+        $outfile | Should -FileContentMatch 'IN_OVERRIDE_JSON'
+    }
+
+    It '--user-toml should work' {
+        $outfile | Should -FileContentMatch 'IN_USER_TOML'
+    }
+}
+
+Describe 'hab plan init' {
+
+    BeforeAll {
+        $testroot = Get-Location
+        if ($IsWindows) {
+            $plan_file = 'plan.ps1'
+        } else {
+            $plan_file = 'plan.sh'
+        }
+        $testroot | Out-Null
+        # PSScriptAnalyzer can't see the actual usages so | Out-Null
+        $plan_file | Out-Null
+    }
+
+    BeforeEach {
+        $tempdir = New-TemporaryDirectory
+        Set-Location $tempdir
+        $plan_path = Join-Path -Path $tempdir bar $plan_file
+        # PSScriptAnalyzer can't see the actual usages so | Out-Null
+        $plan_path | Out-Null
+    }
+
+    AfterEach {
+        Set-Location $testroot
+        Remove-Item -Path $tempdir -Recurse -Force
+    }
+
+    It 'normal plan file (scaffolding placeholder)' {
+        hab plan init --origin foo bar 2>&1 | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        $plan_path | Should -Exist
+        $plan_path | Should -FileContentMatch "# This file is the heart of your application's habitat."
+        $plan_path | Should -FileContentMatch 'pkg_scaffolding="some/scaffolding"'
+        $plan_path | Should -Not -FileContentMatch 'pkg_scaffolding="core/scaffolding-.+"'
+    }
+
+    It 'minimal plan file (scaffolding placeholder)' {
+        hab plan init --origin foo --min bar 2>&1 | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        $plan_path | Should -Exist
+        $plan_path | Should -Not -FileContentMatch "# This file is the heart of your application's habitat."
+        $plan_path | Should -FileContentMatch 'pkg_scaffolding="some/scaffolding"'
+        $plan_path | Should -Not -FileContentMatch 'pkg_scaffolding="core/scaffolding-.+"'
+    }
+
+    It 'minimal plan file with scaffolding specified' {
+        hab plan init --origin foo --min bar --scaffolding go 2>&1 | Out-Null
+        $LASTEXITCODE | Should -Be 0
+        $plan_path | Should -Exist
+        $plan_path | Should -Not -FileContentMatch "# This file is the heart of your application's habitat."
+        $plan_path | Should -Not -FileContentMatch 'pkg_scaffolding="some/scaffolding"'
+        $plan_path | Should -FileContentMatch 'pkg_scaffolding="core/scaffolding-go"'
+        $plan_path | Should -FileContentMatch 'pkg_scaffolding="core/scaffolding-.+"'
+    }
+}


### PR DESCRIPTION
- Fixes `hab plan render` by fixing the default.toml parsing
- Fixes parsing of the argument passed to --scaffolding restoring scaffold plan generation
- Restores scaffolding functionality on windows
- Updates template_plan.sh and template_plan.ps1 to fix `hab plan init`
  - Removes almost all use of `{{~` and `~}}` to stop lines from running together after handlebars upgrade
  - introduces newlines to separate settings that were previously running together
  - Upcases 'Required.' and 'Optional.' and drops the period
  - Replaces no longer available doc URLs with current viable doc URLs
  - Normalizes whitespace in the handlebars templates as it was inconsistent
- requires --scaffolding for a non-placeholder scaffoding setting
  - for some reason the code was always defaulting to "core/scaffolding-ruby" 
- add an end-to-end test for `hab plan init` and `hab plan render`
