### PR TITLE
initialize env_logger

### DIFF
--- a/components/hab/src/main.rs
+++ b/components/hab/src/main.rs
@@ -6,6 +6,7 @@ use hab::cli_driver;
 
 #[tokio::main]
 async fn main() {
+    env_logger::init();
     let mut ui = UI::default_with_env();
     let features = FeatureFlag::from_env(&mut ui);
     if let Err(e) = cli_driver(&mut ui, features).await {


### PR DESCRIPTION
oopsies. somehow this got dropped in the clap v2 purge.