### PR TITLE
add key import logic to darwin studio

### DIFF
--- a/.expeditor/scripts/verify/build_package-aarch64-darwin.sh
+++ b/.expeditor/scripts/verify/build_package-aarch64-darwin.sh
@@ -30,7 +30,7 @@ export HAB_ORIGIN
 HAB_ORIGIN=throwaway
 
 echo "--- :key: Generating fake origin key"
-sudo -E "${bootstrap_hab_binary}" origin key generate
+"${bootstrap_hab_binary}" origin key generate
 
 # Install chef studio from the 'acceptance' channel where we downloaded 'chef/hab'
 # from. Once we release we will not use 'acceptance' but the released 'hab' and
@@ -45,7 +45,7 @@ export HAB_BLDR_CHANNEL="acceptance"
 export HAB_REFRESH_CHANNEL="base-2025"
 
 echo "--- :hab: Running hab pkg build for $package_path"
-sudo -E "${bootstrap_hab_binary}" pkg build "$package_path"
+"${bootstrap_hab_binary}" pkg build "$package_path"
 
 source results/last_build.env
 # shellcheck disable=SC2154

--- a/components/studio/libexec/hab-studio-type-darwin-default.sh
+++ b/components/studio/libexec/hab-studio-type-darwin-default.sh
@@ -25,6 +25,48 @@ _pkgpath_for() {
 
 # shellcheck disable=SC2154
 finish_setup() {
+    # Import origin keys from the host key cache (HAB_CACHE_KEY_PATH, typically
+    # ~/.hab/cache/keys) into the studio's key cache (/opt/hab/cache/keys).
+    # Unlike Linux (which uses a chroot), the darwin studio runs directly on the
+    # host, so we must explicitly target HAB_ROOT_PATH/cache/keys on import.
+    if [ -n "${HAB_ORIGIN_KEYS:-}" ]; then
+        $mkdir_cmd -p "$HAB_ROOT_PATH/cache/keys"
+        for key in $(echo "$HAB_ORIGIN_KEYS" | $sed_cmd 's/,/ /g'); do
+            info "Importing '$key' secret origin key"
+            # shellcheck disable=SC2154
+            if key_text=$(HAB_LICENSE="${HAB_LICENSE:-}" "$system_hab_cmd" origin key export --type secret "$key"); then
+                printf -- "%s" "${key_text}" | HAB_CACHE_KEY_PATH="$HAB_ROOT_PATH/cache/keys" "$system_hab_cmd" origin key import
+            else
+                echo "Error exporting $key key"
+                echo "${key_text}"
+                echo "Habitat was unable to export your secret signing key. Please"
+                echo "verify that you have a signing key for $key present in"
+                echo "~/.hab/cache/keys. You can test this by running:"
+                echo ""
+                echo "    hab origin key export --type secret $key"
+                echo ""
+                echo "This will print your signing key or error if it cannot be found."
+                echo "To create a signing key, run:"
+                echo ""
+                echo "    hab origin key generate $key"
+                echo ""
+                exit 1
+            fi
+            # Import the public key too; required for verifying installed packages.
+            if key_text=$("$system_hab_cmd" origin key export --type public "$key" 2>/dev/null); then
+                info "Importing '$key' public origin key"
+                printf -- "%s" "${key_text}" | HAB_CACHE_KEY_PATH="$HAB_ROOT_PATH/cache/keys" "$system_hab_cmd" origin key import
+            else
+                info "Tried to import '$key' public origin key, but key was not found"
+            fi
+        done
+    else
+        info "No secret keys imported! Did you mean to set HAB_ORIGIN?"
+        echo "To specify a HAB_ORIGIN, either set the HAB_ORIGIN environment"
+        echo "variable to your origin name or run 'hab cli setup' and specify a"
+        echo "default origin."
+    fi
+
     src_dir="$($pwd_cmd)"
     $mkdir_cmd -p "$HAB_STUDIO_ROOT"/etc
     $mkdir_cmd -p "$HAB_STUDIO_ROOT"/bin

--- a/components/studio/libexec/hab-studio-type-darwin-default.sh
+++ b/components/studio/libexec/hab-studio-type-darwin-default.sh
@@ -41,6 +41,7 @@ finish_setup() {
                 echo "${key_text}"
                 echo "Habitat was unable to export your secret signing key. Please"
                 echo "verify that you have a signing key for $key present in"
+                # shellcheck disable=2088
                 echo "~/.hab/cache/keys. You can test this by running:"
                 echo ""
                 echo "    hab origin key export --type secret $key"


### PR DESCRIPTION
on aarch64, after running `hab cli setup` to create origin keys and then running `hab studio enter` keys are not imported into the studio and subsequent builds fail. Veryfy pipeline builds "cheat" by generating origin keys as sudo which puts them right into /opt/hab/cache/keys instead of ~/.hab/cache/keys. This also removes that cheat so that failure to import the user keys would fail the build.