### PR TITLE
macOS Studio handling

### DIFF
--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -65,22 +65,49 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
                                                local_cache_key_path.display())));
     }
 
-    let mut volumes = vec![format!("{}:{}{}",
-                                   env::current_dir().unwrap().to_string_lossy(),
-                                   mnt_prefix,
-                                   "/src"),
-                           format!("{}:{}/{}",
-                                   local_cache_key_path.display(),
-                                   mnt_prefix,
-                                   CACHE_KEY_PATH_POSTFIX),];
-    if let Ok(cache_artifact_path) = henv::var(ARTIFACT_PATH_ENVVAR) {
-        // Don't use Path::join here as "\" can cause problems in Docker mounts
+    let mut volumes = vec![];
+
+    volumes.push(format!("{}:{}{}",
+                         env::current_dir().unwrap().to_string_lossy(),
+                         mnt_prefix,
+                         "/src"));
+    if !cfg!(target_os = "macos") {
         volumes.push(format!("{}:{}/{}",
-                             cache_artifact_path, mnt_prefix, CACHE_ARTIFACT_PATH));
-    }
-    if let Ok(cache_ssl_path) = henv::var(CERT_PATH_ENVVAR) {
-        // Don't use Path::join here as "\" can cause problems in Docker mounts
-        volumes.push(format!("{}:{}/{}", cache_ssl_path, mnt_prefix, CACHE_SSL_PATH));
+                             local_cache_key_path.display(),
+                             mnt_prefix,
+                             CACHE_KEY_PATH_POSTFIX));
+
+        if let Ok(cache_artifact_path) = henv::var(ARTIFACT_PATH_ENVVAR) {
+            // Don't use Path::join here as "\" can cause problems in Docker mounts
+            volumes.push(format!("{}:{}/{}",
+                                 cache_artifact_path, mnt_prefix, CACHE_ARTIFACT_PATH));
+        }
+
+        if let Ok(cache_ssl_path) = henv::var(CERT_PATH_ENVVAR) {
+            // Don't use Path::join here as "\" can cause problems in Docker mounts
+            volumes.push(format!("{}:{}/{}", cache_ssl_path, mnt_prefix, CACHE_SSL_PATH));
+        }
+    } else {
+        volumes.push(format!("{}:{}/{}",
+                             local_cache_key_path.display(),
+                             mnt_prefix,
+                             CACHE_KEY_PATH_POSTFIX.strip_prefix("opt/").unwrap()));
+
+        if let Ok(cache_artifact_path) = henv::var(ARTIFACT_PATH_ENVVAR) {
+            // Don't use Path::join here as "\" can cause problems in Docker mounts
+            volumes.push(format!("{}:{}/{}",
+                                 cache_artifact_path,
+                                 mnt_prefix,
+                                 CACHE_ARTIFACT_PATH.strip_prefix("opt/").unwrap()));
+        }
+
+        if let Ok(cache_ssl_path) = henv::var(CERT_PATH_ENVVAR) {
+            // Don't use Path::join here as "\" can cause problems in Docker mounts
+            volumes.push(format!("{}:{}/{}",
+                                 cache_ssl_path,
+                                 mnt_prefix,
+                                 CACHE_SSL_PATH.strip_prefix("opt/").unwrap()));
+        }
     }
     if !using_windows_containers
        && (Path::new(DOCKER_SOCKET).exists() || cfg!(target_os = "windows"))

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -91,14 +91,18 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
         volumes.push(format!("{}:{}/{}",
                              local_cache_key_path.display(),
                              mnt_prefix,
-                             CACHE_KEY_PATH_POSTFIX.strip_prefix("opt/").unwrap()));
+                             CACHE_KEY_PATH_POSTFIX.strip_prefix("opt/")
+                                                   .expect("key cache path not starting with \
+                                                            'opt/' on macOS.")));
 
         if let Ok(cache_artifact_path) = henv::var(ARTIFACT_PATH_ENVVAR) {
             // Don't use Path::join here as "\" can cause problems in Docker mounts
             volumes.push(format!("{}:{}/{}",
                                  cache_artifact_path,
                                  mnt_prefix,
-                                 CACHE_ARTIFACT_PATH.strip_prefix("opt/").unwrap()));
+                                 CACHE_ARTIFACT_PATH.strip_prefix("opt/")
+                                                    .expect("artifact cache path not starting \
+                                                             with 'opt/' on macOS.")));
         }
 
         if let Ok(cache_ssl_path) = henv::var(CERT_PATH_ENVVAR) {
@@ -106,7 +110,9 @@ pub fn start_docker_studio(_ui: &mut UI, args: &[OsString]) -> Result<()> {
             volumes.push(format!("{}:{}/{}",
                                  cache_ssl_path,
                                  mnt_prefix,
-                                 CACHE_SSL_PATH.strip_prefix("opt/").unwrap()));
+                                 CACHE_SSL_PATH.strip_prefix("opt/")
+                                               .expect("ssl cache path not starting with \
+                                                        'opt/' on macOS.")));
         }
     }
     if !using_windows_containers
@@ -184,9 +190,15 @@ fn update_ssl_cert_file_envvar(mnt_prefix: &str) {
                 // Don't use Path::join here in order to work around platform
                 // differences with paths on Windows with linux containers enabled
                 // TODO: Audit that the environment access only happens in single-threaded code.
+                let cache_ssl_path = if cfg!(target_os = "macos") {
+                    CACHE_SSL_PATH.strip_prefix("opt/")
+                                  .expect("ssl cache path not starting with 'opt/' on macOS")
+                } else {
+                    CACHE_SSL_PATH
+                };
                 unsafe {
                     env::set_var(SSL_CERT_FILE_ENVVAR,
-                                 format!("{}/{}/{}", mnt_prefix, CACHE_SSL_PATH, cert_file_name))
+                                 format!("{}/{}/{}", mnt_prefix, cache_ssl_path, cert_file_name))
                 };
             } else {
                 warn!("Unable to format {:?} for use inside studio", ssl_cert_file);
@@ -471,7 +483,11 @@ mod tests {
         // Don't use Path::join here because we format! the path above,
         // in order to work around platform differences with paths on
         // windows with linux containers enabled
-        let internal_cert_path = format!("{}/{}/{}", mnt_prefix, CACHE_SSL_PATH, key_name);
+        let internal_cert_path = format!("{}/{}/{}",
+                                         mnt_prefix,
+                                         CACHE_SSL_PATH.strip_prefix("opt/")
+                                                       .unwrap_or(CACHE_SSL_PATH),
+                                         key_name);
 
         assert_eq!(std::env::var(SSL_CERT_FILE_ENVVAR), Ok(internal_cert_path));
     }

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -154,10 +154,8 @@ mod inner {
     use crate::{VERSION,
                 command::studio::{docker,
                                   native},
-                common::{FEATURE_FLAGS,
-                         FeatureFlag,
-                         ui::{UI,
-                              UIWriter}},
+                common::ui::{UI,
+                             UIWriter},
                 error::{Error,
                         Result},
                 exec};
@@ -180,58 +178,60 @@ mod inner {
     const STUDIO_CMD_ENVVAR: &str = "HAB_STUDIO_BINARY";
 
     pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
-        if cfg!(target_os = "linux") || FEATURE_FLAGS.contains(FeatureFlag::MACOS_NATIVE_SUPPORT) {
-            if is_native_studio(args) {
+        if is_native_studio(args) {
+            if cfg!(target_os = "linux") {
                 rerun_with_sudo_if_needed(ui, args, true)?;
                 native::start_native_studio(ui, args)
             } else {
-                rerun_with_sudo_if_needed(ui, args, false)?;
-                if is_docker_studio(args) {
-                    docker::start_docker_studio(ui, args)
-                } else {
-                    let command = match henv::var(STUDIO_CMD_ENVVAR) {
-                        Ok(command) => PathBuf::from(command),
-                        Err(_) => {
-                            init()?;
-                            let version: Vec<&str> = VERSION.split('/').collect();
-                            let ident = PackageIdent::from_str(&format!("{}/{}",
-                                                                    super::STUDIO_PACKAGE_IDENT,
-                                                                    version[0]))?;
-                            let command = exec::command_from_min_pkg(ui, STUDIO_CMD, &ident).await?;
-                            // This is a duplicate of the code in `hab pkg exec` and
-                            // should be refactored as part of or after:
-                            // https://github.com/habitat-sh/habitat/issues/6633
-                            // https://github.com/habitat-sh/habitat/issues/6634
-                            let pkg_install = PackageInstall::load(&ident, None)?;
-                            let cmd_env = pkg_install.environment_for_command()?;
-                            for (key, value) in cmd_env.into_iter() {
-                                debug!("Setting: {}='{}'", key, value);
-                                // TODO: Audit that the environment access only happens in
-                                // single-threaded code.
-                                unsafe { env::set_var(key, value) };
-                            }
-
-                            let mut display_args = STUDIO_CMD.to_string();
-                            for arg in args {
-                                display_args.push(' ');
-                                display_args.push_str(arg.to_string_lossy().as_ref());
-                            }
-                            debug!("Running: {}", display_args);
-
-                            command
-                        }
-                    };
-                    if let Some(cmd) = find_command(command.to_string_lossy().as_ref()) {
-                        process::become_command(cmd, args)?;
-                        Ok(())
-                    } else {
-                        Err(Error::ExecCommandNotFound(command))
-                    }
-                }
+                log::error!("Native Studio not supported for this Platform.");
+                return Err(Error::ArgumentError("Native Studio not supported for \
+                                                 macOS."
+                                                        .to_string()));
             }
         } else {
-            // Fallback to docker studio when not on Linux and feature flag not enabled
-            docker::start_docker_studio(ui, args)
+            rerun_with_sudo_if_needed(ui, args, false)?;
+            if is_docker_studio(args) {
+                docker::start_docker_studio(ui, args)
+            } else {
+                let command = match henv::var(STUDIO_CMD_ENVVAR) {
+                    Ok(command) => PathBuf::from(command),
+                    Err(_) => {
+                        init()?;
+                        let version: Vec<&str> = VERSION.split('/').collect();
+                        let ident = PackageIdent::from_str(&format!("{}/{}",
+                                                                    super::STUDIO_PACKAGE_IDENT,
+                                                                    version[0]))?;
+                        let command = exec::command_from_min_pkg(ui, STUDIO_CMD, &ident).await?;
+                        // This is a duplicate of the code in `hab pkg exec` and
+                        // should be refactored as part of or after:
+                        // https://github.com/habitat-sh/habitat/issues/6633
+                        // https://github.com/habitat-sh/habitat/issues/6634
+                        let pkg_install = PackageInstall::load(&ident, None)?;
+                        let cmd_env = pkg_install.environment_for_command()?;
+                        for (key, value) in cmd_env.into_iter() {
+                            debug!("Setting: {}='{}'", key, value);
+                            // TODO: Audit that the environment access only happens in
+                            // single-threaded code.
+                            unsafe { env::set_var(key, value) };
+                        }
+
+                        let mut display_args = STUDIO_CMD.to_string();
+                        for arg in args {
+                            display_args.push(' ');
+                            display_args.push_str(arg.to_string_lossy().as_ref());
+                        }
+                        debug!("Running: {}", display_args);
+
+                        command
+                    }
+                };
+                if let Some(cmd) = find_command(command.to_string_lossy().as_ref()) {
+                    process::become_command(cmd, args)?;
+                    Ok(())
+                } else {
+                    Err(Error::ExecCommandNotFound(command))
+                }
+            }
         }
     }
 

--- a/components/hab/src/command/studio/enter.rs
+++ b/components/hab/src/command/studio/enter.rs
@@ -179,15 +179,8 @@ mod inner {
 
     pub async fn start(ui: &mut UI, args: &[OsString]) -> Result<()> {
         if is_native_studio(args) {
-            if cfg!(target_os = "linux") {
-                rerun_with_sudo_if_needed(ui, args, true)?;
-                native::start_native_studio(ui, args)
-            } else {
-                log::error!("Native Studio not supported for this Platform.");
-                return Err(Error::ArgumentError("Native Studio not supported for \
-                                                 macOS."
-                                                        .to_string()));
-            }
+            rerun_with_sudo_if_needed(ui, args, true)?;
+            native::start_native_studio(ui, args)
         } else {
             rerun_with_sudo_if_needed(ui, args, false)?;
             if is_docker_studio(args) {

--- a/components/hab/src/command/studio/native.rs
+++ b/components/hab/src/command/studio/native.rs
@@ -20,11 +20,12 @@ const HAB_PLAN_BUILD_SOURCE_FILES: [(&str, &[u8]); 4] =
      ("hab-plan-build.sh", include_bytes!("../../../../plan-build/bin/hab-plan-build-linux.sh"))];
 
 #[cfg(target_os = "macos")]
-const HAB_PLAN_BUILD_SOURCE_FILES: [(&str, &[u8]); 5] =
+const HAB_PLAN_BUILD_SOURCE_FILES: [(&str, &[u8]); 6] =
     [("environment.bash", include_bytes!("../../../../plan-build/bin/environment.bash")),
      ("shared.bash", include_bytes!("../../../../plan-build/bin/shared.bash")),
      ("public.bash", include_bytes!("../../../../plan-build/bin/public.bash")),
      ("hab-plan-build.sh", include_bytes!("../../../../plan-build/bin/hab-plan-build-darwin.sh")),
+     ("internal.sh", include_bytes!("../../../../plan-build/bin/internal.sh")),
      ("hab-plan-build-darwin-internal.bash",
       include_bytes!("../../../../plan-build/bin/hab-plan-build-darwin-internal.bash"))];
 


### PR DESCRIPTION
- without any argument starts "studio" from the `chef/hab-studio` package (No need for FeatureFlag)
- with -D starts the "docker" studio (the current behavior without any flags)
- ~with -N flag - errors out - Native studion not supported for macOS~

Also fixed paths of volumes mapped into docker container as the mapped paths inside the containers should be consistent with "Linux" paths (that is without the "opt/" prefix.)