### PR TITLE
add process-exec sandbox rule to /Library/Developer

### DIFF
--- a/components/plan-build/bin/darwin-sandbox.sb
+++ b/components/plan-build/bin/darwin-sandbox.sb
@@ -17,7 +17,7 @@
 (allow file-read-data (literal "/opt"))
 (allow file-read-metadata (literal "/Users"))
 (allow file-read-metadata (subpath "/usr/local"))
-(allow file-read* (subpath "/Library/Developer"))
+(allow file-read* process-exec (subpath "/Library/Developer"))
 (allow file-read* (literal "/private/etc/passwd"))
 (allow file-read* (literal "/private/etc/localtime"))
 (allow file-read-data (literal "/Library/Preferences/Logging/com.apple.diagnosticd.filter.plist"))

--- a/components/studio/libexec/darwin-sandbox.sb
+++ b/components/studio/libexec/darwin-sandbox.sb
@@ -15,7 +15,7 @@
 (allow file-read-data (literal "/opt"))
 (allow file-read-metadata (literal "/Users"))
 (allow file-read-metadata (subpath "/usr/local"))
-(allow file-read* (subpath "/Library/Developer"))
+(allow file-read* process-exec (subpath "/Library/Developer"))
 (allow file-read* (literal "/private/etc/passwd"))
 (allow file-read-data (literal "/Library/Preferences/Logging/com.apple.diagnosticd.filter.plist"))
 (allow network-outbound (remote unix-socket (path-literal "/private/var/run/syslog")))


### PR DESCRIPTION
Without this, compiling native clang plans is failing with `C compiler cannot create executables`.