### PR TITLE
Using 'base-2025' channel for pipelines and plan-build fix

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -1389,5 +1389,3 @@ steps:
       executor:
         docker:
           privileged: true
-          environment:
-            - JOB_HAB_BLDR_URL=https://bldr.acceptance.habitat.sh

--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -3,9 +3,6 @@ expeditor:
     HAB_AUTH_TOKEN:
       path: account/static/habitat/chef-ci
       field: auth_token # Production Builder
-    ACCEPTANCE_HAB_AUTH_TOKEN:
-      path: account/static/habitat/chef-ci
-      field: acceptance_auth_token # Acceptance Builder
   accounts:
     - aws/chef-cd
   defaults:

--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -81,7 +81,6 @@ steps:
       - ". vault-util-init"
       - "sudo -E .expeditor/scripts/release_habitat/build_component-aarch64-darwin.sh components/hab"
     env:
-      PIPELINE_HAB_BLDR_URL: "https://bldr.acceptance.habitat.sh"
       BUILD_PKG_TARGET: "aarch64-darwin"
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -134,7 +133,6 @@ steps:
       - ". vault-util-init"
       - "sudo -E .expeditor/scripts/release_habitat/build_component-aarch64-darwin.sh components/plan-build"
     env:
-      PIPELINE_HAB_BLDR_URL: "https://bldr.acceptance.habitat.sh"
       BUILD_PKG_TARGET: "aarch64-darwin"
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -176,7 +174,6 @@ steps:
       - ". vault-util-init"
       - "sudo -E .expeditor/scripts/release_habitat/build_component-aarch64-darwin.sh components/backline"
     env:
-      PIPELINE_HAB_BLDR_URL: "https://bldr.acceptance.habitat.sh"
       BUILD_PKG_TARGET: "aarch64-darwin"
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -229,7 +226,6 @@ steps:
       - ". vault-util-init"
       - "sudo -E .expeditor/scripts/release_habitat/build_component-aarch64-darwin.sh components/studio"
     env:
-      PIPELINE_HAB_BLDR_URL: "https://bldr.acceptance.habitat.sh"
       BUILD_PKG_TARGET: "aarch64-darwin"
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -436,7 +432,6 @@ steps:
           privileged: true
           environment:
             - BUILD_PKG_TARGET=aarch64-darwin
-            - JOB_HAB_BLDR_URL=https://bldr.acceptance.habitat.sh
 
   - label: "Update Habitat Documentation"
     command:

--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -3,9 +3,6 @@ expeditor:
     HAB_AUTH_TOKEN:
       path: account/static/habitat/chef-ci
       field: auth_token # Production Builder
-    ACCEPTANCE_HAB_AUTH_TOKEN:
-      path: account/static/habitat/chef-ci
-      field: acceptance_auth_token # Production Builder
   accounts:
     - aws/chef-cd
   defaults:

--- a/.expeditor/release_habitat.pipeline.yml
+++ b/.expeditor/release_habitat.pipeline.yml
@@ -530,5 +530,3 @@ steps:
       executor:
         docker:
           privileged: true
-          environment:
-            - JOB_HAB_BLDR_URL=https://bldr.acceptance.habitat.sh

--- a/.expeditor/scripts/end_to_end/setup_environment_darwin.sh
+++ b/.expeditor/scripts/end_to_end/setup_environment_darwin.sh
@@ -13,17 +13,12 @@ source .expeditor/scripts/shared.sh
 # e.g. `dev`, `acceptance` etc.
 channel=${1:?You must specify a channel value}
 
-# Note: We should always have a `hab` binary installed in our CI
-# Anka VMs.
-
-HAB_BLDR_URL="https://bldr.acceptance.habitat.sh"
-HAB_AUTH_TOKEN="${ACCEPTANCE_HAB_AUTH_TOKEN}"
-
 # On macOS, /usr/bin is SIP-protected so we use /usr/local/bin.
 HAB_BINLINK_DIR="/usr/local/bin"
 hab_binary="$(command -v hab)"
 
-install_acceptance_bootstrap_hab_binary
+# This is required till we have binaries
+curlbash_hab "aarch64-darwin" acceptance
 
 
 # Now we are ready to install the `hab`
@@ -52,36 +47,18 @@ echo "--- Using chef/hab version $("${hab_binary}" --version)"
 # Supervisor tests are skipped on macOS (supervisor support is not yet
 # mature on aarch64-darwin), so we do not install hab-sup / hab-launcher.
 
-# Enable macOS native studio support (same flags used in release builds)
-export HAB_FEAT_MACOS_NATIVE_SUPPORT=1
-
-# Install hab-studio for native studio tests
-# echo "--- Installing chef/hab-studio from ${HAB_BLDR_URL}, aarch64-darwin-opt channel"
-# sudo -E "$hab_binary" pkg install chef/hab-studio \
-     # --channel="aarch64-darwin-opt" \
-     # --url="${HAB_BLDR_URL}"
-
-# hab-backline is required by the studio but is only available in stable
-#echo "--- Installing chef/hab-backline from ${HAB_BLDR_URL}, aarch64-darwin-opt channel"
-#sudo -E "$hab_binary" pkg install chef/hab-backline \
-     #--channel="stable" \
-     #--url="${HAB_BLDR_URL}"
-#export HAB_STUDIO_BACKLINE_PKG
-#HAB_STUDIO_BACKLINE_PKG="$(cat "$(hab pkg path chef/hab-backline)/IDENT")"
-#echo "--- HAB_STUDIO_BACKLINE_PKG=${HAB_STUDIO_BACKLINE_PKG}"
-
 # Override the interpreter identity to core/coreutils (installed via
 # hab-backline) because core/busybox-static is not available for
 # aarch64-darwin. This is needed for install hook execution.
 export HAB_INTERPRETER_IDENT="core/coreutils"
 
-echo "--- Installing latest core/powershell from ${HAB_BLDR_URL}, aarch64-darwin-opt channel"
+echo "--- Installing latest core/powershell from ${HAB_BLDR_URL}, base-2025 channel"
 # Try the hab package first, fall back to Homebrew
 if sudo -E "$hab_binary" pkg install core/powershell \
     --binlink \
     --binlink-dir="/usr/local/bin" \
     --force \
-    --channel="aarch64-darwin-opt" \
+    --channel="base-2025" \
     --url="${HAB_BLDR_URL}"; then
     echo "--- Using core/powershell version $(pwsh --version)"
 else
@@ -102,10 +79,10 @@ fi
 
 pwsh_path="$(command -v pwsh)"
 
-echo "--- Installing latest core/pester from ${HAB_BLDR_URL}, aarch64-darwin-opt channel"
+echo "--- Installing latest core/pester from ${HAB_BLDR_URL}, base-2025 channel"
 # Try the hab package first, fall back to PowerShell module
 if ! sudo -E "$hab_binary" pkg install core/pester \
-    --channel="aarch64-darwin-opt" \
+    --channel="base-2025" \
     --url="${HAB_BLDR_URL}"; then
     echo "--- core/pester not available for this platform, installing via PowerShell module"
     # Pin to Pester 4.x to match core/pester on Linux. All existing test

--- a/.expeditor/scripts/release_habitat/build_component-aarch64-darwin.sh
+++ b/.expeditor/scripts/release_habitat/build_component-aarch64-darwin.sh
@@ -13,9 +13,6 @@ trap 'rm -rf /opt/hab' ERR
 
 export HAB_BLDR_URL="${PIPELINE_HAB_BLDR_URL}"
 
-# Following env variable is required to run MacOS Native Studio
-export HAB_FEAT_MACOS_NATIVE_SUPPORT=1
-
 channel=$(get_release_channel)
 
 hab_binary=

--- a/.expeditor/scripts/release_habitat/build_component-aarch64-darwin.sh
+++ b/.expeditor/scripts/release_habitat/build_component-aarch64-darwin.sh
@@ -11,9 +11,6 @@ set -E
 
 trap 'rm -rf /opt/hab' ERR
 
-export HAB_AUTH_TOKEN="${ACCEPTANCE_HAB_AUTH_TOKEN}"
-# TODO: Remove the job specific override in the pipeline yaml once
-# builder changes are released.
 export HAB_BLDR_URL="${PIPELINE_HAB_BLDR_URL}"
 
 # Following env variable is required to run MacOS Native Studio
@@ -27,13 +24,13 @@ install_release_channel_hab_binary "${BUILD_PKG_TARGET}"
 echo "--- :key: Importing keys"
 import_keys
 
-# Install the 'hab-studio' from the aarch64-darwin-opt channel.
+# Install the 'hab-studio' from the base-2025 channel.
 # TODO: Move this to acceptance once we publish.
 # so this may need updating to support other channels.
-${hab_binary} pkg install chef/hab-studio -c aarch64-darwin-opt
+${hab_binary} pkg install chef/hab-studio -c base-2025
 
 export HAB_BLDR_CHANNEL="$channel"
-export HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL="aarch64-darwin-opt"
+export HAB_STUDIO_SECRET_HAB_FALLBACK_CHANNEL="base-2025"
 
 echo "--- :hab: Running hab pkg build for $package_path"
 sudo -E "${hab_binary}" pkg build "$package_path"

--- a/.expeditor/scripts/release_habitat/package_and_upload_binary.sh
+++ b/.expeditor/scripts/release_habitat/package_and_upload_binary.sh
@@ -23,13 +23,6 @@ import_gpg_keys
 tmp_root="$(mktemp --directory --tmpdir="$(pwd)" -t "repackage-XXXX")"
 cd "${tmp_root}"
 
-# We need to do special things for aarch64-darwin till we have a new builder
-# release. TODO: Remove this and JOB_BLDR_URL setting when we release builder
-if [[ "${BUILD_PKG_TARGET}" == "aarch64-darwin" ]]; then
-    export HAB_BLDR_URL="${JOB_HAB_BLDR_URL}"
-    export HAB_AUTH_TOKEN="${ACCEPTANCE_HAB_AUTH_TOKEN}"
-fi
-
 echo "--- Downloading chef/hab for $BUILD_PKG_TARGET from ${channel} channel"
 
 # Currently, we must explicitly specify `--url`, despite the presence

--- a/.expeditor/scripts/release_habitat/promote_artifacts_to_dev.sh
+++ b/.expeditor/scripts/release_habitat/promote_artifacts_to_dev.sh
@@ -73,27 +73,6 @@ for pkg in "${packages_to_promote[@]}"; do
     done
 done
 
-# BEGIN: aarch64-darwin specific quirks till we can do this on SaaS builder.
-# Don't need the 'HAB_AUTH_TOKEN' as we are doing simple curl.
-echo "--- Getting list of aarch64-darwin packages to be added to manifest.json file."
-mac_channel_pkgs_json=$(curl -s "${JOB_HAB_BLDR_URL}/v1/depot/channels/${HAB_ORIGIN}/${source_channel}/pkgs")
-mapfile -t mac_packages_to_promote < <(echo "${mac_channel_pkgs_json}" | \
-                         jq -r \
-                         '.data |
-                         map(.origin + "/" + .name + "/" + .version + "/" + .release)
-                         | .[]')
-
-for pkg in "${mac_packages_to_promote[@]}"; do
-    pkg_target="aarch64-darwin"
-    if ident_has_target "${pkg}" "${pkg_target}"; then
-        echo ":thumbsup: Adding ${pkg} (${pkg_target}) to the '${manifest_input_file}' file"
-        echo "${pkg} ${pkg_target}" >> "${manifest_input_file}"
-    else
-        echo ":thumbsdown: ${pkg} (${pkg_target}) was not a valid combination"
-    fi
-done
-# END: aarch64-darwin specific quirks till we can do this on SaaS builder.
-
 echo "--- Generating manifest.json file"
 version=$(get_version_from_repo)
 sha="${BUILDKITE_COMMIT}"

--- a/.expeditor/scripts/release_habitat/shared.sh
+++ b/.expeditor/scripts/release_habitat/shared.sh
@@ -58,16 +58,12 @@ get_latest_pkg_version_in_release_channel() {
 # *Requires* a pkg target argument.
 install_release_channel_hab_binary() {
     local pkg_target="${1}"
-    curlbash_hab "${pkg_target}"
 
-    # For macOS we will use the acceptance bootstrap binary 'for now'.
-    # TODO: Once the support is merged in the main - we don't need to do the following
-    # step anymore
     if [[ "${pkg_target}" == "aarch64-darwin" ]]; then
-        install_acceptance_bootstrap_hab_binary
-	hab_binary=$(command -v hab)
+        curlbash_hab "${pkg_target}" "acceptance"
+    else
+        curlbash_hab "${pkg_target}"
     fi
-
 
     echo "--- :habicat: Installed latest stable hab: $(${hab_binary} --version)"
     # now install the latest hab available in our channel, if it and the studio exist yet

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -586,7 +586,7 @@ need_cmd() {
 # Use the binary from the acceptance bldr bootstrap package that provides
 # the support for hab CLI with "/opt" support.
 # When we have the support *released* we do not need to do this anymore.
-install_acceptance_bootstrap_hab_binary() {
+install_bootstrap_hab_binary() {
     need_cmd install
 
     # Install the macOS bootstrap package that gives us GNU tar and GNU tail.
@@ -602,8 +602,8 @@ install_acceptance_bootstrap_hab_binary() {
     mkdir "${hab_scratch_dir}"
 
     "${hab_binary}" pkg download chef/hab \
-        --channel aarch64-darwin-opt \
-        --url https://bldr.acceptance.habitat.sh  \
+        --channel base-2025 \
+        --url https://bldr.habitat.sh  \
         --download-directory="${hab_scratch_dir}"
 
     local hab_artifact

--- a/.expeditor/scripts/shared.sh
+++ b/.expeditor/scripts/shared.sh
@@ -251,15 +251,8 @@ promote_packages_to_builder_channel() {
     echo "--- Promoting Habitat packages to the ${destination_channel} channel of ${HAB_BLDR_URL}"
     for target in "${targets[@]}"; do
 
-	# BEGIN: Additional Quirks for aarch64-darwin
-	if [[ "${target}" == "aarch64-darwin" ]]; then
-            hab_auth_token_promote=${ACCEPTANCE_HAB_AUTH_TOKEN}
-            hab_bldr_url_promote=${JOB_HAB_BLDR_URL}
-        else
-            hab_auth_token_promote=${HAB_AUTH_TOKEN}
-            hab_bldr_url_promote=${HAB_BLDR_URL}
-	fi
-	# END: Additional Quirks for aarch64-darwin
+        hab_auth_token_promote=${HAB_AUTH_TOKEN}
+        hab_bldr_url_promote=${HAB_BLDR_URL}
 
         mapfile -t idents < <(echo "${manifest_json}" | jq -r ".packages.\"${target}\" | .[]")
         for ident in "${idents[@]}"; do

--- a/.expeditor/scripts/verify/build_package-aarch64-darwin.sh
+++ b/.expeditor/scripts/verify/build_package-aarch64-darwin.sh
@@ -18,7 +18,9 @@ hab_binary=
 curlbash_hab "${BUILD_PKG_TARGET}" acceptance
 
 
-install_acceptance_bootstrap_hab_binary
+# TODO: remove the following line and the associated function as we are now able to get
+# required binaries using curl_bash
+# install_bootstrap_hab_binary
 bootstrap_hab_binary=$(command -v hab)
 echo "Bootstrap Package Version is : $($bootstrap_hab_binary -V)."
 

--- a/.expeditor/scripts/verify/build_package-aarch64-darwin.sh
+++ b/.expeditor/scripts/verify/build_package-aarch64-darwin.sh
@@ -18,9 +18,6 @@ hab_binary=
 curlbash_hab "${BUILD_PKG_TARGET}" acceptance
 
 
-# TODO: remove the following line and the associated function as we are now able to get
-# required binaries using curl_bash
-# install_bootstrap_hab_binary
 bootstrap_hab_binary=$(command -v hab)
 echo "Bootstrap Package Version is : $($bootstrap_hab_binary -V)."
 
@@ -32,7 +29,7 @@ HAB_ORIGIN=throwaway
 echo "--- :key: Generating fake origin key"
 sudo -E "${bootstrap_hab_binary}" origin key generate
 
-# Install hab-studio from the chef origin via the acceptance channel.
+# Install hab-studio from the chef origin via the base-2025 channel.
 # By default, it installs from the stable channel only,
 # so this may need updating to support other channels.
 ${bootstrap_hab_binary} pkg install chef/hab-studio -c base-2025

--- a/.expeditor/scripts/verify/build_package-aarch64-darwin.sh
+++ b/.expeditor/scripts/verify/build_package-aarch64-darwin.sh
@@ -11,11 +11,6 @@ set -E
 
 trap 'rm -rf /opt/hab' ERR
 
-# Following env variable is required to run MacOS Native Studio
-export HAB_FEAT_MACOS_NATIVE_SUPPORT=1
-
-export HAB_AUTH_TOKEN="${ACCEPTANCE_HAB_AUTH_TOKEN}"
-
 # Since we are using the *bootstrap* packages right now, we will need to 'install' `hab`
 # CLI twice - first get the original `hab` CLI and then use that to download the
 # 'bootstrap' version.
@@ -38,17 +33,14 @@ sudo -E "${bootstrap_hab_binary}" origin key generate
 # Install hab-studio from the chef origin via the acceptance channel.
 # By default, it installs from the stable channel only,
 # so this may need updating to support other channels.
-${bootstrap_hab_binary} pkg install chef/hab-studio -c aarch64-darwin-opt -u https://bldr.acceptance.habitat.sh
+${bootstrap_hab_binary} pkg install chef/hab-studio -c base-2025
 
 # Required for the `hab pkg build` command to download the studio and deps when
 # locally missing
-export HAB_INTERNAL_BLDR_CHANNEL="aarch64-darwin-opt"
+export HAB_INTERNAL_BLDR_CHANNEL="base-2025"
 
 # Required to download the deps of the package to be built
-export HAB_STUDIO_SECRET_HAB_BLDR_CHANNEL="aarch64-darwin-opt"
-
-# Required till we *release* the builder changes to Prod builder
-export HAB_BLDR_URL="https://bldr.acceptance.habitat.sh"
+export HAB_BLDR_CHANNEL="base-2025"
 
 echo "--- :hab: Running hab pkg build for $package_path"
 sudo -E "${bootstrap_hab_binary}" pkg build "$package_path"

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -5,9 +5,6 @@ expeditor:
     HAB_AUTH_TOKEN:
       path: account/static/habitat/chef-ci
       field: auth_token # Production Builder
-    ACCEPTANCE_HAB_AUTH_TOKEN:
-      path: account/static/habitat/chef-ci
-      field: acceptance_auth_token # acceptance builder (for macOS)
   defaults:
     buildkite:
       timeout_in_minutes: 60

--- a/components/plan-build/bin/hab-plan-build-darwin-internal.bash
+++ b/components/plan-build/bin/hab-plan-build-darwin-internal.bash
@@ -747,24 +747,35 @@ _resolve_dependency() {
 # _install_dependency acme/zlib/1.2.8/20151216221001
 # ```
 _install_dependency() {
-  local dep="${1}"
-  if [[ -z "${NO_INSTALL_DEPS:-}" ]]; then
+    local dep="${1}"
+    local origin
+    local channel="$HAB_BLDR_CHANNEL"
+    if [[ -z "${NO_INSTALL_DEPS:-}" || ${NO_INSTALL_DEPS} == "false" ]]; then
+        origin="$(echo "$dep" | cut -d "/" -f 1)"
+        if [[ $origin == "core" || $origin == "chef" ]]; then
+            if [[ $origin == "core" ]]; then
+                channel="$HAB_REFRESH_CHANNEL"
+            fi
+            if [[ $HAB_PREFER_LOCAL_CHEF_DEPS == "false" ]]; then
+                IGNORE_LOCAL="--ignore-local"
+            fi
+        fi
 
-    # Enable --ignore-local if invoked with HAB_FEAT_IGNORE_LOCAL in
-    # the environment, set to either "true" or "TRUE" (features are
-    # not currently enabled by the mere presence of an environment variable)
-    if [[ "${HAB_FEAT_IGNORE_LOCAL:-}" = "true" ||
-      "${HAB_FEAT_IGNORE_LOCAL:-}" = "TRUE" ]]; then
-      IGNORE_LOCAL="--ignore-local"
+        $HAB_BIN pkg install -u $HAB_BLDR_URL --channel $channel ${IGNORE_LOCAL:-} "$@" || {
+            if [[ "$channel" != "$HAB_FALLBACK_CHANNEL" ]]; then
+                build_line "Trying to install '$dep' from '$HAB_FALLBACK_CHANNEL'"
+                $HAB_BIN pkg install -u $HAB_BLDR_URL --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
+            fi
+        }
+    else
+        if resolved=$(_resolve_dependency "${dep}" |  sed "s|${HAB_PKG_PATH}[/]\?||g"); then
+            echo "${resolved}"
+            return 0
+        else
+            return 1
+        fi
     fi
-    $HAB_BIN pkg install -u $HAB_BLDR_URL --channel $HAB_BLDR_CHANNEL ${IGNORE_LOCAL:-} "$@" || {
-      if [[ "$HAB_BLDR_CHANNEL" != "$HAB_FALLBACK_CHANNEL" ]]; then
-        build_line "Trying to install '$dep' from '$HAB_FALLBACK_CHANNEL'"
-        $HAB_BIN pkg install -u $HAB_BLDR_URL --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
-      fi
-    }
-  fi
-  return 0
+    return 0
 }
 
 # **Internal** Returns (on stdout) the `TDEPS` file contents of another locally

--- a/components/plan-build/bin/hab-plan-build-darwin-internal.bash
+++ b/components/plan-build/bin/hab-plan-build-darwin-internal.bash
@@ -761,10 +761,10 @@ _install_dependency() {
             fi
         fi
 
-        $HAB_BIN pkg install -u $HAB_BLDR_URL --channel $channel ${IGNORE_LOCAL:-} "$@" || {
+        $HAB_BIN pkg install -u "$HAB_BLDR_URL" --channel "$channel" ${IGNORE_LOCAL:-} "$@" || {
             if [[ "$channel" != "$HAB_FALLBACK_CHANNEL" ]]; then
                 build_line "Trying to install '$dep' from '$HAB_FALLBACK_CHANNEL'"
-                $HAB_BIN pkg install -u $HAB_BLDR_URL --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
+                $HAB_BIN pkg install -u "$HAB_BLDR_URL" --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
             fi
         }
     else

--- a/components/plan-build/bin/hab-plan-build-darwin-internal.bash
+++ b/components/plan-build/bin/hab-plan-build-darwin-internal.bash
@@ -359,7 +359,7 @@ HAB_PLAN_FILENAME="plan.sh"
 export HAB_BLDR_URL
 # The default Habitat channel from where to download dependencies. If
 # `HAB_BLDR_CHANNEL` is set, this value is overridden.
-: "${HAB_BLDR_CHANNEL:=stable}"
+: "${HAB_BLDR_CHANNEL:=base}"
 # Export Builder channel so all other programs and subshells use this same one
 export HAB_BLDR_CHANNEL
 # Fall back here if package can't be installed from $HAB_BLDR_CHANNEL

--- a/components/plan-build/bin/hab-plan-build-darwin.sh
+++ b/components/plan-build/bin/hab-plan-build-darwin.sh
@@ -55,7 +55,7 @@ HAB_PLAN_FILENAME="plan.sh"
 export HAB_BLDR_URL
 # The default Habitat channel from where to download dependencies. If
 # `HAB_BLDR_CHANNEL` is set, this value is overridden.
-: "${HAB_BLDR_CHANNEL:=stable}"
+: "${HAB_BLDR_CHANNEL:=base}"
 # Export Builder channel so all other programs and subshells use this same one
 export HAB_BLDR_CHANNEL
 # Fall back here if package can't be installed from $HAB_BLDR_CHANNEL

--- a/components/plan-build/bin/hab-plan-build-linux.sh
+++ b/components/plan-build/bin/hab-plan-build-linux.sh
@@ -355,7 +355,7 @@ HAB_PLAN_FILENAME="plan.sh"
 export HAB_BLDR_URL
 # The default Habitat channel from where to download dependencies. If
 # `HAB_BLDR_CHANNEL` is set, this value is overridden.
-: "${HAB_BLDR_CHANNEL:=stable}"
+: "${HAB_BLDR_CHANNEL:=base}"
 # Export Builder channel so all other programs and subshells use this same one
 export HAB_BLDR_CHANNEL
 # Fall back here if package can't be installed from $HAB_BLDR_CHANNEL

--- a/components/plan-build/bin/internal.sh
+++ b/components/plan-build/bin/internal.sh
@@ -262,10 +262,10 @@ _install_dependency() {
             fi
         fi
 
-        $HAB_BIN pkg install -u $HAB_BLDR_URL --channel $channel ${IGNORE_LOCAL:-} "$@" || {
+        $HAB_BIN pkg install -u "$HAB_BLDR_URL" --channel "$channel" ${IGNORE_LOCAL:-} "$@" || {
             if [[ "$channel" != "$HAB_FALLBACK_CHANNEL" ]]; then
                 build_line "Trying to install '$dep' from '$HAB_FALLBACK_CHANNEL'"
-                $HAB_BIN pkg install -u $HAB_BLDR_URL --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
+                $HAB_BIN pkg install -u "$HAB_BLDR_URL" --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
             fi
         }
     else

--- a/components/plan-build/bin/internal.sh
+++ b/components/plan-build/bin/internal.sh
@@ -248,24 +248,35 @@ _resolve_dependency() {
 # _install_dependency acme/zlib/1.2.8/20151216221001
 # ```
 _install_dependency() {
-  local dep="${1}"
-  if [[ -z "${NO_INSTALL_DEPS:-}" ]]; then
+    local dep="${1}"
+    local origin
+    local channel="$HAB_BLDR_CHANNEL"
+    if [[ -z "${NO_INSTALL_DEPS:-}" || ${NO_INSTALL_DEPS} == "false" ]]; then
+        origin="$(echo "$dep" | cut -d "/" -f 1)"
+        if [[ $origin == "core" || $origin == "chef" ]]; then
+            if [[ $origin == "core" ]]; then
+                channel="$HAB_REFRESH_CHANNEL"
+            fi
+            if [[ $HAB_PREFER_LOCAL_CHEF_DEPS == "false" ]]; then
+                IGNORE_LOCAL="--ignore-local"
+            fi
+        fi
 
-    # Enable --ignore-local if invoked with HAB_FEAT_IGNORE_LOCAL in
-    # the environment, set to either "true" or "TRUE" (features are
-    # not currently enabled by the mere presence of an environment variable)
-    if [[ "${HAB_FEAT_IGNORE_LOCAL:-}" = "true" ||
-      "${HAB_FEAT_IGNORE_LOCAL:-}" = "TRUE" ]]; then
-      IGNORE_LOCAL="--ignore-local"
+        $HAB_BIN pkg install -u $HAB_BLDR_URL --channel $channel ${IGNORE_LOCAL:-} "$@" || {
+            if [[ "$channel" != "$HAB_FALLBACK_CHANNEL" ]]; then
+                build_line "Trying to install '$dep' from '$HAB_FALLBACK_CHANNEL'"
+                $HAB_BIN pkg install -u $HAB_BLDR_URL --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
+            fi
+        }
+    else
+        if resolved=$(_resolve_dependency "${dep}" |  sed "s|${HAB_PKG_PATH}[/]\?||g"); then
+            echo "${resolved}"
+            return 0
+        else
+            return 1
+        fi
     fi
-    $HAB_BIN pkg install -u "$HAB_BLDR_URL" --channel "$HAB_BLDR_CHANNEL" ${IGNORE_LOCAL:-} "$@" || {
-      if [[ "$HAB_BLDR_CHANNEL" != "$HAB_FALLBACK_CHANNEL" ]]; then
-        build_line "Trying to install '$dep' from '$HAB_FALLBACK_CHANNEL'"
-        $HAB_BIN pkg install -u "$HAB_BLDR_URL" --channel "$HAB_FALLBACK_CHANNEL" ${IGNORE_LOCAL:-} "$@" || true
-      fi
-    }
-  fi
-  return 0
+    return 0
 }
 
 # **Internal** Returns (on stdout) the `TDEPS` file contents of another locally


### PR DESCRIPTION
Fixed an issue with plan-build that was not using the `HAB_BLDR_CHANNEL` env correctly and updated verify pipeline use SAAS builder and base-2025 channel