### PR TITLE
remove convenience dependencies of docker and buildah

### DIFF
--- a/components/pkg-export-container/habitat/plan.ps1
+++ b/components/pkg-export-container/habitat/plan.ps1
@@ -4,7 +4,6 @@ $pkg_maintainer = "The Habitat Maintainers <humans@habitat.sh>"
 $pkg_license = @("Apache-2.0")
 $pkg_bin_dirs = @("bin")
 $pkg_deps=@(
-    "core/docker",
     "core/visual-cpp-redist-2022"
 )
 $pkg_build_deps = @(

--- a/components/pkg-export-container/habitat/plan.sh
+++ b/components/pkg-export-container/habitat/plan.sh
@@ -4,10 +4,7 @@ _pkg_distname=$pkg_name
 pkg_origin=chef
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
-pkg_deps=(
-    core/buildah
-    core/docker
-)
+pkg_deps=()
 pkg_build_deps=(
     core/musl
     core/perl # Needed for vendored openssl-sys


### PR DESCRIPTION
This removes buildah and docker as runtime deps of the container exporter. We bundle those as a convenience but including this has become burdensome due to the CVEs in their GO ecosystem and not having direct control over them. Any user interested in leveraging docker or buildah is likely going to have these already installed anyways. If they are not installed, the user will get an error message stating that the container engine is missing from the PATH.