### PR TITLE
prevent caching issues downloading shasum

### DIFF
--- a/components/hab/install.ps1
+++ b/components/hab/install.ps1
@@ -57,7 +57,8 @@ Function Get-Archive($channel, $version) {
 
         $hab_url="$url/habitat/${version}/hab-x86_64-windows.zip"
     }
-    $sha_url="$hab_url.sha256sum"
+    # add a random number to querystring to prevent caching issues
+    $sha_url="$hab_url.sha256sum?rand=$(Get-Random)"
     $hab_dest = (Join-Path ($workdir) "hab.zip")
     $sha_dest = (Join-Path ($workdir) "hab.zip.shasum256")
 


### PR DESCRIPTION
This should fix the windows migrate tests. I was able to reproduce the issue locally and the local web client was pulling a cached shasum from the acceptance channel.