### PR TITLE
default remote-sup to localhost

### DIFF
--- a/components/hab/src/cli_v4/utils.rs
+++ b/components/hab/src/cli_v4/utils.rs
@@ -218,8 +218,7 @@ pub(crate) struct RemoteSup {
     #[arg(name = "REMOTE_SUP",
                 long = "remote-sup",
                 short = 'r',
-                default_value = "127.0.0.1:9632",
-                default_missing_value = ListenCtlAddr::default_as_str())]
+                default_value = ListenCtlAddr::default_as_str())]
     remote_sup: Option<ResolvedListenCtlAddr>,
 }
 


### PR DESCRIPTION
`localhost` was the default in 1.6 and this is also causing an e2e test to fail.