### PR TITLE
Removes 'succeeds with autobuild' from test_pkg_bulkupload.ps1

### DIFF
--- a/test/end-to-end/test_pkg_bulkupload.ps1
+++ b/test/end-to-end/test_pkg_bulkupload.ps1
@@ -40,10 +40,6 @@ Describe "hab pkg bulkupload" {
         hab pkg bulkupload --channel bulkuploadtest $cacheDir
         $LASTEXITCODE | Should -Be 0
     }
-    It "succeeds with autobuild" {
-        hab pkg bulkupload --auto-build $cacheDir
-        $LASTEXITCODE | Should -Be 0
-    }
     It "fails without directory argument" {
         hab pkg bulkupload
         $LASTEXITCODE | Should -Not -Be 0


### PR DESCRIPTION
Removes 'succeeds with autobuild' from test_pkg_bulkupload.ps1 as --auto-build was disabled in the context of hab pkg bulkupload