### PR TITLE
fix aarch64-linux docker studio

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -450,6 +450,16 @@ steps:
           single-use: true
           privileged: true
 
+  - label: "[:linux: :docker: test_docker_studio_can_build_packages aarch64]"
+    command:
+      - bash .expeditor/scripts/end_to_end/run_e2e_test.sh dev test_docker_studio_can_build_packages
+    agents:
+      queue: default-privileged-aarch64
+    env:
+      BUILD_PKG_TARGET: "aarch64-linux"
+      DOCKER_STUDIO_TEST: true
+      HAB_STUDIO_SECRET_HAB_INTERNAL_BLDR_CHANNEL: dev
+
   - label: "[:windows: test_studio_supervisor]"
     command:
       - powershell .expeditor/scripts/end_to_end/run_e2e_test.ps1 dev test_studio_supervisor

--- a/.expeditor/scripts/end_to_end/setup_environment.sh
+++ b/.expeditor/scripts/end_to_end/setup_environment.sh
@@ -36,7 +36,7 @@ sudo -E hab pkg install chef/hab-pkg-export-container \
     --channel="${channel}" \
     --url="${HAB_BLDR_URL}"
 
-echo "--- Installing latest core/powershell from ${HAB_BLDR_URL}, stable channel"
+echo "--- Installing latest core/powershell from ${HAB_BLDR_URL}, base channel"
 # Binlink to '/usr/local/bin' to ensure we do not run the system installed version. The system
 # version is installed in `/usr/bin` which occurs earlier in the PATH than '/bin' (the default)
 # binlink location).
@@ -48,9 +48,15 @@ sudo -E hab pkg install core/powershell \
     --url="${HAB_BLDR_URL}"
 echo "--- Using core/powershell version $(pwsh --version)"
 
-echo "--- Installing latest core/pester from ${HAB_BLDR_URL}, stable channel"
+
+if [[ "${BUILD_PKG_TARGET}" == "aarch64-linux" ]]; then
+    pester_channel="base"
+else
+    pester_channel="stable"
+fi
+echo "--- Installing latest core/pester from ${HAB_BLDR_URL}, ${pester_channel} channel"
 sudo -E hab pkg install core/pester \
-    --channel="base" \
+    --channel="${pester_channel}" \
     --url="${HAB_BLDR_URL}"
 
 sudo useradd --system --no-create-home hab

--- a/.expeditor/scripts/end_to_end/setup_environment.sh
+++ b/.expeditor/scripts/end_to_end/setup_environment.sh
@@ -50,7 +50,7 @@ echo "--- Using core/powershell version $(pwsh --version)"
 
 echo "--- Installing latest core/pester from ${HAB_BLDR_URL}, stable channel"
 sudo -E hab pkg install core/pester \
-    --channel="stable" \
+    --channel="base" \
     --url="${HAB_BLDR_URL}"
 
 sudo useradd --system --no-create-home hab

--- a/.expeditor/scripts/end_to_end/setup_environment.sh
+++ b/.expeditor/scripts/end_to_end/setup_environment.sh
@@ -36,13 +36,6 @@ sudo -E hab pkg install chef/hab-pkg-export-container \
     --channel="${channel}" \
     --url="${HAB_BLDR_URL}"
 
-echo "--- Installing latest core/netcat from ${HAB_BLDR_URL}, base-2025 channel"
-sudo -E hab pkg install core/netcat \
-    --binlink \
-    --force \
-    --channel="base" \
-    --url="${HAB_BLDR_URL}"
-
 echo "--- Installing latest core/powershell from ${HAB_BLDR_URL}, stable channel"
 # Binlink to '/usr/local/bin' to ensure we do not run the system installed version. The system
 # version is installed in `/usr/bin` which occurs earlier in the PATH than '/bin' (the default)

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -454,6 +454,8 @@ mod tests {
                    format!("{}-{}:{}", DOCKER_IMAGE, "x86_64-linux", VERSION));
         assert_eq!(image_identifier(None, target::X86_64_LINUX),
                    format!("{}-{}:{}", DOCKER_IMAGE, "x86_64-linux", VERSION));
+        assert_eq!(image_identifier(None, target::AARCH64_LINUX),
+                   format!("{}-{}:{}", DOCKER_IMAGE, "aarch64-linux", VERSION));
         assert_eq!(image_identifier(None, target::X86_64_WINDOWS),
                    format!("{}-{}:{}", DOCKER_IMAGE, "x86_64-linux", VERSION));
         assert_eq!(image_identifier(Some("ltsc2016"), target::X86_64_WINDOWS),
@@ -463,10 +465,6 @@ mod tests {
                    format!("{}-{}:{}-{}",
                            DOCKER_WINDOWS_IMAGE, "x86_64-windows", "ltsc2016", VERSION));
     }
-
-    #[should_panic]
-    #[cfg(feature = "aarch64-linux")]
-    fn retrieve_aarch64_image_identifier() { image_identifier(None, target::AARCH64_LINUX); }
 
     #[test]
     fn update_ssl_cert_file_envvar_not_set() {

--- a/components/hab/src/command/studio/docker.rs
+++ b/components/hab/src/command/studio/docker.rs
@@ -421,7 +421,7 @@ fn studio_target(windows: bool, target: target::PackageTarget) -> target::Packag
         #[cfg(feature = "supported_targets")]
         target::AARCH64_DARWIN => target::X86_64_LINUX,
         #[cfg(feature = "supported_targets")]
-        target::AARCH64_LINUX => panic!("{} studios are not supported", target::AARCH64_LINUX),
+        target::AARCH64_LINUX => target::AARCH64_LINUX,
         #[cfg(feature = "supported_targets")]
         target::AARCH64_WINDOWS => {
             panic!("{} studios are not supported", target::AARCH64_LINUX)

--- a/test/end-to-end/test_docker_studio_can_build_packages.ps1
+++ b/test/end-to-end/test_docker_studio_can_build_packages.ps1
@@ -11,16 +11,4 @@ Describe "Studio build" {
         hab pkg build test/fixtures/plan-in-root -D
         $LASTEXITCODE | Should -Be 0
     }
-
-}
-
-Describe "Targeting different refresh channels" {
-    It "Can target non default refresh channel" {
-        hab pkg build test/fixtures/breakable-refresh-downgrade --refresh-channel LTS-2024 -D
-        Set-Content -Path "results/last_build.ps1" -Value ""
-        Get-Content "results/last_build.env" | ForEach-Object { Add-Content "results/last_build.ps1" -Value "`$$($_.Replace("=", '="'))`"" }
-        . ./results/last_build.ps1
-        hab pkg install ./results/$pkg_artifact
-        "/hab/pkgs/$pkg_ident/TDEPS" | Should -FileContentMatch "core/glibc/2.36"
-    }
 }


### PR DESCRIPTION
This removes the panic when creating a aarch64 docker studio and adds an e2e test for it.