### PR TITLE
Adds test_hab_plan_cli to e2e pipeline

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -1155,6 +1155,37 @@ steps:
             - BUILDKITE_AGENT_ACCESS_TOKEN
             - HAB_AUTH_TOKEN
 
+  - label: "[:linux: test_hab_plan_cli]"
+    command:
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_hab_plan_cli
+    artifact_paths:
+      - "*.log"
+    env:
+      BUILD_PKG_TARGET: x86_64-linux
+    expeditor:
+      executor:
+        docker:
+          privileged: true
+          environment:
+            - BUILD_PKG_TARGET=x86_64-linux
+            - HAB_AUTH_TOKEN
+
+  - label: "[:windows: test_hab_plan_cli]"
+    command:
+      - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_hab_plan_cli
+    artifact_paths:
+      - "*.log"
+    env:
+      BUILD_PKG_TARGET: x86_64-windows
+    expeditor:
+      executor:
+        docker:
+          host_os: windows
+          environment:
+            - BUILD_PKG_TARGET=x86_64-windows
+            - BUILDKITE_AGENT_ACCESS_TOKEN
+            - HAB_AUTH_TOKEN
+
   - wait
 
   - label: "[:habicat: Promote to Acceptance]"


### PR DESCRIPTION
Checked the e2e execution and realized that the new test still needed to be added to the e2e pipeline.