### PR TITLE
Add more tar exporter for macos

### DIFF
--- a/.expeditor/end_to_end.pipeline.yml
+++ b/.expeditor/end_to_end.pipeline.yml
@@ -1386,6 +1386,28 @@ steps:
       automatic:
         limit: 3 # Addressing current Anka system timeouts due to oversubscription
 
+  - label: "[:mac: test_tar_export]"
+    commands:
+      - ". vault-util-init"
+      - "sudo -E .expeditor/scripts/end_to_end/run_e2e_test_darwin.sh dev test_tar_export"
+    artifact_paths:
+      - "*.log"
+    agents:
+      queue: 'default-macos-arm64-privileged'
+    plugins:
+      - chef/anka#v0.7.2:
+          vm-name: buildkite-core-14-arm64
+          always-pull: true
+          wait-network: true
+          inherit-environment-vars: true
+    env:
+      BUILD_PKG_TARGET: aarch64-darwin
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+    retry:
+      automatic:
+        limit: 3 # Addressing current Anka system timeouts due to oversubscription
+
   - wait
 
   - label: "[:habicat: Promote to Acceptance]"

--- a/components/hab/src/cli_v4/pkg/export.rs
+++ b/components/hab/src/cli_v4/pkg/export.rs
@@ -31,7 +31,7 @@ pub(crate) enum PkgExportCommand {
     Container(PkgExportCommandOptions),
 
     /// Tar Exporter
-    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", all(target_os = "macos", target_arch = "aarch64")))]
     #[command(disable_help_flag = true)]
     Tar(PkgExportCommandOptions),
 }
@@ -47,7 +47,7 @@ impl PkgExportCommand {
                                               .map(OsString::from)
                                               .collect::<Vec<_>>()).await
             }
-            #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+            #[cfg(any(target_os = "linux", target_os = "windows", all(target_os = "macos", target_arch = "aarch64")))]
             PkgExportCommand::Tar(opts) => {
                 export::tar::start(ui,
                                    &opts.args

--- a/components/hab/src/cli_v4/pkg/export.rs
+++ b/components/hab/src/cli_v4/pkg/export.rs
@@ -31,7 +31,7 @@ pub(crate) enum PkgExportCommand {
     Container(PkgExportCommandOptions),
 
     /// Tar Exporter
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[command(disable_help_flag = true)]
     Tar(PkgExportCommandOptions),
 }
@@ -47,7 +47,7 @@ impl PkgExportCommand {
                                               .map(OsString::from)
                                               .collect::<Vec<_>>()).await
             }
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
             PkgExportCommand::Tar(opts) => {
                 export::tar::start(ui,
                                    &opts.args

--- a/components/hab/src/cli_v4/pkg/export.rs
+++ b/components/hab/src/cli_v4/pkg/export.rs
@@ -31,7 +31,9 @@ pub(crate) enum PkgExportCommand {
     Container(PkgExportCommandOptions),
 
     /// Tar Exporter
-    #[cfg(any(target_os = "linux", target_os = "windows", all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(any(target_os = "linux",
+              target_os = "windows",
+              all(target_os = "macos", target_arch = "aarch64")))]
     #[command(disable_help_flag = true)]
     Tar(PkgExportCommandOptions),
 }

--- a/components/pkg-export-tar/habitat/aarch64-darwin/plan.sh
+++ b/components/pkg-export-tar/habitat/aarch64-darwin/plan.sh
@@ -5,7 +5,9 @@ pkg_origin=chef
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
 
-pkg_deps=()
+pkg_deps=(
+    core/libiconv
+)
 pkg_build_deps=(
     core/tar
     core/coreutils

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -98,9 +98,10 @@ impl<'a> BuildSpec<'a> {
                     no_hab_bin: cli.no_hab_bin,
 
                     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-                    no_hab_sup: true,
+                    no_hab_sup:                                                                true,
                     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-                    no_hab_sup: cli.no_hab_sup, }
+                    no_hab_sup:
+                        cli.no_hab_sup, }
     }
 
     /// Creates a `BuildRoot` for the given specification.

--- a/components/pkg-export-tar/src/build.rs
+++ b/components/pkg-export-tar/src/build.rs
@@ -97,6 +97,9 @@ impl<'a> BuildSpec<'a> {
 
                     no_hab_bin: cli.no_hab_bin,
 
+                    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+                    no_hab_sup: true,
+                    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
                     no_hab_sup: cli.no_hab_sup, }
     }
 

--- a/components/pkg-export-tar/src/cli.rs
+++ b/components/pkg-export-tar/src/cli.rs
@@ -90,6 +90,7 @@ pub(crate) struct Cli {
     pub(crate) no_hab_bin: bool,
 
     /// Exclude supervisor and launcher packages from the exported tar
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
     #[arg(name = "NO_HAB_SUP", long = "no-hab-sup")]
     pub(crate) no_hab_sup: bool,
 

--- a/test/end-to-end/test_tar_export.ps1
+++ b/test/end-to-end/test_tar_export.ps1
@@ -76,7 +76,12 @@ Describe "hab pkg export tar core/nginx --no-hab-bin" {
 
 Context "hab pkg export tar core/nginx --no-hab-sup" {
     # --no-hab-sup is not available on aarch64-darwin (supervisor is always excluded there)
-    if (-not $IsDarwinArm64) {
+    if ($IsDarwinArm64) {
+        It "Rejects --no-hab-sup flag with a non-zero exit code" {
+            hab pkg export tar core/nginx --no-hab-sup --base-pkgs-channel $env:HAB_INTERNAL_BLDR_CHANNEL
+            $LASTEXITCODE | Should -Not -Be 0
+        }
+    } else {
         hab pkg export tar core/nginx --no-hab-sup --base-pkgs-channel $env:HAB_INTERNAL_BLDR_CHANNEL
         $tar = Get-Item core-nginx-*.tar.gz
         It "Creates tarball" {

--- a/test/end-to-end/test_tar_export.ps1
+++ b/test/end-to-end/test_tar_export.ps1
@@ -1,7 +1,12 @@
 Remove-Item *.tar.gz
 
+$IsDarwinArm64 = $IsLinux -eq $false -and $IsWindows -eq $false -and ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64)
+
+# On aarch64-darwin, packages live under opt/hab; everywhere else under hab
+$HabRoot = if ($IsDarwinArm64) { "opt/hab" } else { "hab" }
+
 function Get-Ident($pkg, $tar) {
-    $ident = tar --list --file $tar | Where-Object { $_ -like "hab/pkgs/$pkg/**/IDENT" }
+    $ident = tar --list --file $tar | Where-Object { $_ -like "$HabRoot/pkgs/$pkg/**/IDENT" }
     if ($null -ne $ident) {
         tar --extract --to-stdout --file $tar $ident
     }
@@ -20,11 +25,21 @@ Describe "hab pkg export tar core/nginx" {
     It "Includes hab" {
         Get-Ident chef/hab $tar | Should -BeLike "chef/hab/$version/*"
     }
-    It "Includes supervisor" {
-        Get-Ident chef/hab-sup $tar | Should -BeLike "chef/hab-sup/$version/*"
-    }
-    It "Includes launcher" {
-        Get-Ident chef/hab-launcher $tar | Should -Not -Be $null
+    # On aarch64-darwin, supervisor and launcher are never included
+    if ($IsDarwinArm64) {
+        It "Does not include supervisor" {
+            Get-Ident chef/hab-sup $tar | Should -Be $null
+        }
+        It "Does not include launcher" {
+            Get-Ident chef/hab-launcher $tar | Should -Be $null
+        }
+    } else {
+        It "Includes supervisor" {
+            Get-Ident chef/hab-sup $tar | Should -BeLike "chef/hab-sup/$version/*"
+        }
+        It "Includes launcher" {
+            Get-Ident chef/hab-launcher $tar | Should -Not -Be $null
+        }
     }
 }
 
@@ -38,34 +53,47 @@ Describe "hab pkg export tar core/nginx --no-hab-bin" {
         Get-Ident core/nginx $tar | Should -Not -Be $null
     }
     It "Does not include hab binary directory" {
-        $habBinDir = tar --list --file $tar | Where-Object { $_ -like "hab/bin/*" }
+        $habBinDir = tar --list --file $tar | Where-Object { $_ -like "$HabRoot/bin/*" }
         $habBinDir | Should -Be $null
     }
-    It "Includes supervisor" {
-        Get-Ident chef/hab-sup $tar | Should -Not -Be $null
-    }
-    It "Includes launcher" {
-        Get-Ident chef/hab-launcher $tar | Should -Not -Be $null
+    # On aarch64-darwin, supervisor and launcher are never included
+    if ($IsDarwinArm64) {
+        It "Does not include supervisor" {
+            Get-Ident chef/hab-sup $tar | Should -Be $null
+        }
+        It "Does not include launcher" {
+            Get-Ident chef/hab-launcher $tar | Should -Be $null
+        }
+    } else {
+        It "Includes supervisor" {
+            Get-Ident chef/hab-sup $tar | Should -Not -Be $null
+        }
+        It "Includes launcher" {
+            Get-Ident chef/hab-launcher $tar | Should -Not -Be $null
+        }
     }
 }
 
 Context "hab pkg export tar core/nginx --no-hab-sup" {
-    hab pkg export tar core/nginx --no-hab-sup --base-pkgs-channel $env:HAB_INTERNAL_BLDR_CHANNEL
-    $tar = Get-Item core-nginx-*.tar.gz
-    It "Creates tarball" {
-        $tar | Should -Not -Be $null
-    }
-    It "Includes nginx" {
-        Get-Ident core/nginx $tar | Should -Not -Be $null
-    }
-    It "Includes hab binary directory" {
-        $habBinDir = tar --list --file $tar | Where-Object { $_ -like "hab/bin/*" }
-        $habBinDir | Should -Not -Be $null
-    }
-    It "Does not include supervisor" {
-        Get-Ident chef/hab-sup $tar | Should -Be $null
-    }
-    It "Does not include launcher" {
-        Get-Ident chef/hab-launcher $tar | Should -Be $null
+    # --no-hab-sup is not available on aarch64-darwin (supervisor is always excluded there)
+    if (-not $IsDarwinArm64) {
+        hab pkg export tar core/nginx --no-hab-sup --base-pkgs-channel $env:HAB_INTERNAL_BLDR_CHANNEL
+        $tar = Get-Item core-nginx-*.tar.gz
+        It "Creates tarball" {
+            $tar | Should -Not -Be $null
+        }
+        It "Includes nginx" {
+            Get-Ident core/nginx $tar | Should -Not -Be $null
+        }
+        It "Includes hab binary directory" {
+            $habBinDir = tar --list --file $tar | Where-Object { $_ -like "$HabRoot/bin/*" }
+            $habBinDir | Should -Not -Be $null
+        }
+        It "Does not include supervisor" {
+            Get-Ident chef/hab-sup $tar | Should -Be $null
+        }
+        It "Does not include launcher" {
+            Get-Ident chef/hab-launcher $tar | Should -Be $null
+        }
     }
 }


### PR DESCRIPTION
This makes sure :
* the `export tar` subcommand is available on aarch64-darwin.
* `--no-hab-sup` is not available on --aarch64-darwin bit it is the default behavior
* there are e2e tests for the tar exporter on aarch64-darwin