### PR TITLE
Broken link fixes

### DIFF
--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -86,7 +86,7 @@ You can also develop your application if you are unsure of the infrastructure yo
 
 ### Learning
 
-- [Learn Chef: Deliver Applications with Chef Habitat](https://www.chef.io/training/tutorials)
+- [Chef Habitat tutorials](https://www.chef.io/training/tutorials)
 - [Chef Habitat webinars](https://www.chef.io/webinars?products=chef-habitat&page=1)
 - [Resource Library](https://www.chef.io/resources?products=chef-habitat&page=1)
 

--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -86,7 +86,7 @@ You can also develop your application if you are unsure of the infrastructure yo
 
 ### Learning
 
-- [Chef Habitat tutorials](https://www.chef.io/training/tutorials)
+- [LearnChef: Tutorials](https://www.chef.io/training/tutorials)
 - [Chef Habitat webinars](https://www.chef.io/webinars?products=chef-habitat&page=1)
 - [Resource Library](https://www.chef.io/resources?products=chef-habitat&page=1)
 

--- a/components/docs-chef-io/content/habitat/_index.md
+++ b/components/docs-chef-io/content/habitat/_index.md
@@ -86,7 +86,7 @@ You can also develop your application if you are unsure of the infrastructure yo
 
 ### Learning
 
-- [Learn Chef: Deliver Applications with Chef Habitat](https://learn.chef.io/courses/course-v1:chef+Habitat101+Perpetual/about)
+- [Learn Chef: Deliver Applications with Chef Habitat](https://www.chef.io/training/tutorials)
 - [Chef Habitat webinars](https://www.chef.io/webinars?products=chef-habitat&page=1)
 - [Resource Library](https://www.chef.io/resources?products=chef-habitat&page=1)
 

--- a/components/docs-chef-io/content/habitat/builder_account.md
+++ b/components/docs-chef-io/content/habitat/builder_account.md
@@ -19,7 +19,7 @@ Whether you are looking to leverage the SaaS or on-prem version of Chef Habitat 
 You need to set a few things up before you can get started with Chef Habitat Builder:
 
 * Download and install the [Chef Habitat CLI]({{< relref "install_habitat" >}})
-* A [GitHub account](https://github.com/join)
+* A [GitHub account](https://github.com/signup)
 
 ## Sign-in and Authorize Chef Habitat Builder
 

--- a/components/docs-chef-io/content/habitat/builder_account.md
+++ b/components/docs-chef-io/content/habitat/builder_account.md
@@ -23,14 +23,14 @@ You need to set a few things up before you can get started with Chef Habitat Bui
 
 ## Sign-in and Authorize Chef Habitat Builder
 
-Chef Habitat Builder automatically creates your account the first time you sign in using the GitHub authentication process. You'll also need to authorize the Chef Habitat Builder application in Github.
+Chef Habitat Builder automatically creates your account the first time you sign in using the GitHub authentication process. You'll also need to authorize the Chef Habitat Builder application in GitHub.
 
 Head over to the Chef Habitat Builder sign-in page at [https://bldr.habitat.sh/#/sign-in](https://bldr.habitat.sh/#/sign-in) to get started.
 
 1. To sign in with an existing GitHub account, select **Sign in with GitHub**
 1. If you need to set up a GitHub account, select the **Sign up here** link
 
-![Chef Habitat sign in with Github](/images/habitat/builder_signin.png)
+![Chef Habitat sign in with GitHub](/images/habitat/builder_signin.png)
 
 Signing in with your GitHub account and authorizing the Chef Habitat Builder application the first time you sign in grants you access to the Chef Habitat Builder platform. Once you've completed signing in and authorizing Chef Habitat Builder, you'll arrive at the 'My Origins' view.
 

--- a/components/docs-chef-io/content/habitat/builder_profile.md
+++ b/components/docs-chef-io/content/habitat/builder_profile.md
@@ -24,18 +24,18 @@ This documentation covers everything from creating an account to setting up auto
 You need to set a few things up before you can get started with Chef Habitat Builder:
 
 * Download and install the [Chef Habitat CLI]({{< relref "install_habitat" >}})
-* A [GitHub account](https://github.com/join)
+* A [GitHub account](https://github.com/signup)
 
 ### Sign-in and Authorize Chef Habitat Builder
 
-Chef Habitat Builder automatically creates your account the first time you sign in using the GitHub authentication process. You'll also need to authorize the Chef Habitat Builder application in Github.
+Chef Habitat Builder automatically creates your account the first time you sign in using the GitHub authentication process. You'll also need to authorize the Chef Habitat Builder application in GitHub.
 
 Head over to the Chef Habitat Builder sign-in page at [https://bldr.habitat.sh/#/sign-in](https://bldr.habitat.sh/#/sign-in) to get started.
 
 1. To sign in with an existing GitHub account, select **Sign in with GitHub**
 1. If you need to set up a GitHub account, select the **Sign up here** link
 
-![Chef Habitat sign in with Github](/images/habitat/builder_signin.png)
+![Chef Habitat sign in with GitHub](/images/habitat/builder_signin.png)
 
 Signing in with your GitHub account and authorizing the Chef Habitat Builder application the first time you sign in grants you access to the Chef Habitat Builder platform. Once you've completed signing in and authorizing Chef Habitat Builder, you'll arrive at the 'My Origins' view.
 

--- a/components/docs-chef-io/content/habitat/get_started.md
+++ b/components/docs-chef-io/content/habitat/get_started.md
@@ -18,7 +18,7 @@ This getting started guide will show you how to use Chef Habitat to build and de
 Before getting started with this tutorial, you will need:
 
 - a workstation running Linux or macOS
-- a [GitHub account](https://github.com/join)
+- a [GitHub account](https://github.com/signup)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed locally (optional)
 - the [Chef Habitat CLI]({{< relref "/habitat/install_habitat" >}}) installed locally
 - an account on [Chef Habitat Builder]({{< relref "builder_account" >}})


### PR DESCRIPTION
## Summary

Fixes broken links identified in the August 2026 link check (rows 1 and 7 in the spreadsheet).

### Changes

**\components/docs-chef-io/content/habitat/builder_account.md\**
- Updated \https://github.com/join\ to \https://github.com/signup\
- Fixed 'Github' to 'GitHub' in body text and image alt text

**\components/docs-chef-io/content/habitat/builder_profile.md\**
- Updated \https://github.com/join\ to \https://github.com/signup\
- Fixed 'Github' to 'GitHub' in body text and image alt text

**\components/docs-chef-io/content/habitat/get_started.md\**
- Updated \https://github.com/join\ to \https://github.com/signup\

**\components/docs-chef-io/content/habitat/_index.md\**
- Updated the "LearnChef: Tutorials" link from \https://learn.chef.io/courses/course-v1:chef+Habitat101+Perpetual/about\ to \https://www.chef.io/training/tutorials\ (the old URL returns 404 as the course has been removed)

### DCO sign-off

Signed-off-by: LisaBarry316 <lisa.barry@progress.com>