### PR TITLE
Removes 'emacs' function and 'core/mg' dep on backline

### DIFF
--- a/components/backline/habitat/aarch64-darwin/plan.sh
+++ b/components/backline/habitat/aarch64-darwin/plan.sh
@@ -12,7 +12,6 @@ pkg_deps=(
     core/diffutils
     core/less
     core/make
-    core/mg
     core/patch
     core/vim
 )

--- a/components/backline/habitat/plan.sh
+++ b/components/backline/habitat/plan.sh
@@ -8,7 +8,6 @@ pkg_deps=(chef/hab-plan-build
           core/diffutils
           core/less
           core/make
-          core/mg
           core/util-linux
           core/vim
           core/ncurses)

--- a/components/rootless_studio/default/profile
+++ b/components/rootless_studio/default/profile
@@ -40,14 +40,6 @@ alias fgrep='fgrep --color=auto'
 export TERMINFO
 TERMINFO=$(hab pkg path core/ncurses)/share/terminfo
 
-emacs() {
-  if type -P emacs > /dev/null; then
-    command emacs "$@"
-  else
-    mg "$@"
-  fi
-}
-
 if [[ -n "${HAB_STUDIO_SUP}" ]]; then
   # This environment variable does not handle spaces well, so we'll re-add
   # them...

--- a/components/studio/libexec/hab-studio-type-default.sh
+++ b/components/studio/libexec/hab-studio-type-default.sh
@@ -131,14 +131,6 @@ alias fgrep='fgrep --color=auto'
 export TERMINFO
 TERMINFO=$(_pkgpath_for core/ncurses)/share/terminfo
 
-emacs() {
-  if type -P emacs > /dev/null; then
-    command emacs "\$@"
-  else
-    mg "\$@"
-  fi
-}
-
 if [[ -n "\${HAB_STUDIO_SUP}" ]]; then
   # This environment variable does not handle spaces well, so we'll re-add
   # them...


### PR DESCRIPTION
This pull request removes support for the `mg` editor from the Backline and Studio environments. This affects both the dependencies and the shell profile scripts, simplifying the environment and reducing maintenance for the unused or unnecessary editor.

Dependency cleanup:

* Removed `core/mg` from the `pkg_deps` array in both `components/backline/habitat/plan.sh` and `components/backline/habitat/aarch64-darwin/plan.sh`. [[1]](diffhunk://#diff-5556dccf983225f43a24d72b3e34d8632e1ad01087e68a81bc4df9a66be32fdcL11) [[2]](diffhunk://#diff-04db08b8757d94b0536ebcb79fbc64ab509005fc62aa9d6968e38c126e6f7057L15)

Shell profile simplification:

* Removed the `emacs()` shell function that fell back to `mg` if `emacs` was not present, from both `components/rootless_studio/default/profile` and `components/studio/libexec/hab-studio-type-default.sh`. [[1]](diffhunk://#diff-618d61bbaf2efa1fa5f867cf89ce5e0d082b6768e155b85bad2fd1c1a5d39fb4L43-L50) [[2]](diffhunk://#diff-6bf85674fcba9f593e3bced6950996246238a44fcb41618a4ff70bb222b55a61L134-L141)