### PR TITLE
Using core/libiconv as a dependency on macOS

### DIFF
--- a/components/hab/habitat/aarch64-darwin/plan.sh
+++ b/components/hab/habitat/aarch64-darwin/plan.sh
@@ -8,7 +8,7 @@ pkg_license=('Apache-2.0')
 # This is getting resolved from the system, while we have a habitat package for that
 # so we shoud use the one from 'our' habitat package.
 pkg_deps=(
-	core/libiconv
+    core/libiconv
 )
 
 pkg_build_deps=(
@@ -101,7 +101,8 @@ do_prepare() {
     build_type="--release"
     build_line "Building artifacts with \`${build_type#--}' mode"
 
-    export RUSTFLAGS="-L $(pkg_path_for libiconv)/lib"
+    RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-L $(pkg_path_for libiconv)/lib"
+    export RUSTFLAGS
     build_line "Setting RUSTFLAGS=$RUSTFLAGS"
 }
 

--- a/components/hab/habitat/aarch64-darwin/plan.sh
+++ b/components/hab/habitat/aarch64-darwin/plan.sh
@@ -5,8 +5,12 @@ pkg_origin=chef
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 
-# There is no true equivalent here (yet), so dependency arrays will be empty.
-pkg_deps=()
+# This is getting resolved from the system, while we have a habitat package for that
+# so we shoud use the one from 'our' habitat package.
+pkg_deps=(
+	core/libiconv
+)
+
 pkg_build_deps=(
     core/tar
     core/coreutils
@@ -97,6 +101,7 @@ do_prepare() {
     build_type="--release"
     build_line "Building artifacts with \`${build_type#--}' mode"
 
+    export RUSTFLAGS="-L $(pkg_path_for libiconv)/lib"
     build_line "Setting RUSTFLAGS=$RUSTFLAGS"
 }
 


### PR DESCRIPTION
This pull request updates the `plan.sh` for the `aarch64-darwin` Habitat package to ensure that the build process uses the Habitat-managed `libiconv` package instead of relying on the system version. The most important changes are:

Dependency management improvements:
* Added `core/libiconv` to the `pkg_deps` array to ensure the Habitat package uses its own managed version of `libiconv` rather than the system-provided one.

Build process updates:
* Set the `RUSTFLAGS` environment variable in the `do_prepare()` function to include the library path for `libiconv`, ensuring that Rust links against the correct library during the build.