### PR TITLE
fix build issues for hab.exe on aarch64

### DIFF
--- a/components/hab/src/cli_v4.rs
+++ b/components/hab/src/cli_v4.rs
@@ -109,7 +109,8 @@ enum Hab {
     #[cfg(any(target_os = "macos",
               any(all(target_os = "linux",
                       any(target_arch = "x86_64", target_arch = "aarch64")),
-                  all(target_os = "windows", target_arch = "x86_64"))))]
+                  all(target_os = "windows",
+                      any(target_arch = "x86_64", target_arch = "aarch64")))))]
     #[command(name = "studio")]
     Studio(StudioOpts),
 

--- a/components/hab/src/cli_v4/studio.rs
+++ b/components/hab/src/cli_v4/studio.rs
@@ -21,7 +21,8 @@ impl StudioOpts {
         #[cfg(any(target_os = "macos",
                   any(all(target_os = "linux",
                           any(target_arch = "x86_64", target_arch = "aarch64")),
-                      all(target_os = "windows", target_arch = "x86_64"),)))]
+                      all(target_os = "windows",
+                          any(target_arch = "x86_64", target_arch = "aarch64")),)))]
         enter::start(ui, &self.args.args).await
     }
 }


### PR DESCRIPTION
Note for building on a clean windows aarch64 instance:

1. Install Rust (rustup)

winget install --id Rustlang.Rustup -e --accept-source-agreements --accept-package-agreements --silent

The repo's  rust-toolchain  file pins  1.91.1 ; running any  rustup / cargo  command inside the repo directory auto-installs and activates it.

2. Install VS Build Tools 2022 with MSVC + Clang (ARM64 host)

winget install --id Microsoft.VisualStudio.2022.BuildTools -e --accept-source-agreements --accept-package-agreements --silent --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.ARM64 --add Microsoft.VisualStudio.Component.VC.Llvm.Clang --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset --includeRecommended"

(This combines the workload + the two extra components I had to add separately last time into one shot.)

3. Install protoc (protobuf compiler)

winget install --id Google.Protobuf -e --accept-source-agreements --accept-package-agreements --silent

4. Apply the source fix (if not already committed)

In  components\hab\src\cli_v4.rs  and  components\hab\src\cli_v4\studio.rs , change the  studio  subcommand's  #[cfg(...)]  gate from:

all(target_os = "windows", target_arch = "x86_64")

to:

all(target_os = "windows", any(target_arch = "x86_64", target_arch = "aarch64"))

(Skip this if you've already committed/merged that change.)

5. Build

Run in a fresh shell (new process, since PATH changes need a restart to pick up  rustup / protoc ):

$vcvars = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
$protoc = (Get-ChildItem "$env:LOCALAPPDATA\Microsoft\WinGet\Packages\Google.Protobuf_*\bin\protoc.exe").FullName

& $env:ComSpec /c "call `"$vcvars`" arm64 >nul 2>&1 & set PROTOC=$protoc & cd /d C:\Users\azureuser\habitat & C:\Users\azureuser\.cargo\bin\cargo.exe build -p hab"
